### PR TITLE
Fix: use full paths with .js extension on esm mode

### DIFF
--- a/babel.config.es.js
+++ b/babel.config.es.js
@@ -1,0 +1,10 @@
+module.exports = {
+  plugins: [
+    [
+      'babel-plugin-custom-import-path-transform',
+      {
+        transformImportPath: './scripts/transform-es-import-path.js'
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "pnpm run dev",
     "dev": "pnpm run clean && pnpm run gen-version && pnpm run gen-volar-dts && cross-env NODE_ENV=development vite",
-    "build:package": "pnpm run gen-version && pnpm run clean && pnpm run gen-volar-dts && tsc -b --force tsconfig.esm.json && node scripts/pre-build/pre-cjs-build.js && tsc -b --force tsconfig.cjs.json && node scripts/post-build && rimraf {es,lib}/*.tsbuildinfo",
+    "build:package": "pnpm run gen-version && pnpm run clean && pnpm run gen-volar-dts && tsc -b --force tsconfig.esm.json && node scripts/pre-build/pre-cjs-build.js && tsc -b --force tsconfig.cjs.json && node scripts/post-build && rimraf {es,lib}/*.tsbuildinfo && babel --config-file ./babel.config.es.js -d es es",
     "build:site": "./scripts/pre-build-site/pre-build-site.sh && cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 vite build && ./scripts/post-build-site/post-build-site.sh",
     "clean": "rimraf site lib es node_modules/naive-ui themes/**/es themes/**/lib",
     "release:package": "pnpm run test && pnpm run build:package && pnpm publish --no-git-checks",
@@ -67,6 +67,8 @@
     ]
   },
   "devDependencies": {
+    "@babel/cli": "^7.17.6",
+    "@babel/core": "^7.17.5",
     "@babel/eslint-parser": "^7.15.8",
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
@@ -89,6 +91,7 @@
     "autoprefixer": "^10.2.6",
     "axios": "^0.26.0",
     "babel-jest": "^27.0.2",
+    "babel-plugin-custom-import-path-transform": "^1.0.3",
     "codesandbox": "^2.2.3",
     "cross-env": "^7.0.3",
     "cssnano": "^5.0.5",

--- a/scripts/transform-es-import-path.js
+++ b/scripts/transform-es-import-path.js
@@ -1,0 +1,58 @@
+const { statSync } = require('fs')
+const { dirname, resolve: pathResolve } = require('path')
+
+const rePathLocal = /^(\.\.?\/)(.*\/)?([^./]*)$/
+
+function tryExts (base, exts, extsDir) {
+  const count = {
+    total: exts.length,
+    notFile: 0,
+    error: 0
+  }
+  for (const ext of exts) {
+    let fst
+    try {
+      fst = statSync(base + ext)
+      if (fst.isFile()) {
+        return { ext, fst }
+      } else if (fst.isDirectory()) {
+        return tryExts(
+          base,
+          extsDir.map((ed) => `${ext}${ed}`),
+          extsDir
+        )
+      }
+      count.notFile += 1
+    } catch (e) {
+      count.error += 1
+    }
+  }
+  throw new Error(
+    `Could not resolve path ${JSON.stringify(base)} with exts ${JSON.stringify(
+      exts
+    )}: ${JSON.stringify(count)}`
+  )
+}
+
+function transformImportPath (originalPath, callingFileName, options) {
+  if (originalPath === 'date-fns/locale/en-US') {
+    return 'date-fns/locale/en-US/index.js'
+  }
+  const plm = originalPath.match(rePathLocal)
+  if (plm) {
+    const fp = pathResolve(dirname(callingFileName), originalPath)
+    let fst
+    let fstEx
+    let fse
+    try {
+      ;({ fst, ext: fstEx } = tryExts(fp, ['', '.js'], ['/index.js']))
+    } catch (e) {
+      fse = e
+    }
+    if (fst) return originalPath + fstEx
+    else if (fse) throw fse
+  }
+  return originalPath
+}
+
+module.exports = transformImportPath


### PR DESCRIPTION
As explained [on Discord](https://discord.com/channels/842427094214770768/842427094214770771/950748048080916561):

When using `vite@2.8.6` and `vite-ssg@0.17.11`, the SSR build fails with these kind of errors:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/{pnpm path}/node_modules/naive-ui/es/alert/src/Alert' imported from /{pnpm path}/node_modules/naive-ui/es/alert/index.js
```
This is not the first error, I've modified many places inside the compiled naiveui package, like this:
```diff
 // example
 // When dealing with files, vite-ssg only finds them if I add the extension:
-export { default as dateNbNO } from './date/nbNO';
+export { default as dateNbNO } from './date/nbNO.js';
 // When dealing with directories, I must add the index file path:
-export { createLocale } from './utils';
+export { createLocale } from './utils/index.js';
```
Related:
https://github.com/antfu/vite-ssg/issues/201
https://github.com/antfu/vite-ssg/issues/205

This PR add a post-build step with Babel to automatically resolve all relative file imports, adding the `.js` extension or `/index.js` when importing from a directory. (obs: it's also necessary to change the locale import from date-fns to `date-fns/locales/en-US/index.js`)

As discussed on discord, I don't expect this PR to be merged, but would like to have a solution to be able to use the latest vite-ssg. Thank you very much.