### PR TITLE
feat(tree): add treeNodeHeight props

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -41,6 +41,7 @@
 - `n-date-picker`'s `shortcuts` prop supports readonly tuple type.
 - `n-step` adds `disabled` prop.
 - `n-calendar` adds `header` slot, closes [#3036](https://github.com/TuSimple/naive-ui/issues/3036).
+- `t-tree` adds `treeNodeHeight` prop. [#3036](https://github.com/TuSimple/naive-ui/issues/3011).
 
 ## 2.29.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -41,6 +41,7 @@
 - `n-date-picker` 的 `shortcuts` 属性支持 readonly tuple 类型
 - `n-step` 新增 `disabled` 属性
 - `n-calendar` 新增 `header` slot，关闭 [#3036](https://github.com/TuSimple/naive-ui/issues/3036)
+- `t-tree` 新增 `treeNodeHeight` 属性, [#3036](https://github.com/TuSimple/naive-ui/issues/3011).
 
 ## 2.29.0
 

--- a/src/tree/demos/enUS/index.demo-entry.md
+++ b/src/tree/demos/enUS/index.demo-entry.md
@@ -64,6 +64,7 @@ checkbox-placement.vue
 | selectable | `boolean` | `true` | Whether the node can be selected. |  |
 | selected-keys | `Array<string \| number>` | `undefined` | If set, selected status will work in controlled manner. |  |
 | virtual-scroll | `boolean` | `false` | Whether to enable virtual scroll. You need to set proper style height of the tree in advance. |  |
+| tree-node-height | `number` | `24` | you need to pass your customized tree-node-height when enable virtual scroll and change each tree node height |  |
 | watch-props | `Array<'defaultCheckedKeys' \| 'defaultSelectedKeys' \|'defaultExpandedKeys'>` | `undefined` | Default prop names that needed to be watched. Components will be updated after the prop is changed. Note: the `watch-props` itself is not reactive. |  |
 | on-dragend | `(data: { node: TreeOption, event: DragEvent }) => void` | `undefined` | The callback function after the node completes the dragging action. |  |
 | on-dragenter | `(data: { node: TreeOption, event: DragEvent }) => void` | `undefined` | Callback function in node drag and drop. |  |

--- a/src/tree/demos/zhCN/index.demo-entry.md
+++ b/src/tree/demos/zhCN/index.demo-entry.md
@@ -68,6 +68,7 @@ scroll-debug.vue
 | selected-keys | `Array<string \| number>` | `undefined` | 如果设定则 `selected` 状态受控 |  |
 | show-irrelevant-nodes | `boolean` | `true` | 是否在搜索状态显示和搜索无关的节点 | 2.28.1 |
 | virtual-scroll | `boolean` | `false` | 是否启用虚拟滚动，启用前你需要设定好树的高度样式 |  |
+| tree-node-height | `number` | `24` | 启用虚拟滚动时，如果你自定义了每个子节点的高度，那么需要将这个高度传给 tree |  |
 | watch-props | `Array<'defaultCheckedKeys' \| 'defaultSelectedKeys' \|'defaultExpandedKeys'>` | `undefined` | 需要检测变更的默认属性，检测后组件状态会更新。注意：`watch-props` 本身不是响应式的 |  |
 | on-dragend | `(data: { node: TreeOption, event: DragEvent }) => void` | `undefined` | 节点完成拖拽动作后的回调函数 |  |
 | on-dragenter | `(data: { node: TreeOption, event: DragEvent }) => void` | `undefined` | 节点拖拽中的回调函数 |  |

--- a/src/tree/demos/zhCN/index.demo-entry.md
+++ b/src/tree/demos/zhCN/index.demo-entry.md
@@ -25,6 +25,7 @@ check-strategy-debug.vue
 change-debug.vue
 scrollbar-debug.vue
 scroll-debug.vue
+virtual-scroll-tree-node-height.vue
 ```
 
 ## API

--- a/src/tree/demos/zhCN/virtual-scroll-tree-node-height.demo.vue
+++ b/src/tree/demos/zhCN/virtual-scroll-tree-node-height.demo.vue
@@ -1,0 +1,70 @@
+<markdown>
+# 修改tree-node高度
+
+...
+</markdown>
+
+<template>
+  <n-tree
+    checkable
+    block-node
+    checkbox-placement="right"
+    virtual-scroll
+    style="height: 260px"
+    :tree-node-height="40"
+    :data="data"
+    :default-expanded-keys="defaultExpandedKeys"
+    :default-checked-keys="defaultCheckedKeys"
+    @update:checked-keys="updateCheckedKeys"
+  />
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import { repeat } from 'seemly'
+import { TreeOption } from 'naive-ui'
+
+function createData (level = 4, baseKey = ''): TreeOption[] | undefined {
+  if (!level) return undefined
+  return repeat(6 - level, undefined).map((_, index) => {
+    const key = '' + baseKey + level + index
+    return {
+      label: createLabel(level),
+      key,
+      children: createData(level - 1, key)
+    }
+  })
+}
+
+function createLabel (level: number): string {
+  if (level === 4) return '道生一'
+  if (level === 3) return '一生二'
+  if (level === 2) return '二生三'
+  if (level === 1) return '三生万物'
+  return ''
+}
+
+export default defineComponent({
+  setup () {
+    return {
+      data: createData(),
+      defaultExpandedKeys: ref(['40', '4030', '403020']),
+      defaultCheckedKeys: ref(['40302010']),
+      updateCheckedKeys: (v: string[]) => {
+        console.log('updateCheckedKeys', v)
+      }
+    }
+  }
+})
+</script>
+
+<style>
+.n-tree-node {
+  /**
+  * when refresh page,css is not working(sometimes)
+  * but css will work after save file(hmr)
+  */
+  height: 40px;
+  align-items: center;
+}
+</style>

--- a/src/tree/src/Tree.tsx
+++ b/src/tree/src/Tree.tsx
@@ -66,7 +66,7 @@ import { NEmpty } from '../../empty'
 // During expanding, some node are mis-applied with :active style
 // Async dnd has bug
 
-const ITEM_SIZE = 30 // 24 + 3 + 3
+// const ITEM_SIZE = 30 // 24 + 3 + 3
 
 export function createTreeMateOptions<T> (
   keyField: string,
@@ -135,6 +135,10 @@ const treeProps = {
   data: {
     type: Array as PropType<TreeOptions>,
     default: () => []
+  },
+  treeNodeHeight: {
+    type: Number,
+    default: 24
   },
   expandOnDragenter: {
     type: Boolean,
@@ -263,6 +267,7 @@ export default defineComponent({
         }
       })
     }
+    const ITEM_SIZE = props.treeNodeHeight + 6
     const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
     const themeRef = useTheme(
       'Tree',
@@ -1312,6 +1317,7 @@ export default defineComponent({
       ? useThemeClass('tree', undefined, cssVarsRef, props)
       : undefined
     return {
+      ITEM_SIZE,
       mergedClsPrefix: mergedClsPrefixRef,
       mergedTheme: themeRef,
       fNodes: mergedFNodesRef,
@@ -1348,7 +1354,8 @@ export default defineComponent({
       checkable,
       handleKeyup,
       handleKeydown,
-      handleFocusout
+      handleFocusout,
+      ITEM_SIZE
     } = this
     const mergedFocusable = internalFocusable && !disabled
     const tabindex = mergedFocusable ? '0' : undefined


### PR DESCRIPTION
we need to pass the customized tree-node-height when enable virtual scroll and change each tree node height.
[#3036](https://github.com/TuSimple/naive-ui/issues/3011).