### PR TITLE
fix: set min height of alert

### DIFF
--- a/src/alert/src/styles/index.cssr.ts
+++ b/src/alert/src/styles/index.cssr.ts
@@ -33,6 +33,7 @@ export default cB('alert', `
   background-color: var(--n-color);
   text-align: start;
   word-break: break-word;
+  min-height: var(--n-icon-size);
 `, [
   cM('closable', [
     cB('alert-body', [


### PR DESCRIPTION
The alert component should have at least the height of the icon. Right now, the icon overlapses the container in case it's height is higher than the container itself.