### PR TITLE
docs(select): placeholder default is `undefined`

### DIFF
--- a/src/input-number/demos/enUS/index.demo-entry.md
+++ b/src/input-number/demos/enUS/index.demo-entry.md
@@ -42,7 +42,7 @@ custom-icon.vue
 | max | `number` | `undefined` | The max value. |  |
 | min | `number` | `undefined` | The min value. |  |
 | parse | `(input: string) => number \| null` | `undefined` | Methof to parse input string. If it's set, `update-value-on-input` will be disabled. | 2.30.0 |
-| placeholder | `string` | `'Please Input'` | Placeholder. |  |
+| placeholder | `string` | `undefined` | Placeholder. |  |
 | precision | `number` | `undefined` | Precision of input value. If it's set, `update-value-on-input` will be disabled. | 2.30.0 |
 | readonly | `boolean` | `false` | Whether it's readonly. |  |
 | show-button | `boolean` | `true` | Whether to show increase/decrease buttons. |  |

--- a/src/input-number/demos/zhCN/index.demo-entry.md
+++ b/src/input-number/demos/zhCN/index.demo-entry.md
@@ -45,7 +45,7 @@ theme-debug.vue
 | max | `number` | `undefined` | 最大值 |  |
 | min | `number` | `undefined` | 最小值 |  |
 | parse | `(input: string) => number \| null` | `undefined` | 解析输入的字符串，设定后会禁用 `update-value-on-input` | 2.30.0 |
-| placeholder | `string` | `'请输入'` | 提示信息 |  |
+| placeholder | `string` | `undefined` | 提示信息 |  |
 | precision | `number` | `undefined` | 数值保留的精度值，设定后会禁用 `update-value-on-input` | 2.30.0 |
 | readonly | `boolean` | `false` | 是否只读 |  |
 | show-button | `boolean` | `true` | 是否有按钮 |  |

--- a/src/select/demos/enUS/index.demo-entry.md
+++ b/src/select/demos/enUS/index.demo-entry.md
@@ -54,7 +54,7 @@ custom-field.vue
 | multiple | `boolean` | `false` | Whether to allow selecting multiple values. |  |
 | node-props | `(option: SelectOption \| SelectGroupOption) => object` | `undefined` | Option's DOM attrs generator. | 2.32.2 |
 | options | `Array<SelectOption \| SelectGroupOption>` | `[]` | Options that can be selected. For more details see SelectOption Properties (below). |  |
-| placeholder | `string` | `'Please Select'` | Placeholder. |  |
+| placeholder | `string` | `undefined` | Placeholder. |  |
 | placement | `'top-start' \| 'top' \| 'top-end' \| 'right-start' \| 'right' \| 'right-end' \| 'bottom-start' \| 'bottom' \| 'bottom-end' \| 'left-start' \| 'left' \| 'left-end'` | `'bottom-start'` | Option menu's placement. | 2.25.0 |
 | remote | `boolean` | `false` | Allows options to be fetched asynchronously. Note that if `remote` is set, `filter` & `tag` won't work on `options`. |  |
 | render-label | `(option: SelectOption \| SelectGroupOption, selected: boolean) => VNodeChild` | `undefined` | Render function for each option label. |  |

--- a/src/select/demos/zhCN/index.demo-entry.md
+++ b/src/select/demos/zhCN/index.demo-entry.md
@@ -64,7 +64,7 @@ create-debug.vue
 | multiple | `boolean` | `false` | 是否为多选 |  |
 | node-props | `(option: SelectOption \| SelectGroupOption) => object` | `undefined` | 选项的 DOM 属性生成函数 | 2.32.2 |
 | options | `Array<SelectOption \| SelectGroupOption>` | `[]` | 配置选项内容，详情见 SelectOption Properties |  |
-| placeholder | `string` | `'请选择'` | 提示信息 |  |
+| placeholder | `string` | `undefined` | 提示信息 |  |
 | placement | `'top-start' \| 'top' \| 'top-end' \| 'right-start' \| 'right' \| 'right-end' \| 'bottom-start' \| 'bottom' \| 'bottom-end' \| 'left-start' \| 'left' \| 'left-end'` | `'bottom-start'` | 菜单的弹出位置 | 2.25.0 |
 | remote | `boolean` | `false` | 是否要异步获取选项。注意如果设定了，那么 `filter` 和 `tag` 都不会对 `options` 生效。这个时候你在全权控制 `options` |  |
 | render-label | `(option: SelectOption \| SelectGroupOption, selected: boolean) => VNodeChild` | `undefined` | 选项标签渲染函数 |  |


### PR DESCRIPTION
placeholder should default to `undefined`. Like input docs.

whould be confusing for other languages.

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
