### PR TITLE
fix(build): umd error

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,6 @@ const baseConfig = defineConfig({
   plugins: [
     nodeResolve({ extensions }),
     esbuild({
-      tsconfig: path.resolve(__dirname, 'tsconfig.esbuild.json'),
       target: 'esnext',
       sourceMap: true
     }),


### PR DESCRIPTION
closes #3642，我看之前加了配置 `tsconfig: path.resolve(__dirname, 'tsconfig.esbuild.json')`，导致 jsx 转译成了 `React.createElement`，之前这样配置的目的是什么呢