### PR TITLE
Menu组件默认全部展开修复

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,6 +8,7 @@
 - Fix `n-calendar`'s displayed month doesn't follow `default-value`, closes [#3645](https://github.com/tusen-ai/naive-ui/issues/3645).
 - Fix `n-form-item`'s `require-mark-placement` prop not working when set to `left`, closes [#3628](https://github.com/tusen-ai/naive-ui/issues/3628).
 - Fix `n-upload`'s `OnBeforeUpload` return type can only be `Promise<boolean>`.
+- Fix `n-menu`'s `default-expand-all` props not working when get options by async method.
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,7 @@
 - 修复 `n-calendar` 在设定了 `default-value` 后默认显示月份没有跟随，关闭 [#3645](https://github.com/tusen-ai/naive-ui/issues/3645)
 - 修复 `n-form-item` 属性 `require-mark-placement` 值为 `left` 时不生效, 关闭 [#3628](https://github.com/tusen-ai/naive-ui/issues/3628).
 - 修复 `n-upload` `OnBeforeUpload` 类型返回值只能为 `Promise<boolean>`
+- 修复 `n-menu` options 为异步获取时，`default-expand-all`失效
 
 ### Feats
 

--- a/src/menu/src/Menu.tsx
+++ b/src/menu/src/Menu.tsx
@@ -217,7 +217,7 @@ export default defineComponent({
             includeSelf: false
           }).keyPath
     }
-    if (watchProps?.includes('defaultExpandedKeys')) {
+    if (props.defaultExpandAll || watchProps?.includes('defaultExpandedKeys')) {
       watchEffect(initUncontrolledExpandedKeys)
     } else {
       initUncontrolledExpandedKeys()


### PR DESCRIPTION
n-menu组件的options如果是异步获取时，设置default-expand-all为true时不生效