### PR TITLE
feat(dialog): add `onAfterLeave` in DialogOptions Properties

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-dialog` adds `onAfterLeave` in DialogOptions Properties, closes [#3662](https://github.com/tusen-ai/naive-ui/issues/3662).
+
 ## 2.33.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-dialog` 新增 `onAfterLeave` 在 DialogOptions Properties 中，关闭 [#3662](https://github.com/tusen-ai/naive-ui/issues/3662)
+
 ## 2.33.2
 
 ### Fixes

--- a/src/dialog/demos/enUS/index.demo-entry.md
+++ b/src/dialog/demos/enUS/index.demo-entry.md
@@ -98,7 +98,7 @@ use-dialog-reactive-list.vue
 All the properties can be modified dynamically.
 
 | Name | Type | Description | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | bordered | `boolean` | Whether to show `border`. |  |
 | class | `any` | Class name of the dialog. | 2.33.0 |
 | closable | `boolean` | Whether to show `close` icon. |  |
@@ -116,8 +116,8 @@ All the properties can be modified dynamically.
 | style | `string \| Object` | Style of the dialog. |  |
 | title | `string \| (() => VNodeChild)` | Can be a `render` function. |  |
 | type | `'error \| 'success' \| 'warning'` | Dialog type. |  |
-| onAfterEnter | `() => void` | `undefined` | Callback on enter animation ends. | 2.33.0 |
-| onAfterLeave | `() => void` | `undefined` | Callback on leave animation ends. |  |
+| onAfterEnter | `() => void \| undefined` | Callback on enter animation ends. | 2.33.0 |
+| onAfterLeave | `() => void \| undefined` | Callback on leave animation ends. | NEXT_VERSION |
 | onClose | `() => boolean \| Promise<boolean> \| any` | The default behavior is closing the confirm. Return `false` or `resolve false` or `Promise rejected` will prevent the default behavior. |  |
 | onEsc | `() => void` | Callback fired when the escape key is pressed and focus is within dialog. | 2.32.0 |
 | onNegativeClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | The default behavior is closing the confirm. Return `false` or `resolve false` or `Promise rejected` will prevent the default behavior. |  |

--- a/src/dialog/demos/enUS/index.demo-entry.md
+++ b/src/dialog/demos/enUS/index.demo-entry.md
@@ -85,7 +85,7 @@ use-dialog-reactive-list.vue
 | title | `string \| (() => VNodeChild)` | `undefined` | Title, can be a `render` function. |  |
 | type | `'error \| 'success' \| 'warning'` | `'warning'` | Dialog type. |  |
 | onAfterEnter | `() => void` | `undefined` | Callback on enter animation ends. | 2.33.0 |
-| onAfterLeave | `() => void` | `undefined` | Callback on leave animation ends. |  |
+| onAfterLeave | `() => void` | `undefined` | Callback on leave animation ends. | NEXT_VERSION |
 | onClose | `() => boolean \| Promise<boolean> \| any` | `undefined` | The default behavior is closing the confirm. Return `false` or resolve `false` or `Promise rejected` will prevent the default behavior. |  |
 | onNegativeClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | `undefined` | The default behavior is closing the confirm. Return `false` or resolve `false` or `Promise rejected` will prevent the default behavior. |  |
 | onPositiveClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | `undefined` | The default behavior is closing the confirm. Return `false` or resolve `false` or `Promise rejected` will prevent the default behavior. |  |
@@ -98,7 +98,7 @@ use-dialog-reactive-list.vue
 All the properties can be modified dynamically.
 
 | Name | Type | Description | Version |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | bordered | `boolean` | Whether to show `border`. |  |
 | class | `any` | Class name of the dialog. | 2.33.0 |
 | closable | `boolean` | Whether to show `close` icon. |  |

--- a/src/dialog/demos/zhCN/index.demo-entry.md
+++ b/src/dialog/demos/zhCN/index.demo-entry.md
@@ -86,7 +86,7 @@ focus-debug.vue
 | title | `string \| (() => VNodeChild)` | `undefined` | 标题，可以是 `render` 函数 |  |
 | type | `'error \| 'success' \| 'warning'` | `'warning'` | 对话框类型 |  |
 | onAfterEnter | `() => void` | `undefined` | 出现动画完成执行的回调 | 2.33.0 |
-| onAfterLeave | `() => void` | `undefined` | 关闭动画完成执行的回调 |  |
+| onAfterLeave | `() => void` | `undefined` | 关闭动画完成执行的回调 | NEXT_VERSION |
 | onClose | `() => boolean \| Promise<boolean> \| any` | `undefined` | 默认行为是关闭确认框。返回 `false` 或者 `resolve false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |
 | onNegativeClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | `undefined` | 默认行为是关闭确认框。返回 `false` 或者 `resolve false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |
 | onPositiveClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | `undefined` | 默认行为是关闭确认框。返回 `false` 或者 `resolve false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |

--- a/src/dialog/demos/zhCN/index.demo-entry.md
+++ b/src/dialog/demos/zhCN/index.demo-entry.md
@@ -99,7 +99,7 @@ focus-debug.vue
 下列属性都可以被动态修改。
 
 | 名称 | 类型 | 说明 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | bordered | `boolean` | 是否显示 `border` |  |
 | class | `any` | 类名 | 2.33.0 |
 | closable | `boolean` | 是否显示 `close` 图标 |  |
@@ -117,8 +117,8 @@ focus-debug.vue
 | style | `string \| Object` | 样式 |  |
 | title | `string \| (() => VNodeChild)` | 可以是 `render` 函数 |  |
 | type | `'error \| 'success' \| 'warning'` | 对话框类型 |  |
-| onAfterEnter | `() => void` | `undefined` | 出现动画完成执行的回调 | 2.33.0 |
-| onAfterLeave | `() => void` | `undefined` | 关闭动画完成执行的回调 | NEXT_VERSION |
+| onAfterEnter | `() => void \| undefined` | 出现动画完成执行的回调 | 2.33.0 |
+| onAfterLeave | `() => void \| undefined` | 关闭动画完成执行的回调 | NEXT_VERSION |
 | onClose | `() => boolean \| Promise<boolean> \| any` | 默认行为是关闭确认框。返回 `false` 或者 resolve `false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |
 | onEsc | `() => void` | 焦点在 dialog 内部时按下 Esc 键的回调 | 2.32.0 |
 | onNegativeClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | 默认行为是关闭确认框。返回 `false` 或者 resolve `false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |

--- a/src/dialog/demos/zhCN/index.demo-entry.md
+++ b/src/dialog/demos/zhCN/index.demo-entry.md
@@ -99,7 +99,7 @@ focus-debug.vue
 下列属性都可以被动态修改。
 
 | 名称 | 类型 | 说明 | 版本 |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | bordered | `boolean` | 是否显示 `border` |  |
 | class | `any` | 类名 | 2.33.0 |
 | closable | `boolean` | 是否显示 `close` 图标 |  |
@@ -118,7 +118,7 @@ focus-debug.vue
 | title | `string \| (() => VNodeChild)` | 可以是 `render` 函数 |  |
 | type | `'error \| 'success' \| 'warning'` | 对话框类型 |  |
 | onAfterEnter | `() => void` | `undefined` | 出现动画完成执行的回调 | 2.33.0 |
-| onAfterLeave | `() => void` | `undefined` | 关闭动画完成执行的回调 |  |
+| onAfterLeave | `() => void` | `undefined` | 关闭动画完成执行的回调 | NEXT_VERSION |
 | onClose | `() => boolean \| Promise<boolean> \| any` | 默认行为是关闭确认框。返回 `false` 或者 resolve `false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |
 | onEsc | `() => void` | 焦点在 dialog 内部时按下 Esc 键的回调 | 2.32.0 |
 | onNegativeClick | `(e: MouseEvent) => boolean \| Promise<boolean> \| any` | 默认行为是关闭确认框。返回 `false` 或者 resolve `false` 或者 `Promise` 被 `reject` 会避免默认行为 |  |

--- a/src/dialog/src/DialogEnvironment.tsx
+++ b/src/dialog/src/DialogEnvironment.tsx
@@ -9,6 +9,7 @@ import { dialogProps, dialogPropKeys } from './dialogProps'
 export const exposedDialogEnvProps = {
   ...dialogProps,
   onAfterEnter: Function as PropType<() => void>,
+  onAfterLeave: Function as PropType<() => void>,
   blockScroll: { type: Boolean, default: true },
   closeOnEsc: { type: Boolean, default: true },
   onEsc: Function as PropType<() => void>,
@@ -49,7 +50,9 @@ export const NDialogEnvironment = defineComponent({
   setup (props) {
     const showRef = ref(true)
     function handleAfterLeave (): void {
-      props.onInternalAfterLeave(props.internalKey)
+      const { onInternalAfterLeave, internalKey, onAfterLeave } = props
+      if (onInternalAfterLeave) onInternalAfterLeave(internalKey)
+      if (onAfterLeave) onAfterLeave()
     }
     function handlePositiveClick (e: MouseEvent): void {
       const { onPositiveClick } = props


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
close #3662