### PR TITLE
docs: improve Web Types generation; include available documentation

### DIFF
--- a/scripts/post-build/gen-web-types.js
+++ b/scripts/post-build/gen-web-types.js
@@ -3,11 +3,13 @@ const fs = require('fs')
 const path = require('path')
 const { kebabCase } = require('lodash')
 
+const baseDir = path.resolve(__dirname, '../..')
+
 exports.genWebTypes = function genWebTypes () {
   const components = require('../../lib/components')
   const { default: version } = require('../../lib/version')
 
-  const elements = []
+  const vueComponents = []
 
   const scaffold = {
     $schema:
@@ -15,12 +17,10 @@ exports.genWebTypes = function genWebTypes () {
     framework: 'vue',
     name: 'naive-ui',
     version,
+    'js-types-syntax': 'typescript',
     contributions: {
       html: {
-        // we need to fill tags
-        elements,
-        attributes: [],
-        'js-types-syntax': 'typescript'
+        'vue-components': vueComponents
       }
     }
   }
@@ -30,52 +30,85 @@ exports.genWebTypes = function genWebTypes () {
   Object.entries(components).forEach(([exportName, component]) => {
     if (exportName[0] !== 'N') return
     if (exportName.startsWith('Nx')) return
-    const { props } = component
-    const name = /^NH\d$/.test(exportName)
-      ? exportName.replace('NH', 'n-h')
-      : kebabCase(exportName)
+
+    const {
+      props: docProps,
+      slots: docSlots,
+      description,
+      docUrl
+    } = loadDocs(component.name)
+
+    const { props: componentProps } = component
+    const name = exportName
     const slots = []
     const attributes = []
+    const props = []
     const events = []
-    props &&
-      Object.entries(props).forEach(([propName, prop]) => {
+    componentProps &&
+      Object.entries(componentProps).forEach(([propName, prop]) => {
         if (propName.startsWith('internal')) return
         if (ignoredPropNames.includes(propName)) return
         if (propName.startsWith('on') && /[A-Z]/.test(propName[2])) {
           // is event
-          events.push({
+          const event = {
             name: kebabCase(propName.slice(2)),
-            description: '-'
-          })
-        } else if (prop === null) {
-          attributes.push({
-            name: kebabCase(propName),
-            default: '-',
-            description: '-',
-            kind: 'expression'
-          })
+            'doc-url': docUrl
+          }
+          assignDocs(event, docProps[kebabCase(propName)])
+          delete docProps[kebabCase(propName)]
+          events.push(event)
         } else {
-          const attribute = {
+          const resultProp = {
             name: kebabCase(propName),
-            default: '-',
-            description: '-'
+            'doc-url': docUrl
           }
-          const type = getType(prop)
+          const type = prop ? getType(prop) : null
           if (type !== null) {
-            attribute.value = {
-              type,
-              kind: 'expression'
-            }
+            resultProp.type = type
           }
-          // is attribute
-          attributes.push(attribute)
+          assignDocs(resultProp, docProps[resultProp.name])
+          delete docProps[resultProp.name]
+          props.push(resultProp)
         }
       })
-    elements.push({
+
+    // Add the rest of the props and events from docs
+    for (const name in docProps) {
+      const prop = {
+        name,
+        'doc-url': docUrl
+      }
+      assignDocs(prop, docProps[name])
+      if (prop.name.startsWith('on-')) {
+        prop.name = prop.name.substring(3)
+        events.push(prop)
+      } else {
+        props.push(prop)
+      }
+    }
+
+    for (const name in docSlots) {
+      const slot = {
+        name,
+        'doc-url': docUrl
+      }
+      assignDocs(slot, docSlots[name])
+      slots.push(slot)
+    }
+
+    vueComponents.push({
       name,
+      description,
+      'doc-url': docUrl,
+      source: {
+        symbol: exportName
+      },
       slots,
       attributes,
-      'js/events': events
+      props,
+      js: {
+        events
+      }
     })
   })
 
@@ -129,6 +162,170 @@ exports.genWebTypes = function genWebTypes () {
     }
     console.error(`unkown type ${type}`)
     return null
+  }
+
+  function loadDocs (componentName) {
+    let componentPath = kebabCase(componentName)
+    switch (componentPath) {
+      case 'row':
+      case 'col':
+        componentPath = 'legacy-grid'
+        break
+      case 'step':
+        componentPath = 'steps'
+        break
+      case 'h-1':
+      case 'h-2':
+      case 'h-3':
+      case 'h-4':
+      case 'h-5':
+      case 'h-6':
+      case 'text':
+      case 'p':
+      case 'ul':
+      case 'ol':
+      case 'li':
+      case 'hr':
+      case 'a':
+      case 'blockquote':
+        componentPath = 'typography'
+        break
+      case 'th':
+      case 'tr':
+      case 'td':
+      case 'thead':
+      case 'tbody':
+        componentPath = 'table'
+        break
+      case 'tab-pane':
+      case 'tab':
+        componentPath = 'tabs'
+        break
+    }
+    let docsPath
+    do {
+      docsPath = path.resolve(
+        baseDir,
+        'src/' + componentPath + '/demos/enUS/index.demo-entry.md'
+      )
+      if (fs.existsSync(docsPath)) break
+      componentPath = componentPath.substring(
+        0,
+        Math.max(0, componentPath.lastIndexOf('-'))
+      )
+    } while (componentPath)
+
+    if (!componentPath) {
+      console.log(`Docs not found for ${componentName}`)
+      return {
+        props: {},
+        slots: {}
+      }
+    }
+    const docsFile = fs.readFileSync(docsPath).toString()
+    const props = extractSectionTable('Props')
+    const slots = extractSectionTable('Slots')
+    const description = extractComponentDescription()
+
+    return {
+      props,
+      slots,
+      description,
+      docUrl: `https://www.naiveui.com/en-US/os-theme/components/${componentPath}`
+    }
+
+    function extractComponentDescription () {
+      const description = docsFile.match(
+        RegExp(`#.*${componentName}\n(.*)## Demos`, 's')
+      )
+      if (description) {
+        return description[1].trim()
+      }
+    }
+
+    function extractSectionTable (sectionName) {
+      const result = {}
+      try {
+        const sectionHeaderRegex = RegExp(
+          `##.*${componentName}[, ].*${sectionName}\n`
+        )
+        const location = docsFile.match(sectionHeaderRegex)
+        if (!location || location.index < 0) return result
+        let end = docsFile.indexOf('##', location.index + 3)
+        if (end < 0) end = docsFile.length
+
+        const rowRegex = /\|((\\\||[^|])+)/g
+        const sectionContents = docsFile.substring(
+          location.index + location[0].length,
+          end
+        )
+        const table = sectionContents
+          .split('\n')
+          .map((it) => it.trim())
+          .filter((it) => !!it && it.indexOf('| ---') < 0 && it.startsWith('|'))
+          .map((it) => {
+            const row = it.match(rowRegex)
+            if (row === null) throw new Error('Failed to match: ' + it)
+            return row.map((it) => it.substring(1).trim())
+          })
+
+        if (table.length > 0) {
+          if (table[0][0] !== 'Name') {
+            throw new Error('Bad table ' + sectionName + ' in ' + componentName)
+          }
+          for (let i = 1; i < table.length; i++) {
+            const row = table[i]
+            const name = row[0]
+            const info = {}
+            for (let j = 1; j < row.length; j++) {
+              info[table[0][j].toLowerCase()] = row[j]
+            }
+            result[name] = info
+          }
+        }
+      } catch (e) {
+        console.error(
+          `Failed to build table info for section ${sectionName} of ${componentName} under ${docsPath}`,
+          e
+        )
+      }
+      return result
+    }
+  }
+
+  function assignDocs (target, docs) {
+    if (!docs) return
+    if (docs.parameters) {
+      // For slot
+      let type = docs.parameters
+      if (type && type.startsWith('`') && type.endsWith('`')) {
+        type = type.substring(1, type.length - 1).trim()
+      }
+      if (type && type.startsWith('(') && type.endsWith(')')) {
+        type = type.substring(1, type.length - 1).trim()
+      }
+      const objDefStart = type ? type.indexOf('{') : -1
+      if (objDefStart >= 0) {
+        target.type = type.substring(objDefStart).replaceAll('\\|', '|')
+      }
+    }
+    if (docs.type) {
+      // For props and events
+      let type = docs.type
+      if (type && type.startsWith('`') && type.endsWith('`')) {
+        type = type.substring(1, type.length - 1).trim()
+      }
+      target.type = type.replaceAll('\\|', '|')
+    }
+    if (docs.description) {
+      target.description = docs.description
+    }
+    if (docs.default) {
+      target.default = docs.default
+    }
+    if (docs.version) {
+      target['description-sections'] = { since: docs.version }
+    }
   }
 }
 


### PR DESCRIPTION
This PR aims at improving user experience in WebStorm and other JetBrains IDEs. The generated Web Types will now include available documentation and information about slots. Source navigation and links to online documentation are also added.

Here is a screencast of how code completion works with new Web Types:
 
![naive-ui-screencast 2022-09-07 12_36_53](https://user-images.githubusercontent.com/4244523/188859451-8e6fde6c-5cb3-4565-93df-f9ef10f2f52c.gif)

Please note that some of the features as code completion within slot destructing parameters will be available on in WebStorm 2022.3.

WebStorm works with `.d.ts` files, but the experience is worse than with properly created Web Types. Further improvements to integration between `*.d.ts` and Web Types is expected to come in 2022.3.

close #3675
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
