### PR TITLE
docs: improve Web Types generation - remove quotes around default value

### DIFF
--- a/scripts/post-build/gen-web-types.js
+++ b/scripts/post-build/gen-web-types.js
@@ -297,13 +297,7 @@ exports.genWebTypes = function genWebTypes () {
     if (!docs) return
     if (docs.parameters) {
       // For slot
-      let type = docs.parameters
-      if (type && type.startsWith('`') && type.endsWith('`')) {
-        type = type.substring(1, type.length - 1).trim()
-      }
-      if (type && type.startsWith('(') && type.endsWith(')')) {
-        type = type.substring(1, type.length - 1).trim()
-      }
+      const type = strip(strip(docs.parameters, '`'), '(', ')')
       const objDefStart = type ? type.indexOf('{') : -1
       if (objDefStart >= 0) {
         target.type = type.substring(objDefStart).replaceAll('\\|', '|')
@@ -311,21 +305,26 @@ exports.genWebTypes = function genWebTypes () {
     }
     if (docs.type) {
       // For props and events
-      let type = docs.type
-      if (type && type.startsWith('`') && type.endsWith('`')) {
-        type = type.substring(1, type.length - 1).trim()
-      }
-      target.type = type.replaceAll('\\|', '|')
+      target.type = strip(docs.type, '`').replaceAll('\\|', '|')
     }
     if (docs.description) {
       target.description = docs.description
     }
     if (docs.default) {
-      target.default = docs.default
+      target.default = strip(docs.default, '`')
     }
     if (docs.version) {
       target['description-sections'] = { since: docs.version }
     }
+  }
+
+  function strip (str, prefix, suffix) {
+    if (!str) return str
+    if (!suffix) suffix = prefix
+    if (str.startsWith(prefix) && str.endsWith(suffix)) {
+      return str.substring(1, str.length - 1).trim()
+    }
+    return str
   }
 }
 


### PR DESCRIPTION
This is a follow up to #3691. It fixes issue with default values having back quotes around them.

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
