### PR TITLE
fix: allow deep imports when package type is `module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     ".": {
       "import": "./es/index.js",
       "require": "./lib/index.js"
+    },
+    "./es/*": {
+      "import": "./es/*.js"
     }
   },
   "web-types": "./web-types.json",


### PR DESCRIPTION
This change will allow packages with type `module` to import modules from deep paths. For example, in my case I implemented a custom input using these imports:
````typescript
import useConfig from 'naive-ui/es/_mixins/use-config'
import useFormItem from 'naive-ui/es/_mixins/use-form-item'
import useTheme from 'naive-ui/es/_mixins/use-theme'
import inputLight from 'naive-ui/es/input/styles/light'
import inputStyle from 'naive-ui/es/input/src/styles/input.cssr'
import { createKey } from 'naive-ui/es/_utils/cssr/create-key'
````

Without this change I saw:
````
8:44:15 AM [vite] Internal server error: Missing "./es/_mixins/use-config" export in "naive-ui" package
  Plugin: vite:import-analysis
````