### PR TITLE
Feat(upload): add props trigger

### DIFF
--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,6 +23,7 @@
 
 ### Feats
 
+- `n-upload` 的 `props` 增加 `trigger` 参数用于控制相关交互功能元素的展示，关闭 [#3843](https://github.com/tusen-ai/naive-ui/issues/3843)
 - `n-collapse-item` 的 `header-extra` 和 `header` 插槽支持 `collapsed` 参数，关闭 [#3723](https://github.com/tusen-ai/naive-ui/issues/3723)
 - `n-loading-bar-provider` 新增 `container-style` 属性
 - `n-loading-bar-provider` 新增 `to` 属性，关闭 [#3724](https://github.com/tusen-ai/naive-ui/issues/3724)
@@ -99,7 +100,7 @@
 
 ### Fixes
 
-- 修复 `n-select` 菜单在 SSR 情况下缺少勾选图标，关闭 https://github.com/07akioni/naive-ui-nuxt-demo/issues/4
+- 修复 `n-select` 菜单在 SSR 情况下缺少勾选图标，关闭 <https://github.com/07akioni/naive-ui-nuxt-demo/issues/4>
 - 修复 `n-card` 的 `embedded` 属性在 `n-dialog` 中不生效，关闭 [#3592](https://github.com/tusen-ai/naive-ui/issues/3592)
 - 修复 `n-radio` 当 `value` 属性为布尔值时报警告, 关闭 [#3540](https://github.com/tusen-ai/naive-ui/issues/3540)
 - 修复 `n-pagination` 被禁用时，快速跳转菜单还会触发并可进行分页跳转

--- a/src/upload/demos/zhCN/image-trigger.demo.vue
+++ b/src/upload/demos/zhCN/image-trigger.demo.vue
@@ -16,7 +16,7 @@
   <n-divider />
   <n-upload
     action="__HTTP__://www.mocky.io/v2/5e4bafc63100007100d8b70f"
-    :default-file-list="previewFileList"
+    :default-file-list="fileList"
     list-type="image-card"
     trigger="hover"
     @preview="handlePreview"
@@ -24,7 +24,7 @@
   <n-divider />
   <n-upload
     action="__HTTP__://www.mocky.io/v2/5e4bafc63100007100d8b70f"
-    :default-file-list="previewFileList"
+    :default-file-list="fileList"
     list-type="image-card"
     trigger="click"
     @preview="handlePreview"
@@ -58,39 +58,8 @@ export default defineComponent({
       previewImageUrl: previewImageUrlRef,
       fileList: ref<UploadFileInfo[]>([
         {
-          id: 'a',
-          name: '我是上传出错的普通文件.png',
-          status: 'error'
-        },
-        {
-          id: 'b',
-          name: '我是普通文本.doc',
-          status: 'finished',
-          type: 'text/plain'
-        },
-        {
-          id: 'c',
-          name: '我是自带url的图片.png',
-          status: 'finished',
-          url: '__HTTP__://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
-        },
-        {
-          id: 'd',
-          name: '我是上传进度99%的文本.doc',
-          status: 'uploading',
-          percentage: 99
-        }
-      ]),
-      previewFileList: ref<UploadFileInfo[]>([
-        {
           id: 'react',
           name: '我是react.png',
-          status: 'finished',
-          url: '__HTTP__://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
-        },
-        {
-          id: 'vue',
-          name: '我是vue.png',
           status: 'finished',
           url: '__HTTP__://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
         }

--- a/src/upload/demos/zhCN/image-trigger.demo.vue
+++ b/src/upload/demos/zhCN/image-trigger.demo.vue
@@ -1,0 +1,101 @@
+<markdown>
+# 交互展示元素控制
+
+通过 `trigger` 属性控制相关交互按钮在何时显示，可选值 `none` (一直显示) | `hover` | `click`
+</markdown>
+
+<template>
+  <n-upload
+    action="__HTTP__://www.mocky.io/v2/5e4bafc63100007100d8b70f"
+    :default-file-list="fileList"
+    list-type="image-card"
+    trigger="none"
+  >
+    点击上传
+  </n-upload>
+  <n-divider />
+  <n-upload
+    action="__HTTP__://www.mocky.io/v2/5e4bafc63100007100d8b70f"
+    :default-file-list="previewFileList"
+    list-type="image-card"
+    trigger="hover"
+    @preview="handlePreview"
+  />
+  <n-divider />
+  <n-upload
+    action="__HTTP__://www.mocky.io/v2/5e4bafc63100007100d8b70f"
+    :default-file-list="previewFileList"
+    list-type="image-card"
+    trigger="click"
+    @preview="handlePreview"
+  />
+  <n-modal
+    v-model:show="showModal"
+    preset="card"
+    style="width: 600px"
+    title="一张很酷的图片"
+  >
+    <img :src="previewImageUrl" style="width: 100%">
+  </n-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import { UploadFileInfo } from 'naive-ui'
+
+export default defineComponent({
+  setup () {
+    const showModalRef = ref(false)
+    const previewImageUrlRef = ref('')
+    function handlePreview (file: UploadFileInfo) {
+      const { url } = file
+      previewImageUrlRef.value = url as string
+      showModalRef.value = true
+    }
+    return {
+      handlePreview,
+      showModal: showModalRef,
+      previewImageUrl: previewImageUrlRef,
+      fileList: ref<UploadFileInfo[]>([
+        {
+          id: 'a',
+          name: '我是上传出错的普通文件.png',
+          status: 'error'
+        },
+        {
+          id: 'b',
+          name: '我是普通文本.doc',
+          status: 'finished',
+          type: 'text/plain'
+        },
+        {
+          id: 'c',
+          name: '我是自带url的图片.png',
+          status: 'finished',
+          url: '__HTTP__://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
+        },
+        {
+          id: 'd',
+          name: '我是上传进度99%的文本.doc',
+          status: 'uploading',
+          percentage: 99
+        }
+      ]),
+      previewFileList: ref<UploadFileInfo[]>([
+        {
+          id: 'react',
+          name: '我是react.png',
+          status: 'finished',
+          url: '__HTTP__://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
+        },
+        {
+          id: 'vue',
+          name: '我是vue.png',
+          status: 'finished',
+          url: '__HTTP__://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
+        }
+      ])
+    }
+  }
+})
+</script>

--- a/src/upload/demos/zhCN/index.demo-entry.md
+++ b/src/upload/demos/zhCN/index.demo-entry.md
@@ -26,7 +26,7 @@ debug.vue
 ### Upload Props
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
-| --- | --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | abstract | `boolean` | `false` | 是否不存在 DOM 包裹，不支持 `image-card` 类型的 Upload |  |
 | accept | `string` | `undefined` | 接受的文件类型，参考 <n-a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept" target="_blank">accept</n-a> |  |
 | action | `string` | `undefined` | 请求提交的地址 |  |
@@ -57,7 +57,7 @@ debug.vue
 | show-file-list | `boolean` | `true` | 是否显示文件列表 |  |
 | show-preview-button | `boolean` | `true` | 是否允许显示预览按钮（在 `list-type` 为 `image-card` 时生效） |  |
 | show-trigger | `boolean` | `true` | 是否显示触发元素 | 2.21.5 |
-| trigger | `none | hover | click` | `hover` | 显示触发元素的时机 | NEXT_VERSION |
+| trigger | `none \| hover \| click` | `hover` | 显示触发元素的时机 | NEXT_VERSION |
 | trigger-style | `Object \| string` | `undefined` | 触发器区域的样式 | 2.29.1 |
 | with-credentials | `boolean` | `false` | 是否携带 Cookie |  |
 | on-change | `(options: { file: UploadFileInfo, fileList: Array<UploadFileInfo>, event?: Event }) => void` | `() => {}` | 组件状态变化的回调，组件的任何文件状态变化都会触发回调 |  |

--- a/src/upload/demos/zhCN/index.demo-entry.md
+++ b/src/upload/demos/zhCN/index.demo-entry.md
@@ -15,6 +15,7 @@ default-files.vue
 before-upload.vue
 image-style.vue
 image-card-style.vue
+image-trigger.vue
 custom-request.vue
 abstract.vue
 debug.vue
@@ -25,7 +26,7 @@ debug.vue
 ### Upload Props
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- |
 | abstract | `boolean` | `false` | 是否不存在 DOM 包裹，不支持 `image-card` 类型的 Upload |  |
 | accept | `string` | `undefined` | 接受的文件类型，参考 <n-a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept" target="_blank">accept</n-a> |  |
 | action | `string` | `undefined` | 请求提交的地址 |  |
@@ -56,6 +57,7 @@ debug.vue
 | show-file-list | `boolean` | `true` | 是否显示文件列表 |  |
 | show-preview-button | `boolean` | `true` | 是否允许显示预览按钮（在 `list-type` 为 `image-card` 时生效） |  |
 | show-trigger | `boolean` | `true` | 是否显示触发元素 | 2.21.5 |
+| trigger | `none | hover | click` | `hover` | 显示触发元素的时机 | NEXT_VERSION |
 | trigger-style | `Object \| string` | `undefined` | 触发器区域的样式 | 2.29.1 |
 | with-credentials | `boolean` | `false` | 是否携带 Cookie |  |
 | on-change | `(options: { file: UploadFileInfo, fileList: Array<UploadFileInfo>, event?: Event }) => void` | `() => {}` | 组件状态变化的回调，组件的任何文件状态变化都会触发回调 |  |

--- a/src/upload/src/Upload.tsx
+++ b/src/upload/src/Upload.tsx
@@ -345,7 +345,11 @@ export const uploadProps = {
   },
   imageGroupProps: Object as PropType<ImageGroupProps>,
   inputProps: Object as PropType<InputHTMLAttributes>,
-  triggerStyle: [String, Object] as PropType<CSSProperties | string>
+  triggerStyle: [String, Object] as PropType<CSSProperties | string>,
+  trigger: {
+    type: String as PropType<'none' | 'hover' | 'click'>,
+    default: 'click'
+  }
 } as const
 
 export type UploadProps = ExtractPublicPropTypes<typeof uploadProps>
@@ -663,7 +667,9 @@ export default defineComponent({
       imageGroupPropsRef: toRef(props, 'imageGroupProps'),
       mergedDirectoryDndRef: computed(() => {
         return props.directoryDnd ?? props.directory
-      })
+      }),
+
+      triggerRef: toRef(props, 'trigger')
     })
 
     const exposedMethods: UploadInst = {

--- a/src/upload/src/Upload.tsx
+++ b/src/upload/src/Upload.tsx
@@ -40,7 +40,8 @@ import type {
   CustomRequest,
   OnError,
   SettledFileInfo,
-  FileAndEntry
+  FileAndEntry,
+  UploadTrigger
 } from './interface'
 import { uploadInjectionKey } from './interface'
 import { createImageDataUrl, createSettledFileInfo, matchType } from './utils'
@@ -347,7 +348,7 @@ export const uploadProps = {
   inputProps: Object as PropType<InputHTMLAttributes>,
   triggerStyle: [String, Object] as PropType<CSSProperties | string>,
   trigger: {
-    type: String as PropType<'none' | 'hover' | 'click'>,
+    type: String as PropType<UploadTrigger>,
     default: 'hover'
   }
 } as const

--- a/src/upload/src/Upload.tsx
+++ b/src/upload/src/Upload.tsx
@@ -348,7 +348,7 @@ export const uploadProps = {
   triggerStyle: [String, Object] as PropType<CSSProperties | string>,
   trigger: {
     type: String as PropType<'none' | 'hover' | 'click'>,
-    default: 'click'
+    default: 'hover'
   }
 } as const
 

--- a/src/upload/src/UploadFile.tsx
+++ b/src/upload/src/UploadFile.tsx
@@ -25,7 +25,7 @@ import { NButton } from '../../button'
 import { NIconSwitchTransition, NBaseIcon } from '../../_internal'
 import { warn } from '../../_utils'
 import NUploadProgress from './UploadProgress'
-import { uploadInjectionKey } from './interface'
+import { uploadInjectionKey, UploadTrigger } from './interface'
 import type { SettledFileInfo, ListType } from './interface'
 import { imageIcon, documentIcon } from './icons'
 import { download, environmentSupportFile, isImageFile } from './utils'
@@ -58,7 +58,11 @@ export default defineComponent({
 
     const imageRef = ref<ImageInst | null>(null)
     const thumbnailUrlRef = ref<string>('')
-    const showTriggerRef = ref<boolean>(NUpload.triggerRef.value === 'none')
+    const showTriggerRef = ref<undefined | UploadTrigger>(
+      NUpload.triggerRef.value === 'click'
+        ? undefined
+        : NUpload.triggerRef.value
+    )
 
     const progressStatusRef = computed(() => {
       const { file } = props
@@ -186,20 +190,9 @@ export default defineComponent({
     }
     function handleTriggerClick (): void {
       if (NUpload.triggerRef.value === 'click') {
-        showTriggerRef.value = !showTriggerRef.value
+        showTriggerRef.value =
+          showTriggerRef.value === 'click' ? undefined : 'click'
       }
-    }
-    function handlerMouseEnterWrapper (): void {
-      if (NUpload.triggerRef.value !== 'hover') {
-        return
-      }
-      showTriggerRef.value = true
-    }
-    function handleMouseLeaveWrapper (): void {
-      if (NUpload.triggerRef.value !== 'hover') {
-        return
-      }
-      showTriggerRef.value = false
     }
     const deriveFileThumbnailUrl = async (): Promise<void> => {
       const { listType } = props
@@ -234,8 +227,6 @@ export default defineComponent({
       handleRetryClick,
       handlePreviewClick,
       handleTriggerClick,
-      handlerMouseEnterWrapper,
-      handleMouseLeaveWrapper,
       showTriggerRef,
       triggerRef: NUpload.triggerRef
     }
@@ -247,8 +238,6 @@ export default defineComponent({
       listType,
       file,
       handleTriggerClick,
-      handlerMouseEnterWrapper,
-      handleMouseLeaveWrapper,
       showTriggerRef,
       triggerRef
     } = this
@@ -322,16 +311,12 @@ export default defineComponent({
             listType !== 'image-card' &&
             `${clsPrefix}-upload-file--with-url`,
           `${clsPrefix}-upload-file--${listType}-type`,
-
           showTriggerRef &&
+            ['click', 'none'].includes(showTriggerRef) &&
+            `${clsPrefix}-upload-file--click ${clsPrefix}-upload-file--${listType}-type--click`,
+          showTriggerRef === 'hover' &&
             `${clsPrefix}-upload-file--hover ${clsPrefix}-upload-file--${listType}-type--hover`
         ]}
-        onMouseenter={
-          triggerRef === 'hover' ? handlerMouseEnterWrapper : undefined
-        }
-        onMouseleave={
-          triggerRef === 'hover' ? handleMouseLeaveWrapper : undefined
-        }
         onClick={triggerRef === 'click' ? handleTriggerClick : undefined}
       >
         <div class={`${clsPrefix}-upload-file-info`}>

--- a/src/upload/src/UploadFile.tsx
+++ b/src/upload/src/UploadFile.tsx
@@ -58,6 +58,7 @@ export default defineComponent({
 
     const imageRef = ref<ImageInst | null>(null)
     const thumbnailUrlRef = ref<string>('')
+    const showTriggerRef = ref<boolean>(NUpload.triggerRef.value === 'none')
 
     const progressStatusRef = computed(() => {
       const { file } = props
@@ -183,7 +184,23 @@ export default defineComponent({
         value.click()
       }
     }
-
+    function handleTriggerClick (): void {
+      if (NUpload.triggerRef.value === 'click') {
+        showTriggerRef.value = !showTriggerRef.value
+      }
+    }
+    function handlerMouseEnterWrapper (): void {
+      if (NUpload.triggerRef.value !== 'hover') {
+        return
+      }
+      showTriggerRef.value = true
+    }
+    function handleMouseLeaveWrapper (): void {
+      if (NUpload.triggerRef.value !== 'hover') {
+        return
+      }
+      showTriggerRef.value = false
+    }
     const deriveFileThumbnailUrl = async (): Promise<void> => {
       const { listType } = props
       if (listType !== 'image' && listType !== 'image-card') {
@@ -215,11 +232,26 @@ export default defineComponent({
       handleRemoveOrCancelClick,
       handleDownloadClick,
       handleRetryClick,
-      handlePreviewClick
+      handlePreviewClick,
+      handleTriggerClick,
+      handlerMouseEnterWrapper,
+      handleMouseLeaveWrapper,
+      showTriggerRef,
+      triggerRef: NUpload.triggerRef
     }
   },
   render () {
-    const { clsPrefix, mergedTheme, listType, file } = this
+    const {
+      clsPrefix,
+      mergedTheme,
+      listType,
+      file,
+      handleTriggerClick,
+      handlerMouseEnterWrapper,
+      handleMouseLeaveWrapper,
+      showTriggerRef,
+      triggerRef
+    } = this
 
     // if there is text list type, show file icon
     let icon: VNode
@@ -289,8 +321,18 @@ export default defineComponent({
             file.status !== 'error' &&
             listType !== 'image-card' &&
             `${clsPrefix}-upload-file--with-url`,
-          `${clsPrefix}-upload-file--${listType}-type`
+          `${clsPrefix}-upload-file--${listType}-type`,
+
+          showTriggerRef &&
+            `${clsPrefix}-upload-file--hover ${clsPrefix}-upload-file--${listType}-type--hover`
         ]}
+        onMouseenter={
+          triggerRef === 'hover' ? handlerMouseEnterWrapper : undefined
+        }
+        onMouseleave={
+          triggerRef === 'hover' ? handleMouseLeaveWrapper : undefined
+        }
+        onClick={triggerRef === 'click' ? handleTriggerClick : undefined}
       >
         <div class={`${clsPrefix}-upload-file-info`}>
           {icon}

--- a/src/upload/src/interface.ts
+++ b/src/upload/src/interface.ts
@@ -4,6 +4,7 @@ import type { MergedTheme } from '../../_mixins'
 import { createInjectionKey } from '../../_utils'
 import type { UploadTheme } from '../styles'
 
+export type UploadTrigger = 'none' | 'hover' | 'click'
 export interface FileInfo {
   id: string
   name: string
@@ -101,7 +102,7 @@ export interface UploadInjection {
   handleFileAddition: (files: FileAndEntry[] | null, e?: Event) => void
   openOpenFileDialog: () => void
 
-  triggerRef: Ref<'none' | 'hover' | 'click'>
+  triggerRef: Ref<UploadTrigger>
 }
 
 export const uploadInjectionKey =

--- a/src/upload/src/interface.ts
+++ b/src/upload/src/interface.ts
@@ -100,6 +100,8 @@ export interface UploadInjection {
   getFileThumbnailUrl: (file: SettledFileInfo) => Promise<string>
   handleFileAddition: (files: FileAndEntry[] | null, e?: Event) => void
   openOpenFileDialog: () => void
+
+  triggerRef: Ref<'none' | 'hover' | 'click'>
 }
 
 export const uploadInjectionKey =

--- a/src/upload/src/styles/index.cssr.ts
+++ b/src/upload/src/styles/index.cssr.ts
@@ -99,13 +99,18 @@ export default c([
           foldPadding: true
         })
       ]),
-      c('&:hover', `
-        background-color: var(--n-item-color-hover);
-      `, [
+      cM('hover', `
+          background-color: var(--n-item-color-hover);
+        `, [
         cB('upload-file-info', [
           cE('action', `
-            opacity: 1;
-          `)
+              opacity: 1;
+              z-index: 2;
+            `, [
+            cM('image-card-type', `
+              z-index: 2;
+            `)
+          ])
         ])
       ]),
       cM('image-type', `
@@ -203,7 +208,7 @@ export default c([
           transition: opacity .2s var(--n-bezier);
           content: "";
         `),
-        c('&:hover', [
+        cM('hover', [
           c('&::before', 'opacity: 1;'),
           cB('upload-file-info', [
             cE('thumbnail', 'opacity: .12;')
@@ -214,6 +219,9 @@ export default c([
         c('&:hover', `
           background-color: var(--n-item-color-hover-error);
         `),
+        //   c('&-action', `
+        //   background-color: var(--n-item-color-hover-error);
+        // `),
         cB('upload-file-info', [
           cE('name', 'color: var(--n-item-text-color-error);'),
           cE('thumbnail', 'color: var(--n-item-text-color-error);')
@@ -268,6 +276,7 @@ export default c([
           transition: opacity .2s var(--n-bezier);
           justify-content: flex-end;
           opacity: 0;
+          z-index: -1;
         `, [
           cB('button', [
             c('&:not(:last-child)', {
@@ -285,7 +294,7 @@ export default c([
             width: auto;
           `),
           cM('image-card-type', `
-            z-index: 2;
+            z-index: -1;
             position: absolute;
             width: 100%;
             height: 100%;

--- a/src/upload/src/styles/index.cssr.ts
+++ b/src/upload/src/styles/index.cssr.ts
@@ -99,7 +99,7 @@ export default c([
           foldPadding: true
         })
       ]),
-      cM('hover', `
+      cM('click', `
           background-color: var(--n-item-color-hover);
         `, [
         cB('upload-file-info', [
@@ -110,6 +110,20 @@ export default c([
             cM('image-card-type', `
               z-index: 2;
             `)
+          ])
+        ])
+      ]),
+      cM('hover:hover', `
+        background-color: var(--n-item-color-hover);
+      `, [
+        cB('upload-file-info', [
+          cE('action', `
+            opacity: 1;
+            z-index: 2;
+            `, [
+            cM('image-card-type', `
+                z-index: 2;
+              `)
           ])
         ])
       ]),
@@ -208,7 +222,13 @@ export default c([
           transition: opacity .2s var(--n-bezier);
           content: "";
         `),
-        cM('hover', [
+        cM('click', [
+          c('&::before', 'opacity: 1;'),
+          cB('upload-file-info', [
+            cE('thumbnail', 'opacity: .12;')
+          ])
+        ]),
+        cM('hover:hover', [
           c('&::before', 'opacity: 1;'),
           cB('upload-file-info', [
             cE('thumbnail', 'opacity: .12;')


### PR DESCRIPTION
- `n-upload` 的 `props` 增加 `trigger` 参数用于控制相关交互功能元素的展示，关闭 [#3843](https://github.com/tusen-ai/naive-ui/issues/3843)
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
