### PR TITLE
 dataTable 添加新属性 summaryHeader

### DIFF
--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -42,6 +42,7 @@ controlled-multiple-sorter
 fixed-header.vue
 fixed-header-column.vue
 summary.vue
+summaryHeader.vue
 ellipsis.vue
 ellipsis-tooltip.vue
 expand.vue
@@ -107,6 +108,7 @@ expandable-debug.vue
 | sticky-expanded-rows | `boolean` | `false` | 展开行是否不随表格横向滚动 | 2.32.2 |
 | striped | `boolean` | `false` | 是否使用斑马线条纹 |  |
 | summary | `DataTableCreateSummary` | `undefined` | 表格总结栏的数据，类型见 <n-a href="#DataTableCreateSummary-Type">DataTableCreateSummary Type</n-a> |  |
+| summaryHeader | `DataTableCreateSummary` | `undefined` | 表格固定在表头的总结栏，用法同`summary` |  |
 | summary-placement | `'top' \| 'bottom'` | `'bottom'` | 总结栏的位置 | 2.33.3 |
 | table-layout | `'auto' \| 'fixed'` | `'auto'` | 表格的 `table-layout` 样式属性，在设定 `ellipsis` 或 `max-height` 的情况下固定为 `'fixed'` |  |
 | virtual-scroll | `boolean` | `false` | 是否开启虚拟滚动，应对大规模数据，开启前请设定好 `max-height`。当 `virtual-scroll` 为 `true` 时，`rowSpan` 将不生效 |  |

--- a/src/data-table/demos/zhCN/summaryHeader.demo.vue
+++ b/src/data-table/demos/zhCN/summaryHeader.demo.vue
@@ -1,0 +1,122 @@
+<markdown>
+# 固定总结栏
+
+使用 `summaryHeader` 属性渲染固定在表头的总结栏。
+</markdown>
+
+<template>
+  <n-data-table
+    :columns="columns"
+    :data="data"
+    :max-height="250"
+    :scroll-x="1800"
+    virtual-scroll
+    :summary-header="summary"
+  />
+</template>
+
+<script lang="ts">
+import { h, defineComponent } from 'vue'
+import type { DataTableColumns, DataTableCreateSummary } from 'naive-ui'
+
+type RowData = {
+  key: number
+  name: string
+  age: number
+  address: string
+}
+
+const columns: DataTableColumns<RowData> = [
+  {
+    type: 'selection',
+    fixed: 'left'
+  },
+  {
+    title: 'Name',
+    key: 'name',
+    width: 200,
+    fixed: 'left'
+  },
+  {
+    title: 'Age',
+    key: 'age',
+    width: 100,
+    fixed: 'left'
+  },
+  {
+    title: 'Row',
+    key: 'row',
+    render (row, index) {
+      return h('span', ['row ', index])
+    }
+  },
+  {
+    title: 'Row1',
+    key: 'row1',
+    render (row, index) {
+      return h('span', ['row ', index])
+    }
+  },
+  {
+    title: 'Row2',
+    key: 'row2',
+    render (row, index) {
+      return h('span', ['row ', index])
+    },
+    width: 100,
+    fixed: 'right'
+  },
+  {
+    title: 'Address',
+    key: 'address',
+    width: 200,
+    fixed: 'right'
+  }
+]
+
+const createSummary: DataTableCreateSummary = (pageData) => {
+  return {
+    name: {
+      value: h('span', { style: { color: 'red' } }, '合计')
+    },
+    age: {
+      value: h(
+        'span',
+        { style: { color: 'red' } },
+        (pageData as RowData[]).reduce(
+          (prevValue, row) => prevValue + row.age,
+          0
+        )
+      )
+    },
+    row: {
+      value: h('span', { style: { color: 'red' } }, '-')
+    },
+    row1: {
+      value: h('span', { style: { color: 'red' } }, '-')
+    },
+    row2: {
+      value: h('span', { style: { color: 'red' } }, '-')
+    },
+    address: {
+      value: h('span', { style: { color: 'red' } }, '-')
+    }
+  }
+}
+
+export default defineComponent({
+  setup () {
+    const data: RowData[] = Array.from({ length: 100 }).map((_, index) => ({
+      key: index,
+      name: `Edward King ${index}`,
+      age: 32,
+      address: `London, Park Lane no. ${index}`
+    }))
+    return {
+      summary: createSummary,
+      data,
+      columns
+    }
+  }
+})
+</script>

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -216,6 +216,7 @@ export default defineComponent({
       rowKeyRef: toRef(props, 'rowKey'),
       renderExpandRef,
       summaryRef: toRef(props, 'summary'),
+      summaryHeaderRef: toRef(props, 'summaryHeader'),
       virtualScrollRef: toRef(props, 'virtualScroll'),
       rowPropsRef: toRef(props, 'rowProps'),
       stripedRef: toRef(props, 'striped'),

--- a/src/data-table/src/TableParts/Header.tsx
+++ b/src/data-table/src/TableParts/Header.tsx
@@ -14,6 +14,7 @@ import { NEllipsis } from '../../../ellipsis'
 import SortButton from '../HeaderButton/SortButton'
 import FilterButton from '../HeaderButton/FilterButton'
 import ResizeButton from '../HeaderButton/ResizeButton'
+import Cell from './Cell'
 import {
   isColumnSortable,
   isColumnFilterable,
@@ -28,9 +29,37 @@ import {
   TableColumnGroup,
   TableBaseColumn,
   dataTableInjectionKey,
-  ColumnKey
+  ColumnKey,
+  RowKey,
+  SummaryRowData,
+  TmNode
 } from '../interface'
 import SelectionMenu from './SelectionMenu'
+
+interface NormalRowRenderInfo {
+  striped: boolean
+  tmNode: TmNode
+  key: RowKey
+  index: number
+}
+
+type RowRenderInfo =
+  | {
+    isSummaryRow: true
+    key: RowKey
+    tmNode: {
+      rawNode: SummaryRowData
+      disabled: boolean
+    }
+    index: number
+  }
+  | NormalRowRenderInfo
+  | {
+    isExpandedRow: true
+    tmNode: TmNode
+    key: RowKey
+    index: number
+  }
 
 function renderTitle (
   column: TableExpandColumn | TableBaseColumn | TableColumnGroup
@@ -71,7 +100,10 @@ export default defineComponent({
       handleTableHeaderScroll,
       deriveNextSorter,
       doUncheckAll,
-      doCheckAll
+      doCheckAll,
+      rawPaginatedDataRef,
+      summaryHeaderRef,
+      renderCell
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     } = inject(dataTableInjectionKey)!
     const cellElsRef = ref<Record<ColumnKey, HTMLTableCellElement>>({})
@@ -159,7 +191,10 @@ export default defineComponent({
       handleColHeaderClick,
       handleTableHeaderScroll,
       handleColumnResizeStart,
-      handleColumnResize
+      handleColumnResize,
+      rawPaginatedData: rawPaginatedDataRef,
+      summaryHeader: summaryHeaderRef,
+      renderCell
     }
   },
   render () {
@@ -183,8 +218,158 @@ export default defineComponent({
       handleColHeaderClick,
       handleCheckboxUpdateChecked,
       handleColumnResizeStart,
-      handleColumnResize
+      handleColumnResize,
+      summaryHeader
     } = this
+    let summaryData: RowRenderInfo[] = []
+    if (summaryHeader) {
+      const summaryRows = summaryHeader(this.rawPaginatedData)
+      if (Array.isArray(summaryRows)) {
+        const summaryRowData = summaryRows.map((row, i) => ({
+          isSummaryRow: true as const,
+          key: `__n_summary__${i}`,
+          tmNode: {
+            rawNode: row,
+            disabled: true
+          },
+          index: -1
+        }))
+        summaryData = summaryRowData
+      } else {
+        const summaryRowData = {
+          isSummaryRow: true as const,
+          key: '__n_summary__',
+          tmNode: {
+            rawNode: summaryRows,
+            disabled: true
+          },
+          index: -1
+        }
+        summaryData = [summaryRowData]
+      }
+    }
+    const { length: colCount } = cols
+    const cordToPass: Record<number, number[]> = {}
+    const cordKey: Record<number, Record<number, RowKey[]>> = {}
+    const renderSummaryHeaderRow = (
+      rowInfo: RowRenderInfo,
+      displayedRowIndex: number
+    ): VNode => {
+      const { index: actualRowIndex } = rowInfo
+      const isSummary = 'isSummaryRow' in rowInfo
+      const { tmNode, key: rowKey } = rowInfo
+      const { rawNode: rowData } = tmNode
+      const row = (
+        <tr
+          key={rowKey}
+          class={[
+            `${mergedClsPrefix}-data-table-tr`,
+            isSummary && `${mergedClsPrefix}-data-table-tr--summary`
+          ]}
+        >
+          {cols.map((col, colIndex) => {
+            if (displayedRowIndex in cordToPass) {
+              const cordOfRowToPass = cordToPass[displayedRowIndex]
+              const indexInCordOfRowToPass = cordOfRowToPass.indexOf(colIndex)
+              if (~indexInCordOfRowToPass) {
+                cordOfRowToPass.splice(indexInCordOfRowToPass, 1)
+                return null
+              }
+            }
+            const { column } = col
+            const colKey = getColKey(col)
+            const { rowSpan, colSpan } = column
+            const mergedColSpan = isSummary
+              ? rowInfo.tmNode.rawNode[colKey]?.colSpan || 1
+              : colSpan
+                ? colSpan(rowData, actualRowIndex)
+                : 1
+            const mergedRowSpan = isSummary
+              ? rowInfo.tmNode.rawNode[colKey]?.rowSpan || 1
+              : rowSpan
+                ? rowSpan(rowData, actualRowIndex)
+                : 1
+            const isLastCol = colIndex + mergedColSpan === colCount
+            const isCrossRowTd = mergedRowSpan > 1
+            if (isCrossRowTd) {
+              cordKey[displayedRowIndex] = {
+                [colIndex]: []
+              }
+            }
+            if (mergedColSpan > 1 || isCrossRowTd) {
+              for (
+                let i = displayedRowIndex;
+                i < displayedRowIndex + mergedRowSpan;
+                ++i
+              ) {
+                if (isCrossRowTd) {
+                  cordKey[displayedRowIndex][colIndex].push(i)
+                }
+                for (let j = colIndex; j < colIndex + mergedColSpan; ++j) {
+                  if (i === displayedRowIndex && j === colIndex) {
+                    continue
+                  }
+                  if (!(i in cordToPass)) {
+                    cordToPass[i] = [j]
+                  } else {
+                    cordToPass[i].push(j)
+                  }
+                }
+              }
+            }
+            const { cellProps } = column
+            const resolvedCellProps = cellProps?.(rowData, actualRowIndex)
+            return (
+              <td
+                {...resolvedCellProps}
+                key={colKey}
+                style={[
+                  {
+                    textAlign: column.align || undefined,
+                    left: pxfy(fixedColumnLeftMap[colKey]?.start),
+                    right: pxfy(fixedColumnRightMap[colKey]?.start)
+                  },
+                  resolvedCellProps?.style || ''
+                ]}
+                colspan={mergedColSpan}
+                rowspan={mergedRowSpan}
+                data-col-key={colKey}
+                class={[
+                  `${mergedClsPrefix}-data-table-th`,
+                  column.className,
+                  resolvedCellProps?.class,
+                  isSummary && `${mergedClsPrefix}-data-table-td--summary`,
+                  column.fixed &&
+                    `${mergedClsPrefix}-data-table-th--fixed-${column.fixed}`,
+                  column.align &&
+                    `${mergedClsPrefix}-data-table-td--${column.align}-align`,
+                  column.type === 'selection' &&
+                    `${mergedClsPrefix}-data-table-th--selection`,
+                  isLastCol && `${mergedClsPrefix}-data-table-th--last`
+                ]}
+              >
+                {column.type === 'selection' || column.type === 'expand' ? (
+                  !isSummary ? (
+                    <span />
+                  ) : null
+                ) : (
+                  <Cell
+                    clsPrefix={mergedClsPrefix}
+                    index={actualRowIndex}
+                    row={rowData}
+                    column={column}
+                    isSummary={isSummary}
+                    mergedTheme={mergedTheme}
+                    renderCell={this.renderCell}
+                  />
+                )}
+              </td>
+            )
+          })}
+        </tr>
+      )
+      return row
+    }
     let hasEllipsis = false
     const theadVNode = (
       <thead
@@ -313,6 +498,10 @@ export default defineComponent({
             </tr>
           )
         })}
+        {!!summaryData &&
+          summaryData.map((rowInfo, displayedRowIndex) => {
+            return renderSummaryHeaderRow(rowInfo, displayedRowIndex)
+          })}
       </thead>
     )
     if (!discrete) {

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -50,6 +50,7 @@ export const dataTableProps = {
   rowProps: Function as PropType<CreateRowProps<any>>,
   rowKey: Function as PropType<CreateRowKey<any>>,
   summary: [Function] as PropType<CreateSummary<any>>,
+  summaryHeader: [Function] as PropType<CreateSummary<any>>,
   data: {
     type: Array as PropType<RowData[]>,
     default: () => []
@@ -369,6 +370,7 @@ export interface DataTableInjection {
   rowKeyRef: Ref<CreateRowKey | undefined>
   renderExpandRef: Ref<undefined | RenderExpand>
   summaryRef: Ref<undefined | CreateSummary>
+  summaryHeaderRef: Ref<undefined | CreateSummary>
   rawPaginatedDataRef: Ref<InternalRowData[]>
   virtualScrollRef: Ref<boolean>
   bodyWidthRef: Ref<number | null>


### PR DESCRIPTION
 dataTable 添加新属性 summaryHeader (总结栏渲染在表头,实现固定);
解决总结栏难以固定问题