### PR TITLE
refactor(n-data-table): optimize the layout of filter button

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -2,6 +2,10 @@
 
 ## 2.33.5
 
+### Breaking Changes
+
+- Wrap a `DIV` container around the columns of `n-data-table` to optimize the layout of filter button, closes [#3853](https://github.com/tusen-ai/naive-ui/issues/3853).
+
 ### Fixes
 
 - Fix `n-data-table` throws error on tree data check action, closes [#3832](https://github.com/tusen-ai/naive-ui/issues/3832).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,10 @@
 
 ## 2.33.5
 
+### Breaking Changes
+
+- 在 `n-data-table` 的列外包裹一层 `DIV` 容器用以优化过滤按钮的布局，关闭 [#3853](https://github.com/tusen-ai/naive-ui/issues/3853)
+
 ### Fixes
 
 - 修复 `n-data-table` 树形数据勾选时报错，关闭 [#3832](https://github.com/tusen-ai/naive-ui/issues/3832)

--- a/src/data-table/src/TableParts/Header.tsx
+++ b/src/data-table/src/TableParts/Header.tsx
@@ -218,29 +218,32 @@ export default defineComponent({
                   }
                   return (
                     <>
-                      {ellipsis === true || (ellipsis && !ellipsis.tooltip) ? (
-                        <div
-                          class={`${mergedClsPrefix}-data-table-th__ellipsis`}
-                        >
-                          {renderTitle(column)}
-                        </div>
-                      ) // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-                        : ellipsis && typeof ellipsis === 'object' ? (
-                        <NEllipsis
-                          {...ellipsis}
-                          theme={mergedTheme.peers.Ellipsis}
-                          themeOverrides={mergedTheme.peerOverrides.Ellipsis}
-                        >
-                          {{
-                            default: () => renderTitle(column)
-                          }}
-                        </NEllipsis>
-                        ) : (
-                          renderTitle(column)
-                        )}
-                      {isColumnSortable(column) ? (
-                        <SortButton column={column as TableBaseColumn} />
-                      ) : null}
+                      <div class={`${mergedClsPrefix}-data-table-th__title`}>
+                        {ellipsis === true ||
+                        (ellipsis && !ellipsis.tooltip) ? (
+                          <div
+                            class={`${mergedClsPrefix}-data-table-th__ellipsis`}
+                          >
+                            {renderTitle(column)}
+                          </div>
+                            ) // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+                          : ellipsis && typeof ellipsis === 'object' ? (
+                          <NEllipsis
+                            {...ellipsis}
+                            theme={mergedTheme.peers.Ellipsis}
+                            themeOverrides={mergedTheme.peerOverrides.Ellipsis}
+                          >
+                            {{
+                              default: () => renderTitle(column)
+                            }}
+                          </NEllipsis>
+                          ) : (
+                            renderTitle(column)
+                          )}
+                        {isColumnSortable(column) ? (
+                          <SortButton column={column as TableBaseColumn} />
+                        ) : null}
+                      </div>
                       {isColumnFilterable(column) ? (
                         <FilterButton
                           column={column as TableBaseColumn}

--- a/src/data-table/src/styles/index.cssr.ts
+++ b/src/data-table/src/styles/index.cssr.ts
@@ -210,7 +210,11 @@ export default c([
     `, [
       cM('filterable', {
         paddingRight: '36px'
-      }),
+      }, [
+        cM('sortable', {
+          paddingRight: 'calc(var(--n-th-padding) + 36px)'
+        })
+      ]),
       fixedColumnStyle,
       cM('selection', `
         padding: 0;
@@ -218,6 +222,13 @@ export default c([
         line-height: 0;
         z-index: 3;
       `),
+      cE('title', {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        flex: 'auto',
+        maxWidth: '100%'
+      }),
       cE('ellipsis', `
         display: inline-block;
         vertical-align: bottom;


### PR DESCRIPTION
## Breaking Changes
Wrap a `DIV` container around the columns of `n-data-table` to optimize the layout of the filter button.

closes #3853.

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
