### PR TITLE
fix: 修复谷歌、edge浏览器106版本下拖动tree，出现白屏现象 。拖拽tree页面白屏，关闭#3909

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fix `n-tree` 在谷歌、edge 浏览器 106 版本下拖动 tree，出现白屏现象，关闭 [#3909](https://github.com/tusen-ai/naive-ui/issues/3909)
+
 - Fix `n-data-table` throws error on tree data check action, closes [#3832](https://github.com/tusen-ai/naive-ui/issues/3832).
 
 ### Feats

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- 修复 `n-tree` 在谷歌、edge 浏览器 106 版本下拖动 tree，出现白屏现象，关闭 [#3909](https://github.com/tusen-ai/naive-ui/issues/3909)
+
 - 修复 `n-data-table` 树形数据勾选时报错，关闭 [#3832](https://github.com/tusen-ai/naive-ui/issues/3832)
 
 ### Feats

--- a/src/tree/src/styles/index.cssr.ts
+++ b/src/tree/src/styles/index.cssr.ts
@@ -51,6 +51,8 @@ export default cB('tree', `
     padding: 3px 0;
   `),
   cB('tree-node', `
+    transform: translate(0, 0);
+    z-index: 0;
     position: relative;
     display: flex;
     border-radius: var(--n-node-border-radius);

--- a/src/tree/src/styles/index.cssr.ts
+++ b/src/tree/src/styles/index.cssr.ts
@@ -51,8 +51,7 @@ export default cB('tree', `
     padding: 3px 0;
   `),
   cB('tree-node', `
-    transform: translate(0, 0);
-    z-index: 0;
+    transform: translate3d(0,0,0);
     position: relative;
     display: flex;
     border-radius: var(--n-node-border-radius);


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
close #3909