### PR TITLE
fix(popover): Numbers and English do not wrap when the width limit is exceeded

### DIFF
--- a/src/popover/src/styles/index.cssr.ts
+++ b/src/popover/src/styles/index.cssr.ts
@@ -37,6 +37,7 @@ export default c([
     font-size: var(--n-font-size);
     color: var(--n-text-color);
     box-shadow: var(--n-box-shadow);
+    word-break: break-word;
   `, [
     c('>', [
       cB('scrollbar', `


### PR DESCRIPTION
Numbers and English do not wrap when the width limit is exceeded

reproduction：https://codesandbox.io/s/keen-hopper-ebrgdj?file=/src/Demo.vue