### PR TITLE
fix(image): preview image mouse to drag (#3950)

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,6 +8,10 @@
 - `n-transfer` adds `show-selected` prop, closes [#3711](https://github.com/tusen-ai/naive-ui/issues/3711).
 - `n-data-table` adds `loading` slot, closes [#3865](https://github.com/tusen-ai/naive-ui/issues/3865).
 
+### Fixes
+
+- Fix `n-image` to preview the image, press and drag the left mouse click,closes [#3950](https://github.com/tusen-ai/naive-ui/issues/3950).
+
 ### i18n
 
 - Add arDZ locale.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,10 @@
 - `n-transfer` 新增 `show-selected` 属性，关闭 [#3711](https://github.com/tusen-ai/naive-ui/issues/3711)
 - `n-data-table` 新增 `loading` 插槽，关闭 [#3865](https://github.com/tusen-ai/naive-ui/issues/3865)
 
+### Fixes
+
+- 修复 `n-image` 进行图片预览只可以按住鼠标左键拖拽，关闭 [#3950](https://github.com/tusen-ai/naive-ui/issues/3950)
+
 ### i18n
 
 - 新增 arDZ locale

--- a/src/image/src/ImagePreview.tsx
+++ b/src/image/src/ImagePreview.tsx
@@ -12,7 +12,8 @@ import {
   PropType,
   toRef,
   onBeforeUnmount,
-  VNode
+  VNode,
+  withModifiers
 } from 'vue'
 import { zindexable } from 'vdirs'
 import { useIsMounted } from 'vooks'
@@ -598,7 +599,10 @@ export default defineComponent({
                           >
                             <img
                               draggable={false}
-                              onMousedown={this.handlePreviewMousedown}
+                              onMousedown={withModifiers(
+                                this.handlePreviewMousedown,
+                                ['left']
+                              )}
                               onDblclick={this.handlePreviewDblclick}
                               class={`${clsPrefix}-image-preview`}
                               key={this.previewSrc}


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
修复 `n-image` 进行图片预览只可以按住鼠标左键拖拽，关闭 [#3950](https://github.com/tusen-ai/naive-ui/issues/3950)