### PR TITLE
fix: 轮播图组件，在轮播两张图片时，第二张与回到第一张交互不流畅，存在向左拉动效果 #3937

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -26,6 +26,7 @@
 - Fix `n-tree`'s dragging causes partial white screen in Chrome and Edge with version 106, closes [#3909](https://github.com/tusen-ai/naive-ui/issues/3909).
 - Fix `n-select` shows wrong value in select box after `value-field` is set and `max-tag-count="responsive"` and remove selected option in overflow tag's popover, closes [#3869](https://github.com/tusen-ai/naive-ui/issues/3869).
 - Fix `n-ellipsis` won't overflow in `n-card`'s title, closes [#3935](https://github.com/tusen-ai/naive-ui/issues/3935).
+- Fix `n-carousel`，When rotating two pictures，The interaction between the second and the first one is not fluent,closes [#3937](https://github.com/tusen-ai/naive-ui/issues/3937)
 
 ### i18n
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -27,6 +27,8 @@
 - 修复 `n-select` 在设定了 `value-field` 和 `max-tag-count="responsive"` 之后在溢出标签的弹框中移除选中选项之后选框会显示错误的值，关闭 [#3869](https://github.com/tusen-ai/naive-ui/issues/3869)
 - 修复 `n-ellipsis` 在 `n-card` 标题中使用不会溢出，关闭 [#3935](https://github.com/tusen-ai/naive-ui/issues/3935)
 
+- 修复 `n-carousel`，在轮播两张图片时，第二张与回到第一张交互不流畅，存在向左拉动效果,关闭 [#3937](https://github.com/tusen-ai/naive-ui/issues/3937)
+
 ### i18n
 
 - 新增 arDZ locale

--- a/src/carousel/src/Carousel.tsx
+++ b/src/carousel/src/Carousel.tsx
@@ -762,6 +762,9 @@ export default defineComponent({
               realIndex = length - 1
             }
           }
+          if (displayTotalViewRef.value === 2 && lastRealIndex === 2) {
+            realIndex = 3
+          }
           translateTo(realIndex, speedRef.value)
         } else {
           fixTranslate()


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
