### PR TITLE
feat(input): adds `inside-label` prop

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-input` adds `insideLabel` prop.
+
 ## 2.34.2
 
 ### Fixes

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -4,7 +4,7 @@
 
 ### Feats
 
-- `n-input` adds `insideLabel` prop.
+- `n-input` adds `inside-label` prop.
 
 ## 2.34.2
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,7 +4,7 @@
 
 ### Feats
 
-- `n-input` 新增`insideLabel`属性
+- `n-input` 新增`inside-label`属性
 
 ## 2.34.2
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-input` 新增`insideLabel`属性
+
 ## 2.34.2
 
 ### Fixes

--- a/src/input/demos/enUS/index.demo-entry.md
+++ b/src/input/demos/enUS/index.demo-entry.md
@@ -24,6 +24,7 @@ input-props.vue
 status.vue
 pattern.vue
 graphemes.vue
+inside-label.vue
 ```
 
 ## API
@@ -40,6 +41,7 @@ graphemes.vue
 | default-value | `string \| [string, string] \| null` | `null` | Default value when not manually set. |  |
 | disabled | `boolean` | `false` | Whether to disable the input. |  |
 | input-props | `HTMLInputAttributes` | `undefined` | The dom props of the input element inside the component. This is disabled if the `pair` property is true. For avaiable attributes, [see here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). Warning：It won't override internal props with the same name (except `type`). |  |
+| insideLabel | `string` | `undefined` | Set Inside label. When focusing, the prompt text will transition to the top of the input box | NEXT_VERSION |
 | loading | `boolean` | `undefined` | Set loading state. If set (true/false), the element will always take up enough space for the loading indicator. |  |
 | maxlength | `number` | `undefined` | Maximum input length. |  |
 | minlength | `number` | `undefined` | Minimum input length. |  |

--- a/src/input/demos/enUS/index.demo-entry.md
+++ b/src/input/demos/enUS/index.demo-entry.md
@@ -41,7 +41,7 @@ inside-label.vue
 | default-value | `string \| [string, string] \| null` | `null` | Default value when not manually set. |  |
 | disabled | `boolean` | `false` | Whether to disable the input. |  |
 | input-props | `HTMLInputAttributes` | `undefined` | The dom props of the input element inside the component. This is disabled if the `pair` property is true. For avaiable attributes, [see here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). Warning：It won't override internal props with the same name (except `type`). |  |
-| insideLabel | `string` | `undefined` | Set Inside label. When focusing, the prompt text will transition to the top of the input box | NEXT_VERSION |
+| inside-label | `string` | `undefined` | Set Inside label. When focusing, the prompt text will transition to the top of the input box | NEXT_VERSION |
 | loading | `boolean` | `undefined` | Set loading state. If set (true/false), the element will always take up enough space for the loading indicator. |  |
 | maxlength | `number` | `undefined` | Maximum input length. |  |
 | minlength | `number` | `undefined` | Minimum input length. |  |

--- a/src/input/demos/enUS/inside-label.demo.vue
+++ b/src/input/demos/enUS/inside-label.demo.vue
@@ -1,0 +1,15 @@
+<markdown>
+# Inside label
+
+Maybe it can make your input box feel better
+</markdown>
+
+<template>
+  <n-space vertical>
+    <n-input
+      placeholder="Please enter the account"
+      inside-label="Account"
+      clearable
+    />
+  </n-space>
+</template>

--- a/src/input/demos/zhCN/index.demo-entry.md
+++ b/src/input/demos/zhCN/index.demo-entry.md
@@ -45,7 +45,7 @@ textarea-resize-debug.vue
 | count-graphemes | `(value: string) => number` | `undefined` | 计算输入的字数。如果设定了，那么原生的 `maxlength` 和 `minlength` 属性将不再被使用 | 2.34.0 |
 | disabled | `boolean` | `false` | 是否禁用 |  |
 | input-props | `HTMLInputAttributes` | `undefined` | Input 组件内部 input 元素的属性，对 `pair` 类型不生效，[在这里查看原生属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)。注意：input-props 不会覆盖内部 input 元素的已经存在的属性（除了 `type`） |  |
-| insideLabel | `string` | `undefined` | 设置内置提示，聚焦时提示文本会过度到输入框上方 | NEXT_VERSION |
+| inside-label | `string` | `undefined` | 设置内置提示，聚焦时提示文本会过度到输入框上方 | NEXT_VERSION |
 | loading | `boolean` | `undefined` | 是否展示加载图标，设为非 `undefined` 会占据空间 |  |
 | maxlength | `number` | `undefined` | 最大输入长度 |  |
 | minlength | `number` | `undefined` | 最小输入长度 |  |

--- a/src/input/demos/zhCN/index.demo-entry.md
+++ b/src/input/demos/zhCN/index.demo-entry.md
@@ -24,6 +24,7 @@ input-props.vue
 status.vue
 pattern.vue
 graphemes.vue
+inside-label.vue
 rtl-debug.vue
 prefix-debug.vue
 modal-debug.vue
@@ -44,6 +45,7 @@ textarea-resize-debug.vue
 | count-graphemes | `(value: string) => number` | `undefined` | 计算输入的字数。如果设定了，那么原生的 `maxlength` 和 `minlength` 属性将不再被使用 | 2.34.0 |
 | disabled | `boolean` | `false` | 是否禁用 |  |
 | input-props | `HTMLInputAttributes` | `undefined` | Input 组件内部 input 元素的属性，对 `pair` 类型不生效，[在这里查看原生属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)。注意：input-props 不会覆盖内部 input 元素的已经存在的属性（除了 `type`） |  |
+| insideLabel | `string` | `undefined` | 设置内置提示，聚焦时提示文本会过度到输入框上方 | NEXT_VERSION |
 | loading | `boolean` | `undefined` | 是否展示加载图标，设为非 `undefined` 会占据空间 |  |
 | maxlength | `number` | `undefined` | 最大输入长度 |  |
 | minlength | `number` | `undefined` | 最小输入长度 |  |

--- a/src/input/demos/zhCN/inside-label.demo.vue
+++ b/src/input/demos/zhCN/inside-label.demo.vue
@@ -1,0 +1,11 @@
+<markdown>
+# 内部的提示语
+
+好像一些高端大气上档次的网站登录页都是这样的
+</markdown>
+
+<template>
+  <n-space vertical>
+    <n-input placeholder="请输入账户" inside-label="账户" clearable />
+  </n-space>
+</template>

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -123,6 +123,10 @@ export const inputProps = {
     type: Boolean,
     default: undefined
   },
+  insideLabel: {
+    type: String,
+    default: undefined
+  },
   allowInput: Function as PropType<(value: string) => boolean>,
   renderCount: Function as PropType<(props: { value: string }) => VNodeChild>,
   onMousedown: Function as PropType<(e: MouseEvent) => void>,
@@ -1033,7 +1037,10 @@ export default defineComponent({
               this.round && !(type === 'textarea'),
             [`${mergedClsPrefix}-input--pair`]: this.pair,
             [`${mergedClsPrefix}-input--focus`]: this.mergedFocus,
-            [`${mergedClsPrefix}-input--stateful`]: this.stateful
+            [`${mergedClsPrefix}-input--stateful`]: this.stateful,
+            [`${mergedClsPrefix}-input--inside-label`]: this.insideLabel,
+            [`${mergedClsPrefix}-input--show-label`]:
+              this.insideLabel && this.mergedValue
           }
         ]}
         style={this.cssVars as CSSProperties}
@@ -1055,13 +1062,16 @@ export default defineComponent({
       >
         {/* textarea & basic input */}
         <div class={`${mergedClsPrefix}-input-wrapper`}>
-          {resolveWrappedSlot(
-            $slots.prefix,
-            (children) =>
-              children && (
-                <div class={`${mergedClsPrefix}-input__prefix`}>{children}</div>
-              )
-          )}
+          {!this.insideLabel &&
+            resolveWrappedSlot(
+              $slots.prefix,
+              (children) =>
+                children && (
+                  <div class={`${mergedClsPrefix}-input__prefix`}>
+                    {children}
+                  </div>
+                )
+            )}
           {type === 'textarea' ? (
             <NScrollbar
               ref="textareaScrollbarInstRef"
@@ -1113,7 +1123,7 @@ export default defineComponent({
                         onChange={this.handleChange}
                         onScroll={this.handleTextAreaScroll}
                       />
-                      {this.showPlaceholder1 ? (
+                      {this.showPlaceholder1 && !this.insideLabel ? (
                         <div
                           class={`${mergedClsPrefix}-input__placeholder`}
                           style={[
@@ -1185,7 +1195,7 @@ export default defineComponent({
                 onInput={(e) => this.handleInput(e, 0)}
                 onChange={(e) => this.handleChange(e, 0)}
               />
-              {this.showPlaceholder1 ? (
+              {this.showPlaceholder1 && !this.insideLabel ? (
                 <div class={`${mergedClsPrefix}-input__placeholder`}>
                   <span>{this.mergedPlaceholder[0]}</span>
                 </div>
@@ -1274,6 +1284,11 @@ export default defineComponent({
                   ) : null
             })}
         </div>
+        {this.insideLabel && (
+          <div class={`${mergedClsPrefix}-input__label`}>
+            {this.insideLabel}
+          </div>
+        )}
         {/* pair input */}
         {this.pair ? (
           <span class={`${mergedClsPrefix}-input__separator`}>
@@ -1290,7 +1305,7 @@ export default defineComponent({
                 tabindex={
                   this.passivelyActivated && !this.activated ? -1 : undefined
                 }
-                placeholder={this.mergedPlaceholder[1]}
+                placeholder={this.insideLabel ? '' : this.mergedPlaceholder[1]}
                 disabled={this.mergedDisabled}
                 maxlength={countGraphemes ? undefined : this.maxlength}
                 minlength={countGraphemes ? undefined : this.minlength}
@@ -1306,7 +1321,7 @@ export default defineComponent({
                 onInput={(e) => this.handleInput(e, 1)}
                 onChange={(e) => this.handleChange(e, 1)}
               />
-              {this.showPlaceholder2 ? (
+              {this.showPlaceholder2 && !this.insideLabel ? (
                 <div class={`${mergedClsPrefix}-input__placeholder`}>
                   <span>{this.mergedPlaceholder[1]}</span>
                 </div>

--- a/src/input/src/styles/input.cssr.ts
+++ b/src/input/src/styles/input.cssr.ts
@@ -269,7 +269,14 @@ export default cB('input', `
       cE('state-border', `
         border: var(--n-border-focus);
         box-shadow: var(--n-box-shadow-focus);
-      `)
+      `),
+      cE('label', `
+        color: var(--n-icon-color);
+        top: 4px;
+        left: var(--n-padding-left);
+        font-size: calc(var(--n-font-size) / 1.2);
+      `),
+      cE('suffix', 'align-items:flex-start')
     ])
   ]),
   cE('border, state-border', `
@@ -374,7 +381,34 @@ export default cB('input', `
         `)
       ])
     ])
-  ]))
+  ])),
+  cM('inside-label', `
+    position:relative;
+    height:50px;
+  `, [
+    cB('input-wrapper', `
+      padding-top: var(--n-padding-top);
+    `),
+    cE('label', `
+      position: absolute;
+      color: var(--n-icon-color);
+      left: calc(var(--n-padding-left) * 1.5);
+      top: calc(var(--n-padding-top) - 6px);
+      font-size: var(--n-icon-size);
+      transition: all .3s var(--n-bezier);
+    `)
+  ]),
+  cM('show-label', '',
+    [
+      cE('label', `
+        color: var(--n-icon-color);
+        top: 4px;
+        left: var(--n-padding-left);
+        font-size: calc(var(--n-font-size) / 1.2);
+      `),
+      cE('suffix', 'align-items:flex-start')
+    ]
+  )
 ])
 
 export const safariStyle = cB('input', [

--- a/src/input/tests/Input.spec.tsx
+++ b/src/input/tests/Input.spec.tsx
@@ -322,4 +322,18 @@ describe('n-input', () => {
 
     wrapper.unmount()
   })
+
+  it('should work with `insideLabel` prop', async () => {
+    const wrapper = mount(NInput, {
+      props: {
+        insideLabel: '账户',
+        clearable: true
+      }
+    })
+    wrapper.find('input').element.focus()
+    expect(wrapper.find('.n-input--inside-label').exists()).toBe(true)
+    expect(wrapper.find('.n-base-clear').exists()).toBe(true)
+    expect(wrapper.find('.n-input__label').exists()).toBe(true)
+    wrapper.unmount()
+  })
 })

--- a/src/locales/__snapshots__/index.spec.tsx.snap
+++ b/src/locales/__snapshots__/index.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`locale works 1`] = `
       </div>
       <!---->
       <!---->
+      <!---->
       <div class="n-input__border"></div>
       <div class="n-input__state-border"></div>
       <!---->
@@ -41,6 +42,7 @@ exports[`locale works 1`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -73,6 +75,7 @@ exports[`locale works 1`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -101,6 +104,7 @@ exports[`locale works 1`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -133,6 +137,7 @@ exports[`locale works 1`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -156,6 +161,7 @@ exports[`locale works 2`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -185,6 +191,7 @@ exports[`locale works 2`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -217,6 +224,7 @@ exports[`locale works 2`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -245,6 +253,7 @@ exports[`locale works 2`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -277,6 +286,7 @@ exports[`locale works 2`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -300,6 +310,7 @@ exports[`locale works 3`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -329,6 +340,7 @@ exports[`locale works 3`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -361,6 +373,7 @@ exports[`locale works 3`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -389,6 +402,7 @@ exports[`locale works 3`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -421,6 +435,7 @@ exports[`locale works 3`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -444,6 +459,7 @@ exports[`locale works 4`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -473,6 +489,7 @@ exports[`locale works 4`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -505,6 +522,7 @@ exports[`locale works 4`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -533,6 +551,7 @@ exports[`locale works 4`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -565,6 +584,7 @@ exports[`locale works 4`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -588,6 +608,7 @@ exports[`locale works 5`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -617,6 +638,7 @@ exports[`locale works 5`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -649,6 +671,7 @@ exports[`locale works 5`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -677,6 +700,7 @@ exports[`locale works 5`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -709,6 +733,7 @@ exports[`locale works 5`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -732,6 +757,7 @@ exports[`locale works 6`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -761,6 +787,7 @@ exports[`locale works 6`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -793,6 +820,7 @@ exports[`locale works 6`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -821,6 +849,7 @@ exports[`locale works 6`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -853,6 +882,7 @@ exports[`locale works 6`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -876,6 +906,7 @@ exports[`locale works 7`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -905,6 +936,7 @@ exports[`locale works 7`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -937,6 +969,7 @@ exports[`locale works 7`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -965,6 +998,7 @@ exports[`locale works 7`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -997,6 +1031,7 @@ exports[`locale works 7`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1020,6 +1055,7 @@ exports[`locale works 8`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1049,6 +1085,7 @@ exports[`locale works 8`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1081,6 +1118,7 @@ exports[`locale works 8`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1109,6 +1147,7 @@ exports[`locale works 8`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1141,6 +1180,7 @@ exports[`locale works 8`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1164,6 +1204,7 @@ exports[`locale works 9`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1193,6 +1234,7 @@ exports[`locale works 9`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1225,6 +1267,7 @@ exports[`locale works 9`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1253,6 +1296,7 @@ exports[`locale works 9`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1285,6 +1329,7 @@ exports[`locale works 9`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1308,6 +1353,7 @@ exports[`locale works 10`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1337,6 +1383,7 @@ exports[`locale works 10`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1369,6 +1416,7 @@ exports[`locale works 10`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1397,6 +1445,7 @@ exports[`locale works 10`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1429,6 +1478,7 @@ exports[`locale works 10`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1452,6 +1502,7 @@ exports[`locale works 11`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1481,6 +1532,7 @@ exports[`locale works 11`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1513,6 +1565,7 @@ exports[`locale works 11`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1541,6 +1594,7 @@ exports[`locale works 11`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1573,6 +1627,7 @@ exports[`locale works 11`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1596,6 +1651,7 @@ exports[`locale works 12`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1625,6 +1681,7 @@ exports[`locale works 12`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1657,6 +1714,7 @@ exports[`locale works 12`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1685,6 +1743,7 @@ exports[`locale works 12`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1717,6 +1776,7 @@ exports[`locale works 12`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1740,6 +1800,7 @@ exports[`locale works 13`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1769,6 +1830,7 @@ exports[`locale works 13`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1801,6 +1863,7 @@ exports[`locale works 13`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1829,6 +1892,7 @@ exports[`locale works 13`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1861,6 +1925,7 @@ exports[`locale works 13`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1884,6 +1949,7 @@ exports[`locale works 14`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -1913,6 +1979,7 @@ exports[`locale works 14`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -1945,6 +2012,7 @@ exports[`locale works 14`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -1973,6 +2041,7 @@ exports[`locale works 14`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2005,6 +2074,7 @@ exports[`locale works 14`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2028,6 +2098,7 @@ exports[`locale works 15`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2057,6 +2128,7 @@ exports[`locale works 15`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2089,6 +2161,7 @@ exports[`locale works 15`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2117,6 +2190,7 @@ exports[`locale works 15`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2149,6 +2223,7 @@ exports[`locale works 15`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2172,6 +2247,7 @@ exports[`locale works 16`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2201,6 +2277,7 @@ exports[`locale works 16`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2233,6 +2310,7 @@ exports[`locale works 16`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2261,6 +2339,7 @@ exports[`locale works 16`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2293,6 +2372,7 @@ exports[`locale works 16`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2316,6 +2396,7 @@ exports[`locale works 17`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2345,6 +2426,7 @@ exports[`locale works 17`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2377,6 +2459,7 @@ exports[`locale works 17`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2405,6 +2488,7 @@ exports[`locale works 17`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2437,6 +2521,7 @@ exports[`locale works 17`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2460,6 +2545,7 @@ exports[`locale works 18`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2489,6 +2575,7 @@ exports[`locale works 18`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2521,6 +2608,7 @@ exports[`locale works 18`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2549,6 +2637,7 @@ exports[`locale works 18`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2581,6 +2670,7 @@ exports[`locale works 18`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2604,6 +2694,7 @@ exports[`locale works 19`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2633,6 +2724,7 @@ exports[`locale works 19`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2665,6 +2757,7 @@ exports[`locale works 19`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2693,6 +2786,7 @@ exports[`locale works 19`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2725,6 +2819,7 @@ exports[`locale works 19`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2748,6 +2843,7 @@ exports[`locale works 20`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2777,6 +2873,7 @@ exports[`locale works 20`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2809,6 +2906,7 @@ exports[`locale works 20`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2837,6 +2935,7 @@ exports[`locale works 20`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2869,6 +2968,7 @@ exports[`locale works 20`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2892,6 +2992,7 @@ exports[`locale works 21`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -2921,6 +3022,7 @@ exports[`locale works 21`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -2953,6 +3055,7 @@ exports[`locale works 21`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -2981,6 +3084,7 @@ exports[`locale works 21`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -3013,6 +3117,7 @@ exports[`locale works 21`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -3036,6 +3141,7 @@ exports[`locale works 22`] = `
         </div>
         <!---->
       </div>
+      <!---->
       <!---->
       <!---->
       <div class="n-input__border"></div>
@@ -3065,6 +3171,7 @@ exports[`locale works 22`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>
@@ -3097,6 +3204,7 @@ exports[`locale works 22`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -3127,6 +3235,7 @@ exports[`locale works 22`] = `
           </div>
           <!---->
           <!---->
+          <!---->
           <div class="n-input__border"></div>
           <div class="n-input__state-border"></div>
           <!---->
@@ -3155,6 +3264,7 @@ exports[`locale works 22`] = `
               <!---->
             </div>
           </div>
+          <!---->
           <!---->
           <!---->
           <div class="n-input__border"></div>


### PR DESCRIPTION
### 改动原因

看到苹果或者小米这类的官网，登录的输入框效果和其他的不太一样，所以尝试新增一个属性来实现

### 改动说明：

- 新增属性`inside-label`，类型为`string`
- 输入框聚焦时，`label`文本会上移到左上方
- 可以支持清除
- 不支持前缀插槽

如果能过，后续可能会补充到`form`中去。

修改后效果如下
![image](https://user-images.githubusercontent.com/49502875/203759461-e6d8562e-5ad4-4b60-a4ef-8e8af72a4879.png)
![7178e9b8d62d46d7c4bea534baa93c5f_0_1669285324 (1)](https://user-images.githubusercontent.com/49502875/203760542-bb9cc56c-0757-4364-abbf-1e1d3728e940.gif)

