### PR TITLE
fix(input-group-label): use form-item size

### DIFF
--- a/src/input/src/InputGroupLabel.tsx
+++ b/src/input/src/InputGroupLabel.tsx
@@ -1,5 +1,5 @@
 import { computed, defineComponent, h, PropType } from 'vue'
-import { useConfig, useTheme, useThemeClass } from '../../_mixins'
+import { useConfig, useFormItem, useTheme, useThemeClass } from '../../_mixins'
 import type { ThemeProps } from '../../_mixins'
 import { createKey } from '../../_utils'
 import type { ExtractPublicPropTypes } from '../../_utils'
@@ -10,10 +10,7 @@ import type { Size } from './interface'
 
 export const inputGroupLabelProps = {
   ...(useTheme.props as ThemeProps<InputTheme>),
-  size: {
-    type: String as PropType<Size>,
-    default: 'medium'
-  },
+  size: String as PropType<Size>,
   bordered: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined
@@ -38,8 +35,10 @@ export default defineComponent({
       props,
       mergedClsPrefixRef
     )
+    const formItem = useFormItem(props)
+    const { mergedSizeRef } = formItem
     const cssVarsRef = computed(() => {
-      const { size } = props
+      const { value: size } = mergedSizeRef
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -66,7 +65,10 @@ export default defineComponent({
     const themeClassHandle = inlineThemeDisabled
       ? useThemeClass(
         'input-group-label',
-        computed(() => props.size[0]),
+        computed(() => {
+          const { value: size } = mergedSizeRef
+          return size[0]
+        }),
         cssVarsRef,
         props
       )


### PR DESCRIPTION
当 input-group-label 组件没设置 size 属性时，使用 form-item 组件的 size 属性
![GIF 2022-12-26 星期一 17-25-36](https://user-images.githubusercontent.com/63504321/209531655-2e731355-2c05-4434-a78e-741a5beea67d.gif)
