### PR TITLE
fix(image): fallback-src is not displayed correctly (#4249)

### DIFF
--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -161,12 +161,14 @@ export default defineComponent({
       width: this.width || imgProps.width,
       height: this.height || imgProps.height,
       src: isImageSupportNativeLazy
-        ? loadSrc
-        : this.showError
+        ? this.showError
           ? this.fallbackSrc
           : this.shouldStartLoading
             ? loadSrc
-            : undefined,
+            : undefined
+        : this.showError
+          ? this.fallbackSrc
+          : loadSrc,
       alt: this.alt || imgProps.alt,
       'aria-label': this.alt || imgProps.alt,
       onClick: this.mergedOnClick,


### PR DESCRIPTION
修复 `n-image` 组件 `fallback-src` 不正确显示的 bug