### PR TITLE
fix(image): fallback-src is not displayed correctly (#4249)

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- 修复 `n-image` 的 `fallback-src` 显示不正确
 - Fix `n-dynamic-input` can't access `value[index]` by `index` passed in `on-remove` prop.
 - Fix `n-dynamic-input` doesn't return correct `index` in `on-create` callback.
 - Fix `trTR` i18n, closes [#4231](https://github.com/tusen-ai/naive-ui/issues/4231).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- 修复 `n-image` 的 `fallback-src` 显示不正确
 - 修复 `n-dynamic-input` 的 `on-remove` 方法返回被删除的数据下标 `index` 时 `value[index]` 已经不存在
 - 修复 `n-dynamic-input` 在点击添加按钮后 `on-create` 返回的 `index` 不正确
 - 修复 `trTR` 国际化，关闭 [#4231](https://github.com/tusen-ai/naive-ui/issues/4231)

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -161,12 +161,14 @@ export default defineComponent({
       width: this.width || imgProps.width,
       height: this.height || imgProps.height,
       src: isImageSupportNativeLazy
-        ? loadSrc
-        : this.showError
+        ? this.showError
           ? this.fallbackSrc
           : this.shouldStartLoading
             ? loadSrc
-            : undefined,
+            : undefined
+        : this.showError
+          ? this.fallbackSrc
+          : loadSrc || undefined,
       alt: this.alt || imgProps.alt,
       'aria-label': this.alt || imgProps.alt,
       onClick: this.mergedOnClick,


### PR DESCRIPTION
close #4249 修复 `n-image` 的 `fallback-src` 显示不正确 