### PR TITLE
fix(notification): multiple elements box-shadow repeat

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -7,6 +7,7 @@
 - Fix `n-dynamic-input` can't access `value[index]` by `index` passed in `on-remove` prop.
 - Fix `n-dynamic-input` doesn't return correct `index` in `on-create` callback.
 - Fix `trTR` i18n, closes [#4231](https://github.com/tusen-ai/naive-ui/issues/4231).
+- Fix `n-notification` notify more times when document's visibilityState is `hidden` that `box-shadow` will multiple repeat, closes [#4126](https://github.com/tusen-ai/naive-ui/issues/4126).
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - 修复 `n-dynamic-input` 的 `on-remove` 方法返回被删除的数据下标 `index` 时 `value[index]` 已经不存在
 - 修复 `n-dynamic-input` 在点击添加按钮后 `on-create` 返回的 `index` 不正确
 - 修复 `trTR` 国际化，关闭 [#4231](https://github.com/tusen-ai/naive-ui/issues/4231)
+- 修复 `n-notification` 在浏览器页签 `hidden` 时多次弹出造成的 `box-shadow` 重叠的问题，关闭 [#4126](https://github.com/tusen-ai/naive-ui/issues/4126)
 
 ### Feats
 

--- a/src/notification/src/NotificationEnvironment.tsx
+++ b/src/notification/src/NotificationEnvironment.tsx
@@ -132,9 +132,23 @@ export const NotificationEnvironment = defineComponent({
         hide()
       }
     }
+    function isDocVisible (): boolean {
+      return document.visibilityState === 'visible'
+    }
     onMounted(() => {
       if (props.duration) {
-        timerId = window.setTimeout(hide, props.duration)
+        timerId = window.setTimeout(() => {
+          if (!isDocVisible()) {
+            timerId && window.clearTimeout(timerId)
+            document.addEventListener('visibilitychange', () => {
+              if (isDocVisible()) {
+                timerId = window.setTimeout(hide, props.duration)
+              }
+            })
+            return
+          }
+          hide()
+        }, props.duration)
       }
     })
     return {

--- a/src/notification/tests/Notification.spec.tsx
+++ b/src/notification/tests/Notification.spec.tsx
@@ -98,6 +98,37 @@ describe('n-notification', () => {
     expect(document.querySelector('.n-notification')).toBe(null)
     wrapper.unmount()
   })
+
+  it('should not be hid when visibilityState is "hidden"', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden'
+      }
+    })
+    const Comp = defineComponent({
+      setup () {
+        const notification = useNotification()
+        notification.info({
+          title: 'info',
+          content: 'info',
+          duration: 1000
+        })
+      },
+      render () {
+        return null
+      }
+    })
+    const wrapper = mount(() => (
+      <Provider>{{ default: () => <Comp /> }}</Provider>
+    ))
+    await nextTick()
+    await sleep(500)
+    expect(document.querySelector('.n-notification')).not.toEqual(null)
+    await sleep(1200)
+    expect(document.querySelector('.n-notification')).not.toEqual(null)
+    wrapper.unmount()
+  })
 })
 
 describe('notification-provider', () => {


### PR DESCRIPTION
close [4126](https://github.com/tusen-ai/naive-ui/issues/4126).

针对这个问题，感觉在 `document hidden` 的时候也不应该允许持续执行 `notification` 插入，如果可以的话我另外提一个 `feature` 来优化一下。页面隐藏的时候把的需要执行的`notification` 都暂时存到队列里，等页面激活的时候再执行。