### PR TITLE
fix(carousel): Full height flex items should use align-items: stretch

### DIFF
--- a/src/carousel/src/styles/index.cssr.ts
+++ b/src/carousel/src/styles/index.cssr.ts
@@ -22,12 +22,15 @@ export default cB('carousel', `
     height: 100%;
     transition-timing-function: var(--n-bezier);
     transition-property: transform;
+    align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    -webkit-align-items: stretch;
   `, [
     cE('slide', `
       flex-shrink: 0;
       position: relative;
       width: 100%;
-      height: 100%;
       outline: none;
       overflow: hidden;
     `, [


### PR DESCRIPTION
close #4304 
If we want the carousel slides to be all the same height, we need to use align-items: stretch on the flex element or align-self: stretch on the children elements.
Currently we are using height: 100% on the children elements and it's not working if children elements are simple div.