### PR TITLE
docs: fix nuxt config file

### DIFF
--- a/demo/pages/docs/ssr/enUS/index.md
+++ b/demo/pages/docs/ssr/enUS/index.md
@@ -16,8 +16,6 @@ If you are using Nuxt, please see [example](https://github.com/07akioni/naive-ui
 2. Add the following config in your `nuxt.config.ts`.
 
 ```ts
-import { defineNuxtConfig } from 'nuxt'
-
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   build: {

--- a/demo/pages/docs/ssr/zhCN/index.md
+++ b/demo/pages/docs/ssr/zhCN/index.md
@@ -16,8 +16,6 @@
 2. 在 `nuxt.config.ts` 增添下列配置
 
 ```ts
-import { defineNuxtConfig } from 'nuxt'
-
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   build: {


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

`nuxt` 包并没有导出 `defineNuxtConfig` 类型。

按照现有文档示例，我们会得到以下报错。

![nuxt](https://user-images.githubusercontent.com/36569518/211155524-de3e8cad-c01d-4960-9c09-b97739459698.png)

在 `nuxt` 中，其实启动前会自动引入必要 `api` 并生成类型，`defineNuxtConfig` 也是一样。

所以即使没有引入 `defineNuxtConfig`，也能正常运行并得到正确类型提示。

当然也可以从 `nuxt/config` 中引入 `defineNuxtConfig`，但是当前并不能从中得到很好的类型提示。

基于以上问题以及考虑，移除 `defineNuxtConfig` 是更好的选择。
