### PR TITLE
Specify createDiscreteApi return type

### DIFF
--- a/src/discrete/src/discrete.ts
+++ b/src/discrete/src/discrete.ts
@@ -15,7 +15,7 @@ export function createDiscreteApi<T extends DiscreteApiType> (
     notificationProviderProps,
     loadingBarProviderProps
   }: DiscreteApiOptions = {}
-): DiscreteApi {
+): DiscreteApi<T> {
   const providersAndProps: Array<{
     type: DiscreteApiType
     Provider: Component


### PR DESCRIPTION
Narrow down `createDiscreteApi` return type based on provided types.

Currently `createDiscreteApi(['dialog'])` return type includes the following properties `app | dialog | loadingBar | message | notification | unmount`. The return type with proposed change would have just `app | dialog | unmount`

P.S. Sorry for not adding changelog, editing via github :s