### PR TITLE
docs(drawer): Fix wrong prop name

### DIFF
--- a/src/drawer/demos/enUS/index.demo-entry.md
+++ b/src/drawer/demos/enUS/index.demo-entry.md
@@ -39,7 +39,8 @@ resizable.vue
 | scrollbar-props | `object` | `undefined` | 属性参考 [Scrollbar props](scrollbar#Scrollbar-Props) |  |
 | show | `boolean` | `false` | Whether to show drawer. |  |
 | show-mask | `boolean` | `true` | Whether to show mask. If set to `'transparent'`, transparent mask would be shown. If set to false, `trap-focus` will be disabled. | 2.28.3 |
-| style | `string \| Object` | `undefined` | Style of the drawer. |  |
+| drawer-style | `string \| Object` | `undefined` | Style of the drawer. |  |
+| drawer-class | `string` | `undefined` | Class of the drawer. |  |
 | to | `string \| HTMLElement` | `'body'` | Container node of the drawer. |  |
 | trap-focus | `boolean` | `true` | Whether to trap focus inside drawer. | 2.24.2 |
 | width | `number \| string` | `undefined` | Works when placement is `left` and `right`. |  |

--- a/src/drawer/demos/zhCN/index.demo-entry.md
+++ b/src/drawer/demos/zhCN/index.demo-entry.md
@@ -38,7 +38,7 @@ rtl-debug.vue
 | default-width | `number \| string` | `251` | 抽屉的默认宽度，在位置是 `left` 和 `right` 时生效 | 2.31.0 |
 | default-height | `number \| string` | `251` | 抽屉的默认高度，在位置是 `top` 和 `bottom` 时生效 | 2.31.0 |
 | display-directive | `'if' \| 'show'` | `'if'` | `n-drawer` 在控制内容是否渲染时使用的指令，`'if'` 对应 `v-if`，`'show'` 对应 `v-show` |  |
-| height | `number \| string` | `undefined` | 抽屉的高度，在位置是 `top` 和 `bottom` 时生效 |  |
+| height | `number \| string` | `undefined` | 抽屉的高度，在位置1是 `top` 和 `bottom` 时生效 |  |
 | mask-closable | `boolean` | `true` | 点击遮罩时是否发出 `update:show` 事件 |  |
 | native-scrollbar | `boolean` | `true` | 是否使用原生滚动 |  |
 | placement | `'top' \| 'right' \| 'bottom' \| 'left'` | `'right'` | 抽屉展示的位置 |  |
@@ -46,7 +46,8 @@ rtl-debug.vue
 | scrollbar-props | `object` | `undefined` | 属性参考 [Scrollbar props](scrollbar#Scrollbar-Props) |  |
 | show | `boolean` | `false` | 是否展示抽屉 |  |
 | show-mask | `boolean \| 'transparent'` | `true` | 是否显示遮罩，如果设为 `'transparent'` 会展示透明遮罩，如果设为 `false` 会禁用 `trap-focus` | 2.28.3 |
-| style | `string \| Object` | `undefined` | 抽屉的样式 |  |
+| drawer-style | `string \| Object` | `undefined` | 抽屉的样式 |  |
+| drawer-class | `string` | `undefined` | 抽屉的class |  |
 | to | `string \| HTMLElement` | `'body'` | 抽屉出现的区域 |  |
 | trap-focus | `boolean` | `true` | 是否将焦点锁定在 Drawer 内部 | 2.24.2 |
 | width | `number \| string` | `undefined` | 抽屉的宽度，在位置是 `left` 和 `right` 时生效 |  |

--- a/src/drawer/demos/zhCN/index.demo-entry.md
+++ b/src/drawer/demos/zhCN/index.demo-entry.md
@@ -38,7 +38,7 @@ rtl-debug.vue
 | default-width | `number \| string` | `251` | 抽屉的默认宽度，在位置是 `left` 和 `right` 时生效 | 2.31.0 |
 | default-height | `number \| string` | `251` | 抽屉的默认高度，在位置是 `top` 和 `bottom` 时生效 | 2.31.0 |
 | display-directive | `'if' \| 'show'` | `'if'` | `n-drawer` 在控制内容是否渲染时使用的指令，`'if'` 对应 `v-if`，`'show'` 对应 `v-show` |  |
-| height | `number \| string` | `undefined` | 抽屉的高度，在位置1是 `top` 和 `bottom` 时生效 |  |
+| height | `number \| string` | `undefined` | 抽屉的高度，在位置是 `top` 和 `bottom` 时生效 |  |
 | mask-closable | `boolean` | `true` | 点击遮罩时是否发出 `update:show` 事件 |  |
 | native-scrollbar | `boolean` | `true` | 是否使用原生滚动 |  |
 | placement | `'top' \| 'right' \| 'bottom' \| 'left'` | `'right'` | 抽屉展示的位置 |  |


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22576780/213379882-8e92b03d-b62a-4eb2-bbd7-039e7d09347c.png)
n-drawer 這個prop是無效的
看了一下原碼應該對應`drawerStyle`跟`drawerClass`
[main/src/drawer/src/Drawer.tsx#L111](https://github.com/tusen-ai/naive-ui/blob/96b573ef8c354a2336720b10f9b6891e98dcb1c7/src/drawer/src/Drawer.tsx#L111)