### PR TITLE
feat(Code): add focus-line feature

### DIFF
--- a/src/code/demos/enUS/focus-line.demo.vue
+++ b/src/code/demos/enUS/focus-line.demo.vue
@@ -1,0 +1,43 @@
+<markdown>
+# Focus line
+
+It can focus one line.If you want to use focus line feature, please add `lineToDiv` plugin to `hljs`.
+</markdown>
+<template>
+  <div style="overflow: auto">
+    <n-space vertical :size="16">
+      <n-code
+        :code="`
+  function sleep (ms = 1000) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }`"
+        language="javascript"
+        :hljs="hljs"
+        :focus-line="2"
+        show-line-numbers
+      />
+    </n-space>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import hljs from 'highlight.js/lib/core'
+import javascript from 'highlight.js/lib/languages/javascript'
+import { lineToDiv } from 'naive-ui'
+
+hljs.addPlugin(lineToDiv())
+
+export default defineComponent({
+  setup () {
+    hljs.registerLanguage('javascript', javascript)
+    return {
+      cppCode: `int main () {
+    std::cout << "Hello Naive UI";
+    return 0;
+  }`,
+      hljs
+    }
+  }
+})
+</script>

--- a/src/code/demos/enUS/highlight-line.demo.vue
+++ b/src/code/demos/enUS/highlight-line.demo.vue
@@ -1,0 +1,35 @@
+<markdown>
+# Highlight line
+
+It can highlight lines.If you want to use focus line feature, please add `lineToDiv` plugin to `hljs`.
+</markdown>
+<template>
+  <div style="overflow: auto">
+    <n-space vertical :size="16">
+      <n-code
+        :code="`
+      function sleep (ms = 1000) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+}`"
+        language="javascript"
+        :highlight-lines="[2]"
+        show-line-numbers
+      />
+    </n-space>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  setup () {
+    return {
+      cppCode: `int main () {
+        std::cout << "Hello Naive UI";
+        return 0;
+      }`
+    }
+  }
+})
+</script>

--- a/src/code/demos/enUS/index.demo-entry.md
+++ b/src/code/demos/enUS/index.demo-entry.md
@@ -19,8 +19,10 @@ The following code shows how to set hljs of Code. Importing highlight.js on dema
   import { defineComponent } from 'vue'
   import hljs from 'highlight.js/lib/core'
   import javascript from 'highlight.js/lib/languages/javascript'
+  import { lineToDiv } from 'naive-ui'
 
   hljs.registerLanguage('javascript', javascript)
+  hljs.addPlugin(lineToDiv())
 
   export default defineComponent({
     setup() {
@@ -40,7 +42,12 @@ inline.vue
 softwrap.vue
 line-numbers.vue
 focus-line.vue
+highlight-line.vue
 ```
+
+<n-alert title="warning" type="warning" style="margin:16px 0;" :bordered="false">
+If you want to use `focus-line` or `highlight-line` feature, please add `lineToDiv` to `hljs`.Since `hljs`'s plugin is global, please don't add plugin repeatly.
+</n-alert>
 
 ## API
 
@@ -56,3 +63,4 @@ focus-line.vue
 | trim | `boolean` | `true` | Whether to display trimmed code. |  |
 | word-wrap | `boolean` | `false` | Whether to display word-wrapped code. | 2.24.0 |
 | focus-line | `number` | `undefined` | focus which line | 2.34.4 |
+| highlight-line | `number[]` | `undefined` | highlight line numbers | 2.34.4 |

--- a/src/code/demos/enUS/index.demo-entry.md
+++ b/src/code/demos/enUS/index.demo-entry.md
@@ -39,6 +39,7 @@ basic.vue
 inline.vue
 softwrap.vue
 line-numbers.vue
+focus-line.vue
 ```
 
 ## API
@@ -54,3 +55,4 @@ line-numbers.vue
 | show-line-numbers | `boolean` | `false` | Whether to show line numbers. Won't work if `inline` or `word-wrap` is `true`. | 2.32.0 |
 | trim | `boolean` | `true` | Whether to display trimmed code. |  |
 | word-wrap | `boolean` | `false` | Whether to display word-wrapped code. | 2.24.0 |
+| focus-line | `number` | `undefined` | focus which line | 2.34.4 |

--- a/src/code/demos/zhCN/focus-line.demo.vue
+++ b/src/code/demos/zhCN/focus-line.demo.vue
@@ -1,0 +1,43 @@
+<markdown>
+# 聚焦行
+
+它可以聚焦于一行。如果你想使用聚焦行特性，请为`hljs`添加`lineToDiv`插件。
+</markdown>
+<template>
+  <div style="overflow: auto">
+    <n-space vertical :size="16">
+      <n-code
+        :code="`
+  function sleep (ms = 1000) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }`"
+        language="javascript"
+        :hljs="hljs"
+        :focus-line="2"
+        show-line-numbers
+      />
+    </n-space>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import hljs from 'highlight.js/lib/core'
+import javascript from 'highlight.js/lib/languages/javascript'
+import { lineToDiv } from 'naive-ui'
+
+hljs.addPlugin(lineToDiv())
+
+export default defineComponent({
+  setup () {
+    hljs.registerLanguage('javascript', javascript)
+    return {
+      cppCode: `int main () {
+    std::cout << "Hello Naive UI";
+    return 0;
+  }`,
+      hljs
+    }
+  }
+})
+</script>

--- a/src/code/demos/zhCN/highlight-line.demo.vue
+++ b/src/code/demos/zhCN/highlight-line.demo.vue
@@ -1,0 +1,35 @@
+<markdown>
+# 代码行高亮
+
+它可以将代码行高亮。
+</markdown>
+<template>
+  <div style="overflow: auto">
+    <n-space vertical :size="16">
+      <n-code
+        :code="`
+function sleep (ms = 1000) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}`"
+        language="javascript"
+        :highlight-lines="[2]"
+        show-line-numbers
+      />
+    </n-space>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  setup () {
+    return {
+      cppCode: `int main () {
+            std::cout << "Hello Naive UI";
+            return 0;
+          }`
+    }
+  }
+})
+</script>

--- a/src/code/demos/zhCN/index.demo-entry.md
+++ b/src/code/demos/zhCN/index.demo-entry.md
@@ -41,7 +41,12 @@ softwrap.vue
 loop-debug.vue
 line-numbers.vue
 focus-line.vue
+highlight-line.vue
 ```
+
+<n-alert title="注意" type="warning" style="margin:16px 0;" :bordered="false">
+如果你打算使用`focus-line`或者`highlight-line`特性的话, 请添加`lineToDiv`插件到`hljs`, 由于`hljs`的插件是全局的, 所以应该尽量避免重复添加插件。
+</n-alert>
 
 ## API
 
@@ -57,3 +62,4 @@ focus-line.vue
 | trim | `boolean` | `true` | 是否显示 trim 后的代码 |  |
 | word-wrap | `boolean` | `false` | 代码过长时是否自动换行 | 2.24.0 |
 | focus-line | `number` | `undefined` | 聚焦于哪一行 | 2.34.4 |
+| highlight-line | `number[]` | `undefined` | 高亮的行号 | 2.34.4 |

--- a/src/code/demos/zhCN/index.demo-entry.md
+++ b/src/code/demos/zhCN/index.demo-entry.md
@@ -40,6 +40,7 @@ inline.vue
 softwrap.vue
 loop-debug.vue
 line-numbers.vue
+focus-line.vue
 ```
 
 ## API
@@ -55,3 +56,4 @@ line-numbers.vue
 | show-line-numbers | `boolean` | `false` | 是否显示行号，在 `inline` 或 `word-wrap` 的情况下不生效 | 2.32.0 |
 | trim | `boolean` | `true` | 是否显示 trim 后的代码 |  |
 | word-wrap | `boolean` | `false` | 代码过长时是否自动换行 | 2.24.0 |
+| focus-line | `number` | `undefined` | 聚焦于哪一行 | 2.34.4 |

--- a/src/code/index.ts
+++ b/src/code/index.ts
@@ -1,2 +1,3 @@
 export { default as NCode, codeProps } from './src/Code'
 export type { CodeProps } from './src/Code'
+export { default as lineToDiv } from './src/utils'

--- a/src/code/src/Code.tsx
+++ b/src/code/src/Code.tsx
@@ -96,7 +96,9 @@ export default defineComponent({
             const { focusLine } = props
             if (focusLine) {
               const children = preEl.children
-              if (children[focusLine - 1]) { children[focusLine - 1]?.classList.add('__has_focus__') }
+              if (children[focusLine - 1]) {
+                children[focusLine - 1]?.classList.add('__has_focus__')
+              }
             }
             codeEl.appendChild(preEl)
           }
@@ -119,9 +121,7 @@ export default defineComponent({
       }
     }
 
-    onMounted(() => {
-      setCode()
-    })
+    onMounted(setCode)
 
     watch(toRef(props, 'language'), setCode)
     watch(toRef(props, 'code'), setCode)

--- a/src/code/src/Code.tsx
+++ b/src/code/src/Code.tsx
@@ -33,6 +33,7 @@ export const codeProps = {
     default: true
   },
   hljs: Object as PropType<Hljs>,
+  focusLine: Number,
   uri: Boolean,
   inline: Boolean,
   wordWrap: Boolean,
@@ -52,6 +53,7 @@ export default defineComponent({
     const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig()
     const codeRef = ref<HTMLElement | null>(null)
     const hljsRef = internalNoHighlight ? { value: undefined } : useHljs(props)
+
     const createCodeHtml = (
       language: string,
       code: string,
@@ -91,6 +93,11 @@ export default defineComponent({
             const preEl = document.createElement('pre')
             preEl.className = '__code__'
             preEl.innerHTML = html
+            const { focusLine } = props
+            if (focusLine) {
+              const children = preEl.children
+              if (children[focusLine - 1]) { children[focusLine - 1]?.classList.add('__has_focus__') }
+            }
             codeEl.appendChild(preEl)
           }
           return
@@ -111,7 +118,11 @@ export default defineComponent({
         codeEl.appendChild(wrap)
       }
     }
-    onMounted(setCode)
+
+    onMounted(() => {
+      setCode()
+    })
+
     watch(toRef(props, 'language'), setCode)
     watch(toRef(props, 'code'), setCode)
     if (!internalNoHighlight) watch(hljsRef, setCode)
@@ -207,7 +218,8 @@ export default defineComponent({
           `${mergedClsPrefix}-code`,
           this.themeClass,
           wordWrap && `${mergedClsPrefix}-code--word-wrap`,
-          mergedShowLineNumbers && `${mergedClsPrefix}-code--show-line-numbers`
+          mergedShowLineNumbers && `${mergedClsPrefix}-code--show-line-numbers`,
+          this.focusLine && `${mergedClsPrefix}-code--has-focus-line`
         ]}
         style={this.cssVars as any}
         ref="codeRef"

--- a/src/code/src/Code.tsx
+++ b/src/code/src/Code.tsx
@@ -34,6 +34,7 @@ export const codeProps = {
   },
   hljs: Object as PropType<Hljs>,
   focusLine: Number,
+  highlightLines: Array as PropType<number[]>,
   uri: Boolean,
   inline: Boolean,
   wordWrap: Boolean,
@@ -93,11 +94,16 @@ export default defineComponent({
             const preEl = document.createElement('pre')
             preEl.className = '__code__'
             preEl.innerHTML = html
-            const { focusLine } = props
+            const { focusLine, highlightLines } = props
+            const children = preEl.children
             if (focusLine) {
-              const children = preEl.children
-              if (children[focusLine - 1]) {
+              children[focusLine - 1] &&
                 children[focusLine - 1]?.classList.add('__has_focus__')
+            }
+            if (highlightLines) {
+              for (const line of highlightLines) {
+                children[line - 1] &&
+                  children[line - 1]?.classList.add('__highlight_line__')
               }
             }
             codeEl.appendChild(preEl)
@@ -142,6 +148,7 @@ export default defineComponent({
           fontSize,
           fontWeightStrong,
           lineNumberTextColor,
+          lineHighLightBgColor,
           // extracted from hljs atom-one-light.scss
           'mono-3': $1,
           'hue-1': $2,
@@ -170,7 +177,8 @@ export default defineComponent({
         '--n-hue-5-2': $7,
         '--n-hue-6': $8,
         '--n-hue-6-2': $9,
-        '--n-line-number-text-color': lineNumberTextColor
+        '--n-line-number-text-color': lineNumberTextColor,
+        '--n-line-highlight-bg-color': lineHighLightBgColor
       }
     })
     const themeClassHandle = inlineThemeDisabled
@@ -219,7 +227,9 @@ export default defineComponent({
           this.themeClass,
           wordWrap && `${mergedClsPrefix}-code--word-wrap`,
           mergedShowLineNumbers && `${mergedClsPrefix}-code--show-line-numbers`,
-          this.focusLine && `${mergedClsPrefix}-code--has-focus-line`
+          this.focusLine && `${mergedClsPrefix}-code--has-focus-line`,
+          this.highlightLines?.length &&
+            `${mergedClsPrefix}-code--has-highlight-line`
         ]}
         style={this.cssVars as any}
         ref="codeRef"

--- a/src/code/src/styles/index.cssr.ts
+++ b/src/code/src/styles/index.cssr.ts
@@ -28,9 +28,14 @@ export default c([
     cM('has-focus-line', [
       cB('code-line', [
         c('&:not(.__has_focus__)', `
-          filter: blur(2px) 
+          filter: blur(2px);
         `)
       ])
+    ]),
+    cM('has-highlight-line', [
+      c('.__highlight_line__', `
+        background-color: var(--n-line-highlight-bg-color); 
+      `)
     ]),
     cE('line-numbers', `
       user-select: none;

--- a/src/code/src/styles/index.cssr.ts
+++ b/src/code/src/styles/index.cssr.ts
@@ -25,6 +25,13 @@ export default c([
     cM('show-line-numbers', `
       display: flex;
     `),
+    cM('has-focus-line', [
+      cB('code-line', [
+        c('&:not(.__has_focus__)', `
+          filter: blur(2px) 
+        `)
+      ])
+    ]),
     cE('line-numbers', `
       user-select: none;
       padding-right: 12px;

--- a/src/code/src/utils.ts
+++ b/src/code/src/utils.ts
@@ -1,0 +1,50 @@
+import { useConfig } from '../../_mixins'
+export default (): any => {
+  const { mergedClsPrefixRef } = useConfig()
+  return {
+    'after:highlight': (result: any) => {
+      const htmlLines = result.value.split('\n')
+      let spanStack: string[] = []
+      result.value = htmlLines
+        .map((content: string, index: number) => {
+          let startSpanIndex, endSpanIndex
+          let needle = 0
+          content = spanStack.join('') + content
+          spanStack = []
+          while (true) {
+            const remainingContent = content.slice(needle)
+            startSpanIndex = remainingContent.indexOf('<span')
+            endSpanIndex = remainingContent.indexOf('</span')
+            if (startSpanIndex === -1 && endSpanIndex === -1) {
+              break
+            }
+            if (
+              endSpanIndex === -1 ||
+              (startSpanIndex !== -1 && startSpanIndex < endSpanIndex)
+            ) {
+              const nextSpan = /<span .+?>/.exec(remainingContent)
+              if (nextSpan === null) {
+                // never: but ensure no exception is raised if it happens some day.
+                break
+              }
+              spanStack.push(nextSpan[0])
+              needle += startSpanIndex + nextSpan[0].length
+            } else {
+              spanStack.pop()
+              needle += endSpanIndex + 1
+            }
+          }
+          if (spanStack.length > 0) {
+            content += Array(spanStack.length).fill('</span>').join('')
+          }
+          let retString = '<div '
+          retString += `class="${mergedClsPrefixRef.value}-code-line ${
+            mergedClsPrefixRef.value
+          }-code-line--${index + 1}"`
+          retString += `>${content}</div>`
+          return retString
+        })
+        .join('')
+    }
+  }
+}

--- a/src/code/src/utils.ts
+++ b/src/code/src/utils.ts
@@ -38,9 +38,7 @@ export default (): any => {
             content += Array(spanStack.length).fill('</span>').join('')
           }
           let retString = '<div '
-          retString += `class="${mergedClsPrefixRef.value}-code-line ${
-            mergedClsPrefixRef.value
-          }-code-line--${index + 1}"`
+          retString += `class="${mergedClsPrefixRef.value}-code-line"`
           retString += `>${content}</div>`
           return retString
         })

--- a/src/code/styles/dark.ts
+++ b/src/code/styles/dark.ts
@@ -22,7 +22,7 @@ const codeDark: CodeTheme = {
       'hue-6-2': '#e6c07b',
       // line-number styles
       lineNumberTextColor: textColor3,
-      lineHighLightBgColor: '#626462'
+      lineHighLightBgColor: '#000'
     }
   }
 }

--- a/src/code/styles/dark.ts
+++ b/src/code/styles/dark.ts
@@ -21,7 +21,8 @@ const codeDark: CodeTheme = {
       'hue-6': '#d19a66',
       'hue-6-2': '#e6c07b',
       // line-number styles
-      lineNumberTextColor: textColor3
+      lineNumberTextColor: textColor3,
+      lineHighLightBgColor: '#626462'
     }
   }
 }

--- a/src/code/styles/light.ts
+++ b/src/code/styles/light.ts
@@ -20,7 +20,7 @@ const self = (vars: ThemeCommonVars) => {
     'hue-6-2': '#c18401',
     // line-number styles
     lineNumberTextColor: textColor3,
-    lineHighLightBgColor: '#eaf8ec'
+    lineHighLightBgColor: '#f4f5f4'
   }
 }
 

--- a/src/code/styles/light.ts
+++ b/src/code/styles/light.ts
@@ -19,7 +19,8 @@ const self = (vars: ThemeCommonVars) => {
     'hue-6': '#986801',
     'hue-6-2': '#c18401',
     // line-number styles
-    lineNumberTextColor: textColor3
+    lineNumberTextColor: textColor3,
+    lineHighLightBgColor: '#eaf8ec'
   }
 }
 


### PR DESCRIPTION
close #4482 
<img width="660" alt="image" src="https://user-images.githubusercontent.com/87003751/219052684-6025d95e-f530-46c6-99f9-76213af1f9fb.png">

The `lineToDiv` mentioned in docs works by splitting the code in lines.
Highlightjs doesn't provide removePlugin api，so we can't add plugin inside component(because if we do this, each time user mount a n-code component, hljs will be added a plugin)
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
