### PR TITLE
fix(scrollbar): height collapse with min-height

### DIFF
--- a/src/_internal/scrollbar/src/styles/index.cssr.ts
+++ b/src/_internal/scrollbar/src/styles/index.cssr.ts
@@ -20,6 +20,7 @@ export default cB('scrollbar', `
       width: 100%;
       overflow: scroll;
       height: 100%;
+      min-height: inherit;
       max-height: inherit;
       scrollbar-width: none;
     `, [


### PR DESCRIPTION
Height collapse when the min-height of data table is larger than the max-height