### PR TITLE
fix(image): prop `width` and `height` dosen't work within card cover slot

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,6 +8,7 @@
 - Fix `n-dynamic-input` doesn't return correct `index` in `on-create` callback.
 - Fix `trTR` i18n, closes [#4231](https://github.com/tusen-ai/naive-ui/issues/4231).
 - Fix `n-input`'s show password icon is offset when use both `password` and `disabled`, closes [#4364](https://github.com/tusen-ai/naive-ui/issues/4364).
+- Fix `n-image`'s prop `width` and `height` dose not work within card cover slot, closes [#4519](https://github.com/tusen-ai/naive-ui/issues/4519).
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,7 @@
 - 修复 `n-dynamic-input` 在点击添加按钮后 `on-create` 返回的 `index` 不正确
 - 修复 `trTR` 国际化，关闭 [#4231](https://github.com/tusen-ai/naive-ui/issues/4231)
 - 修复 `n-input` 同时使用 `password` 和 `disabled` 时，显示密码图标偏移的问题，关闭 [#4364](https://github.com/tusen-ai/naive-ui/issues/4364)
+- 修复 `n-image` 在 `n-card` 中设置属性 `width`、`height` 失效，关闭[#4519](https://github.com/tusen-ai/naive-ui/issues/4519)
 
 ### Feats
 

--- a/src/_utils/css/format-length.ts
+++ b/src/_utils/css/format-length.ts
@@ -1,4 +1,4 @@
-const pureNumberRegex = /^(\d|\.)+$/
+export const pureNumberRegex = /^(\d|\.)+$/
 const numberRegex = /(\d|\.)+/
 
 interface FormatLengthOptions {

--- a/src/_utils/css/index.ts
+++ b/src/_utils/css/index.ts
@@ -1,2 +1,2 @@
-export { formatLength } from './format-length'
+export { formatLength, pureNumberRegex } from './format-length'
 export { color2Class } from './color-to-class'

--- a/src/_utils/index.ts
+++ b/src/_utils/index.ts
@@ -34,7 +34,7 @@ export type {
   ExtractInternalPropTypes,
   Mutable
 } from './naive'
-export { formatLength, color2Class } from './css'
+export { formatLength, pureNumberRegex, color2Class } from './css'
 export { createKey } from './cssr'
 export { isJsdom } from './env/is-jsdom'
 export { isBrowser } from './env/is-browser'

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -13,6 +13,7 @@ import {
 } from 'vue'
 import { isImageSupportNativeLazy } from '../../_utils/env/is-native-lazy-load'
 import type { ExtractPublicPropTypes } from '../../_utils'
+import { pureNumberRegex } from '../../_utils'
 import { useConfig } from '../../_mixins'
 import { imageContextKey, imagePreviewSharedProps } from './interface'
 import { observeIntersection } from './utils'
@@ -155,11 +156,14 @@ export default defineComponent({
 
     const placeholderNode = this.$slots.placeholder?.()
     const loadSrc: string = this.src || imgProps.src || ''
+    const isPureNumberWidth = pureNumberRegex.test(this.width as any)
+    const isPureNumberHeight = pureNumberRegex.test(this.height as any)
+
     const imgNode = h('img', {
       ...imgProps,
       ref: 'imageRef',
-      width: this.width || imgProps.width,
-      height: this.height || imgProps.height,
+      width: isPureNumberWidth ? this.width : undefined,
+      height: isPureNumberHeight ? this.height : undefined,
       src: isImageSupportNativeLazy
         ? loadSrc
         : this.showError
@@ -178,11 +182,19 @@ export default defineComponent({
           ? 'lazy'
           : 'eager',
       style: [
+        {
+          objectFit: this.objectFit,
+          width: isPureNumberWidth
+            ? `${this.width as string | number}px`
+            : this.width,
+          height: isPureNumberHeight
+            ? `${this.height as string | number}px`
+            : this.height
+        },
         imgProps.style || '',
         placeholderNode && !loaded
           ? { height: '0', width: '0', visibility: 'hidden' }
-          : '',
-        { objectFit: this.objectFit }
+          : ''
       ],
       'data-error': this.showError,
       'data-preview-src': this.previewSrc || this.src


### PR DESCRIPTION
closes #4519
If only the width/height attribute is specified for the img, the parent element's higher priority may override it, as shown below.

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/33979706/221175662-53d41aaf-9f67-4b33-81d1-009eb6d76e77.png">

In addition, Vue will render a value of 0 if it has a unit.

 ```vue
<n-image width="100px" height="100" />
```
Vue rendered result
```html
<img width="0" height="100" />
```
I think we can add inline style within the component.
```html
<img height="100" style="width:100px;height:100px;" />
```