### PR TITLE
fix: 修复当列排序开启且拖动列宽拖拽按钮后，会触发排序功能

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,6 +8,7 @@
 - Fix `n-dynamic-input` doesn't return correct `index` in `on-create` callback.
 - Fix `trTR` i18n, closes [#4231](https://github.com/tusen-ai/naive-ui/issues/4231).
 - Fix `n-input`'s show password icon is offset when use both `password` and `disabled`, closes [#4364](https://github.com/tusen-ai/naive-ui/issues/4364).
+- Fix `n-data-table` dragging the column width button to trigger the sorting function when the cursor is in the column header, closes [#4610](https://github.com/tusen-ai/naive-ui/issues/4610).
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,7 @@
 - 修复 `n-dynamic-input` 在点击添加按钮后 `on-create` 返回的 `index` 不正确
 - 修复 `trTR` 国际化，关闭 [#4231](https://github.com/tusen-ai/naive-ui/issues/4231)
 - 修复 `n-input` 同时使用 `password` 和 `disabled` 时，显示密码图标偏移的问题，关闭 [#4364](https://github.com/tusen-ai/naive-ui/issues/4364)
+- 修复 `n-data-table` 拖动列宽按钮后，当光标处于列头会触发排序功能，关闭 [#4610](https://github.com/tusen-ai/naive-ui/issues/4610)
 
 ### Feats
 

--- a/src/data-table/src/TableParts/Header.tsx
+++ b/src/data-table/src/TableParts/Header.tsx
@@ -92,7 +92,8 @@ export default defineComponent({
     ): void {
       if (
         happensIn(e, 'dataTableFilter') ||
-        happensIn(e, 'dataTableResizable')
+        happensIn(e, 'dataTableResizable') ||
+        e.eventPhase !== e.BUBBLING_PHASE
       ) {
         return
       }


### PR DESCRIPTION
- fix: 修复列排序开启且拖动列宽拖拽按钮时，当鼠标的光标处于列头时(不在列宽拖拽按钮上)，会触发排序功能
- 关闭 [#4610](https://github.com/tusen-ai/naive-ui/issues/4610)
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
