### PR TITLE
docs(countdown): Type hint error for 'duration'

### DIFF
--- a/src/countdown/demos/enUS/index.demo-entry.md
+++ b/src/countdown/demos/enUS/index.demo-entry.md
@@ -18,7 +18,7 @@ reset.vue
 | Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
 | active | `boolean` | `true` | Whether countdown is active. | 2.23.2 |
-| duration | `string` | `0` | The duration of the countdown (unit is millisecond). Not reactive. | 2.23.2 |
+| duration | `number` | `0` | The duration of the countdown (unit is millisecond). Not reactive. | 2.23.2 |
 | precision | `0 \| 1 \| 2 \| 3` | `0` | The precision of the second. | 2.23.2 |
 | render | `(props: { hours: number, minutes: number, seconds: number, milliseconds: number }) => VNodeChild` | `undefined` | Time's render function | 2.23.2 |
 | on-finish | `() => void` | `undefined` | The callback on countdown is finished. | 2.23.2 |

--- a/src/countdown/demos/zhCN/index.demo-entry.md
+++ b/src/countdown/demos/zhCN/index.demo-entry.md
@@ -19,7 +19,7 @@ finish-debug.vue
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
 | --- | --- | --- | --- | --- |
 | active | `boolean` | `true` | 是否处于计时状态 | 2.23.2 |
-| duration | `string` | `0` | 倒计时持续时间，单位毫秒，非响应式 | 2.23.2 |
+| duration | `number` | `0` | 倒计时持续时间，单位毫秒，非响应式 | 2.23.2 |
 | precision | `0 \| 1 \| 2 \| 3` | `0` | 倒计时的秒显示的精度 | 2.23.2 |
 | render | `(props: { hours: number, minutes: number, seconds: number, milliseconds: number }) => VNodeChild` | `undefined` | 时间的渲染函数 | 2.23.2 |
 | on-finish | `() => void` | `undefined` | 倒计时结束的回调 | 2.23.2 |


### PR DESCRIPTION
Countdown 组件 API功能说明文档中的 duration 类型提示有误