### PR TITLE
docs(select): Description error for 'show-checkmark'

### DIFF
--- a/src/select/demos/enUS/index.demo-entry.md
+++ b/src/select/demos/enUS/index.demo-entry.md
@@ -65,7 +65,7 @@ custom-field.vue
 | reset-menu-on-options-change | `boolean` | `true` | Whether to reset menu staus on options change, for example, scroll status. | 2.24.2 |
 | show | `boolean` | `undefined` | Whether to show/open the option menu. |  |
 | show-arrow | `boolean` | `true` | Whether to show the dropdown arrow. |  |
-| show-checkmark | `boolean` | `true` | Whether to show checkmark in multiple select mode. | 2.33.4 |
+| show-checkmark | `boolean` | `true` | Whether to show checkmark. | 2.33.4 |
 | show-on-focus | `boolean` | `false` | Whether to show menu on focus. | 2.34.3 |
 | size | `'tiny' \| 'small' \| 'medium' \| 'large'` | `'medium'` | Size of the select input. |  |
 | status | `'success' \| 'warning' \| 'error'` | `undefined` | Validation status. | 2.27.0 |

--- a/src/select/demos/zhCN/index.demo-entry.md
+++ b/src/select/demos/zhCN/index.demo-entry.md
@@ -75,7 +75,7 @@ create-debug.vue
 | reset-menu-on-options-change | `boolean` | `true` | 是否在选项变化时重置菜单状态，例如滚动状态 | 2.24.2 |
 | show | `boolean` | `undefined` | 是否展示菜单 |  |
 | show-arrow | `boolean` | `true` | 是否展示箭头 |  |
-| show-checkmark | `boolean` | `true` | 多选情况下是否展示对勾 | 2.33.4 |
+| show-checkmark | `boolean` | `true` | 是否展示对勾 | 2.33.4 |
 | show-on-focus | `boolean` | `false` | 聚焦时是否展示菜单 | 2.34.3 |
 | size | `'tiny' \| 'small' \| 'medium' \| 'large'` | `'medium'` | 组件尺寸 |  |
 | status | `'success' \| 'warning' \| 'error'` | `undefined` | 验证状态 | 2.27.0 |


### PR DESCRIPTION
通过我的一些实验，我注意到复选标记在单选和多选模式下的行为相似。这可能是歧义或文档错误。