### PR TITLE
feat(n-image-group): add `on-preview-prev` `on-preview-next` prop

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-image-group` adds `on-preview-prev` `on-preview-next` prop
+
 ## 2.34.4
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-image-group` 新增 `on-preview-prev` `on-preview-next` 属性
+
 ## 2.34.4
 
 ### Fixes

--- a/src/image/demos/enUS/index.demo-entry.md
+++ b/src/image/demos/enUS/index.demo-entry.md
@@ -43,6 +43,8 @@ previewed-img-props.vue
 
 | Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
+| on-preview-prev | `() => void` | `undefined` | Click the callback from the previous slide |  |
+| on-preview-next | `() => void` | `undefined` | Click the callback on the next slide |
 | show-toolbar | `boolean` | `true` | Whether to show the bottom toolbar when the image enlarge. |  |
 | show-toolbar-tooltip | `boolean` | `false` | Whether to show toolbar buttons' tooltip. | 2.24.0 |
 

--- a/src/image/demos/zhCN/index.demo-entry.md
+++ b/src/image/demos/zhCN/index.demo-entry.md
@@ -43,6 +43,8 @@ previewed-img-props.vue
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
 | --- | --- | --- | --- | --- |
+| on-preview-prev | `() => void` | `undefined` | 点击上一张的回调 |  |
+| on-preview-next | `() => void` | `undefined` | 点击下一张的回调 |  |
 | show-toolbar | `boolean` | `true` | 图片放大后是否展示底部工具栏 |  |
 | show-toolbar-tooltip | `boolean` | `false` | 是否展示工具栏的提示 | 2.24.0 |
 

--- a/src/image/src/ImageGroup.tsx
+++ b/src/image/src/ImageGroup.tsx
@@ -56,6 +56,7 @@ export default defineComponent({
       } else {
         setPreviewSrc(imgs[0].dataset.previewSrc)
       }
+      step === 1 ? props.onPreviewNext?.() : props.onPreviewPrev?.()
     }
     provide(imageGroupInjectionKey, {
       mergedClsPrefixRef,

--- a/src/image/src/interface.ts
+++ b/src/image/src/interface.ts
@@ -1,4 +1,4 @@
-import type { ImgHTMLAttributes, Ref } from 'vue'
+import type { ImgHTMLAttributes, PropType, Ref } from 'vue'
 import type { ThemeProps } from '../../_mixins'
 import { useTheme } from '../../_mixins'
 import { createInjectionKey } from '../../_utils'
@@ -13,6 +13,8 @@ export interface MoveStrategy {
 
 export const imagePreviewSharedProps = {
   ...(useTheme.props as ThemeProps<ImageTheme>),
+  onPreviewPrev: Function as PropType<() => void>,
+  onPreviewNext: Function as PropType<() => void>,
   showToolbar: { type: Boolean, default: true },
   showToolbarTooltip: Boolean
 }


### PR DESCRIPTION
Easy to know the current preview switching behavior
