### PR TITLE
fix(time-picker): trigger an incorrect value when click the 'now' button by passing a zero value as the time step

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-time-picker` trigger an incorrect value when click the 'now' button by passing a zero value as the time step, closes [#4859](https://github.com/tusen-ai/naive-ui/issues/4859).
+
 ## 2.34.4
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-time-picker` 设置时间步进传递零值时，点击此刻按钮触发错误的值, 关闭 [#4859](https://github.com/tusen-ai/naive-ui/issues/4859)
+
 ## 2.34.4
 
 ### Fixes

--- a/src/time-picker/src/TimePicker.tsx
+++ b/src/time-picker/src/TimePicker.tsx
@@ -681,11 +681,14 @@ export default defineComponent({
       }
       const [mergeHours, mergeMinutes, mergeSeconds] = (
         ['hours', 'minutes', 'seconds'] as const
-      ).map((i) =>
-        !props[i] || isTimeInStep(getNowTime[i](now), i, props[i])
-          ? getNowTime[i](now)
-          : findSimilarTime(getNowTime[i](now), i, props[i])
-      )
+      ).map((i) => {
+        const timePart = props[i]
+        const nowTime = getNowTime[i](now)
+        if (timePart === 0) return 0
+        return !timePart || isTimeInStep(nowTime, i, timePart)
+          ? nowTime
+          : findSimilarTime(nowTime, i, timePart)
+      })
       const newValue = setSeconds(
         setMinutes(
           setHours(

--- a/src/time-picker/src/utils.ts
+++ b/src/time-picker/src/utils.ts
@@ -218,8 +218,8 @@ export function getTimeUnits (
           return getFixValue(hourAsNumber === 12 ? 12 : hourAsNumber - 12)
         })
     }
-    return defaultValue.filter((hour) => {
-      return Number(hour) % stepOrList === 0
+    return defaultValue.filter((tick) => {
+      return Number(tick) === 0 || Number(tick) % stepOrList === 0
     })
   } else {
     return isHourWithAmPm === 'am'


### PR DESCRIPTION
closes #4859
