### PR TITLE
fix: async form validation demo phone number alway invalid

### DIFF
--- a/src/form/demos/enUS/async.demo.vue
+++ b/src/form/demos/enUS/async.demo.vue
@@ -96,7 +96,7 @@ export default defineComponent({
           required: true,
           trigger: ['input'],
           validator: (rule: FormItemRule, value: string) => {
-            return /^[1]+[3,8]+\\d{9}$/.test(value)
+            return /^[1]+[3,8]+\d{9}$/.test(value)
           }
         }
       },

--- a/src/form/demos/zhCN/async.demo.vue
+++ b/src/form/demos/zhCN/async.demo.vue
@@ -89,7 +89,7 @@ export default defineComponent({
           required: true,
           trigger: ['input'],
           validator: (rule: FormItemRule, value: string) => {
-            return /^[1]+[3,8]+\\d{9}$/.test(value)
+            return /^[1]+[3,8]+\d{9}$/.test(value)
           }
         }
       },


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

The demo at https://www.naiveui.com/en-US/os-theme/components/form#async.vue seems to aim to validate whether a Chinense phone number is provided in the `Phone` field, but the incorrect regex causes a correct phone number to fail the validation.
