### PR TITLE
fix(data-table): add td max-width limit(#3755)

### DIFF
--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-data-table` 当使用树形表格时，某一列设置了固定宽度且 ellipsis: true 后，如果文字溢出，不会显示省略号，而是换行[#3755](https://github.com/tusen-ai/naive-ui/issues/3755)
+
 ## 2.34.4
 
 ### Fixes

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -810,7 +810,11 @@ export default defineComponent({
                           {
                             textAlign: column.align || undefined,
                             left: pxfy(fixedColumnLeftMap[colKey]?.start),
-                            right: pxfy(fixedColumnRightMap[colKey]?.start)
+                            right: pxfy(fixedColumnRightMap[colKey]?.start),
+                            '--prefix-num':
+                              hasChildren && colIndex === childTriggerColIndex
+                                ? (isSummary ? 0 : rowInfo.tmNode.level) + 1
+                                : 0
                           },
                           resolvedCellProps?.style || ''
                         ]}

--- a/src/data-table/src/styles/index.cssr.ts
+++ b/src/data-table/src/styles/index.cssr.ts
@@ -388,7 +388,7 @@ export default c([
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
-        max-width: 100%;
+        max-width: calc(100% - var(--prefix-num, 0) * 16px - min(var(--prefix-num, 0) ,1) * 8px);
         vertical-align: bottom;
       `),
       cM('selection, expand', `


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
修复 `n-data-table` 当使用树形表格时，某一列设置了固定宽度且 ellipsis: true 后，如果文字溢出，不会显示省略号，而是换行 #3755 