### PR TITLE
docs(data-table): typo checked-row-keys desc

### DIFF
--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -79,7 +79,7 @@ expandable-debug.vue
 | allow-checking-not-loaded | `boolean` | `false` | 是否允许级联勾选还没有完全加载的节点。如果你要用这个属性，请记住 `checked-row-keys` 可能是不完整的 | 2.28.0 |
 | bordered | `boolean` | `true` | 是否显示 border |  |
 | bottom-bordered | `boolean` | `true` | 是否显示 bottom border |  |
-| checked-row-keys | `Array<string \| number>` | `undefined` | 被选中的列的 key |  |
+| checked-row-keys | `Array<string \| number>` | `undefined` | 被选中的行的 key |  |
 | cascade | `boolean` | `true` | 在进行树型数据选择的时候是否级联 |  |
 | children-key | `string` | `'children'` | 树形数据下后代节点在数据中的 key |  |
 | columns | `Array<DataTableColumn>` | `[]` | 需要展示的列 |  |


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
Fix: #4995 

The English docs is displaying correctly.
![image](https://github.com/tusen-ai/naive-ui/assets/19891724/68d0c3d2-bf55-4958-bec3-a8f1cfd79582)

The Chinese docs is displaying incorrectly.
![image](https://github.com/tusen-ai/naive-ui/assets/19891724/036f29a3-c76c-49df-9243-27ff05139203)
