### PR TITLE
refactor(data-table): header and body's scrolling synchronization implementation

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -32,6 +32,10 @@
 - Fix `n-tree`'s `TreeOption`'s `checkboxDisabled` prop doesn't work when `check-on-click` is `true`.
 - Fix rapid clicks on `n-date-input`'s buttons triggering a text select for the rest of the website.
 
+## Refactors
+
+- Refactor `n-data-table` header and body's scrolling synchronization implementation.
+
 ### Features
 
 - `n-drawer` adds `max-height`, `min-height`, `max-width` and `max-width` props.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -32,6 +32,10 @@
 - 修复 `n-tree` `check-on-click` 为 `true` 时，`TreeOption` `checkboxDisabled` 不生效
 - 修复 `n-date-input` 的按钮快速点击时网站其余文本会被选中
 
+## Refactors
+
+- 重构 `n-data-table` header 和 body 滚动同步实现
+
 ### Features
 
 - `n-drawer` 新增 `max-height`、`min-height`、`max-width`、`max-width` 属性

--- a/src/data-table/src/use-scroll.ts
+++ b/src/data-table/src/use-scroll.ts
@@ -182,7 +182,10 @@ export function useScroll (
     }
   }
   function handleTableHeaderScroll (): void {
-    if (scrollPartRef.value !== 'body') {
+    if (!scrollPartRef.value) {
+      scrollPartRef.value = 'head'
+    }
+    if (scrollPartRef.value === 'head') {
       beforeNextFrameOnce(syncScrollState)
     } else {
       scrollPartRef.value = undefined
@@ -190,7 +193,10 @@ export function useScroll (
   }
   function handleTableBodyScroll (e: Event): void {
     props.onScroll?.(e)
-    if (scrollPartRef.value !== 'head') {
+    if (!scrollPartRef.value) {
+      scrollPartRef.value = 'body'
+    }
+    if (scrollPartRef.value === 'body') {
       beforeNextFrameOnce(syncScrollState)
     } else {
       scrollPartRef.value = undefined
@@ -207,8 +213,6 @@ export function useScroll (
     if (props.maxHeight || props.flexHeight) {
       if (!header) return
       // we need to deal with overscroll
-      const directionHead = lastScrollLeft - header.scrollLeft
-      scrollPartRef.value = directionHead !== 0 ? 'head' : 'body'
       if (scrollPartRef.value === 'head') {
         lastScrollLeft = header.scrollLeft
         body.scrollLeft = lastScrollLeft


### PR DESCRIPTION
#4051 改成这样实现好一点，但是发现在 Safari 中滚动有弹性效果导致会有一点点小问题；
https://codesandbox.io/s/fix-naiveui-datatable-scrolling-sync-demo-y4q1hx?file=/src/App.vue
复现步骤：
1. 鼠标先点击表头，让焦点在表头上；
2. 鼠标移入表体，使用触控板快速滑动，有弹性效果；
3. 按键盘左键，第一下滚动表头会滚动，表体没动。

![2](https://github.com/tusen-ai/naive-ui/assets/33979706/050c301d-684f-4e7b-8269-dafb8b5299b3)
