### PR TITLE
feat(tabs): add animation for segment

### DIFF
--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -516,18 +516,30 @@ export default defineComponent({
     })
 
     const tabsRailElRef = ref<HTMLElement | null>(null)
-    watch(mergedValueRef, () => {
-      if (props.type === 'segment') {
-        const tabsRailEl = tabsRailElRef.value
-        if (tabsRailEl) {
-          void nextTick(() => {
-            tabsRailEl.classList.add('transition-disabled')
-            void tabsRailEl.offsetWidth
-            tabsRailEl.classList.remove('transition-disabled')
-          })
+    const segmentCapsuleElRef = ref<HTMLElement | null>(null)
+    watch(
+      mergedValueRef,
+      () => {
+        if (props.type === 'segment') {
+          const tabsRailEl = tabsRailElRef.value
+          if (tabsRailEl) {
+            void nextTick(() => {
+              tabsRailEl.classList.add('transition-disabled')
+              const ele = tabsRailEl.querySelector('.n-tabs-tab--active')
+              if (ele && segmentCapsuleElRef.value) {
+                const rect = ele.getBoundingClientRect()
+                segmentCapsuleElRef.value.style.width = `${rect.width}px`
+                segmentCapsuleElRef.value.style.transform = `translateX(${
+                  rect.left - tabsRailEl.getBoundingClientRect().left - 3
+                }px)`
+              }
+              tabsRailEl.classList.remove('transition-disabled')
+            })
+          }
         }
-      }
-    })
+      },
+      { flush: 'post' }
+    )
 
     const exposedMethods: TabsInst = {
       syncBarPosition: () => {
@@ -632,6 +644,7 @@ export default defineComponent({
       mergedValue: mergedValueRef,
       renderedNames: new Set<NonNullable<TabPaneProps['name']>>(),
       tabsRailElRef,
+      segmentCapsuleElRef,
       tabsPaneWrapperRef,
       tabsElRef,
       barElRef,
@@ -801,7 +814,16 @@ export default defineComponent({
               )
           )}
           {isSegment ? (
-            <div class={`${mergedClsPrefix}-tabs-rail`} ref="tabsRailElRef">
+            <div
+              class={`${mergedClsPrefix}-tabs-rail ${mergedClsPrefix}-tabs-rail-segment`}
+              ref="tabsRailElRef"
+            >
+              <div
+                class={`${mergedClsPrefix}-tabs-haha`}
+                ref="segmentCapsuleElRef"
+              >
+                <Tab name="">&nbsp;</Tab>
+              </div>
               {showPane
                 ? tabPaneChildren.map((tabPaneVNode: any, index: number) => {
                   renderNameListRef.value.push(tabPaneVNode.props.name)

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -517,29 +517,26 @@ export default defineComponent({
 
     const tabsRailElRef = ref<HTMLElement | null>(null)
     const segmentCapsuleElRef = ref<HTMLElement | null>(null)
-    watch(
-      mergedValueRef,
-      () => {
-        if (props.type === 'segment') {
-          const tabsRailEl = tabsRailElRef.value
-          if (tabsRailEl) {
-            void nextTick(() => {
-              tabsRailEl.classList.add('transition-disabled')
-              const ele = tabsRailEl.querySelector('.n-tabs-tab--active')
-              if (ele && segmentCapsuleElRef.value) {
-                const rect = ele.getBoundingClientRect()
-                segmentCapsuleElRef.value.style.width = `${rect.width}px`
-                segmentCapsuleElRef.value.style.transform = `translateX(${
-                  rect.left - tabsRailEl.getBoundingClientRect().left - 3
-                }px)`
-              }
-              tabsRailEl.classList.remove('transition-disabled')
-            })
+
+    watchEffect(() => {
+      if (props.type === 'segment') {
+        const { value: tabsRailEl } = tabsRailElRef
+        if (!tabsRailEl) return
+        void nextTick(() => {
+          tabsRailEl.classList.add('transition-disabled')
+          const activeTabEl = tabsRailEl.querySelector('.n-tabs-tab--active')
+          if (activeTabEl && segmentCapsuleElRef.value) {
+            const rect = activeTabEl.getBoundingClientRect()
+            // move segment capsule to match the position of the active tab
+            segmentCapsuleElRef.value.style.width = `${rect.width}px`
+            segmentCapsuleElRef.value.style.transform = `translateX(${
+              rect.left - tabsRailEl.getBoundingClientRect().left - 3
+            }px)`
           }
-        }
-      },
-      { flush: 'post' }
-    )
+          tabsRailEl.classList.remove('transition-disabled')
+        })
+      }
+    })
 
     const exposedMethods: TabsInst = {
       syncBarPosition: () => {

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -389,6 +389,33 @@ export default defineComponent({
       barEl.classList.remove(disableTransitionClassName)
     }
 
+    const tabsRailElRef = ref<HTMLElement | null>(null)
+    const segmentCapsuleElRef = ref<HTMLElement | null>(null)
+
+    function updateSegmentPosition (): void {
+      if (props.type === 'segment') {
+        const { value: tabsRailEl } = tabsRailElRef
+        if (!tabsRailEl) return
+        void nextTick(() => {
+          tabsRailEl.classList.add('transition-disabled')
+          const activeTabEl = tabsRailEl.querySelector('.n-tabs-tab--active')
+          if (activeTabEl && segmentCapsuleElRef.value) {
+            const rect = activeTabEl.getBoundingClientRect()
+            // move segment capsule to match the position of the active tab
+            segmentCapsuleElRef.value.style.width = `${rect.width}px`
+            segmentCapsuleElRef.value.style.transform = `translateX(${
+              rect.left - tabsRailEl.getBoundingClientRect().left - 3
+            }px)`
+          }
+          tabsRailEl.classList.remove('transition-disabled')
+        })
+      }
+    }
+
+    watch([mergedValueRef, tabsRailElRef], () => {
+      updateSegmentPosition()
+    })
+
     let memorizedWidth = 0
     function _handleNavResize (entry: ResizeObserverEntry): void {
       if (entry.contentRect.width === 0 && entry.contentRect.height === 0) {
@@ -512,29 +539,6 @@ export default defineComponent({
         el.classList.remove(shadowEndClass)
       } else {
         el.classList.add(shadowEndClass)
-      }
-    })
-
-    const tabsRailElRef = ref<HTMLElement | null>(null)
-    const segmentCapsuleElRef = ref<HTMLElement | null>(null)
-
-    watch([mergedValueRef, tabsRailElRef], () => {
-      if (props.type === 'segment') {
-        const { value: tabsRailEl } = tabsRailElRef
-        if (!tabsRailEl) return
-        void nextTick(() => {
-          tabsRailEl.classList.add('transition-disabled')
-          const activeTabEl = tabsRailEl.querySelector('.n-tabs-tab--active')
-          if (activeTabEl && segmentCapsuleElRef.value) {
-            const rect = activeTabEl.getBoundingClientRect()
-            // move segment capsule to match the position of the active tab
-            segmentCapsuleElRef.value.style.width = `${rect.width}px`
-            segmentCapsuleElRef.value.style.transform = `translateX(${
-              rect.left - tabsRailEl.getBoundingClientRect().left - 3
-            }px)`
-          }
-          tabsRailEl.classList.remove('transition-disabled')
-        })
       }
     })
 

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -815,12 +815,9 @@ export default defineComponent({
               )
           )}
           {isSegment ? (
-            <div
-              class={`${mergedClsPrefix}-tabs-rail ${mergedClsPrefix}-tabs-rail-segment`}
-              ref="tabsRailElRef"
-            >
+            <div class={`${mergedClsPrefix}-tabs-rail`} ref="tabsRailElRef">
               <div
-                class={`${mergedClsPrefix}-tabs-haha`}
+                class={`${mergedClsPrefix}-tabs-capsule`}
                 ref="segmentCapsuleElRef"
               >
                 <Tab name="">&nbsp;</Tab>

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -518,7 +518,7 @@ export default defineComponent({
     const tabsRailElRef = ref<HTMLElement | null>(null)
     const segmentCapsuleElRef = ref<HTMLElement | null>(null)
 
-    watchEffect(() => {
+    watch([mergedValueRef, tabsRailElRef], () => {
       if (props.type === 'segment') {
         const { value: tabsRailEl } = tabsRailElRef
         if (!tabsRailEl) return

--- a/src/tabs/src/styles/index.cssr.ts
+++ b/src/tabs/src/styles/index.cssr.ts
@@ -104,7 +104,7 @@ export default cB('tabs', `
     display: flex;
     align-items: center;
   `, [
-    cB('tabs-haha', `
+    cB('tabs-capsule', `
         border-radius: var(--n-tab-border-radius);
         width: 50px;
         position: absolute;
@@ -112,7 +112,7 @@ export default cB('tabs', `
         background-color: var(--n-tab-color-segment);
         box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .08);
         transition: 0.3s;
-      `, []),
+      `),
     cB('tabs-tab-wrapper', `
       flex-basis: 0;
       flex-grow: 1;

--- a/src/tabs/src/styles/index.cssr.ts
+++ b/src/tabs/src/styles/index.cssr.ts
@@ -104,6 +104,15 @@ export default cB('tabs', `
     display: flex;
     align-items: center;
   `, [
+    cB('tabs-haha', `
+        border-radius: var(--n-tab-border-radius);
+        width: 50px;
+        position: absolute;
+        pointer-events: none;
+        background-color: var(--n-tab-color-segment);
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .08);
+        transition: 0.3s;
+      `, []),
     cB('tabs-tab-wrapper', `
       flex-basis: 0;
       flex-grow: 1;
@@ -122,8 +131,6 @@ export default cB('tabs', `
         cM('active', `
           font-weight: var(--n-font-weight-strong);
           color: var(--n-tab-text-color-active);
-          background-color: var(--n-tab-color-segment);
-          box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .08);
         `),
         c('&:hover', `
           color: var(--n-tab-text-color-hover);
@@ -279,6 +286,7 @@ export default cB('tabs', `
     cE('label', `
       display: flex;
       align-items: center;
+      z-index: 1;
     `)
   ]),
   cB('tabs-bar', `


### PR DESCRIPTION
closes #3910

Just a ugly brute force implementation, for prototyping an idea. The following things need to be checked:
- [ ] resize
- [ ] style

Demo:

![tab](https://github.com/tusen-ai/naive-ui/assets/8041462/5dd530e3-9a24-42c3-ba73-62cbb5d6bb98)

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
