### PR TITLE
fix(Input): Input props onKeydown is Array

### DIFF
--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -659,7 +659,7 @@ export default defineComponent({
       on('mouseup', document, hidePassword)
     }
     function handleWrapperKeydown (e: KeyboardEvent): void {
-      props.onKeydown?.(e)
+      if (props.onKeydown) call(props.onKeydown, e)
       switch (e.key) {
         case 'Escape':
           handleWrapperKeydownEsc()


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

## Issue
If use like this:
```vue
<template>
  <n-input
    @keydown.ctrl.c="handleDownKey"
    @keydown.ctrl.a="handleDownKey"
  />
</template>

<script setup lang="ts">
import { NInput } from "naive-ui";

const handleDownKey = () => {
  console.log("key down pressed");
};
</script>
```
will throw Error
![image](https://github.com/tusen-ai/naive-ui/assets/41336612/bd31c10b-1e82-4259-a5e0-0c61426af7c3)

the reason is the `props.onKeydown` maybe `Array`.

## Link
https://codesandbox.io/p/sandbox/blissful-rubin-wz7sfn?file=%2Fsrc%2FApp.vue%3A16%2C1
