### PR TITLE
feat(autocomplete): Add option to disable auto selection of first matching option in menu

### DIFF
--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -3307,3 +3307,7 @@
 ### Feats
 
 - `n-data-table` 增加了 empty 插槽 [#86](https://github.com/tusen-ai/naive-ui/issues/86)
+
+### Feats
+
+- 給 n-auto-complte 元件增加 auto-select props，用來設定展開後是否預設選取第一個 option [#4674](https://github.com/tusen-ai/naive-ui/issues/4674)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnson0903/naive-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Vue 3 Component Library. Fairly Complete, Theme Customizable, Uses TypeScript, Fast",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "naive-ui",
-  "version": "2.34.4",
+  "name": "@johnson0903/naive-ui",
+  "version": "1.0.0",
   "description": "A Vue 3 Component Library. Fairly Complete, Theme Customizable, Uses TypeScript, Fast",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -36,7 +36,7 @@
     "transpile-docs": "node scripts/md-to-vue data-table",
     "release:site": "TUSIMPLE=true pnpm run build:site && node build-doc/generate-deploy-sh.js && sudo bash build-doc/deploy-doc.sh"
   },
-  "author": "07akioni",
+  "author": "johnson0903",
   "license": "MIT",
   "files": [
     "es",

--- a/src/_internal/select-menu/src/SelectMenu.tsx
+++ b/src/_internal/select-menu/src/SelectMenu.tsx
@@ -396,7 +396,8 @@ export default defineComponent({
       selfRef,
       next,
       prev,
-      getPendingTmNode
+      getPendingTmNode,
+      setPendingTmNode
     }
     useOnResize(selfRef, props.onResize)
     return {

--- a/src/_internal/select-menu/src/interface.ts
+++ b/src/_internal/select-menu/src/interface.ts
@@ -58,6 +58,10 @@ export interface InternalExposedProps {
   getPendingTmNode: () => TreeNode<SelectBaseOption> | null
   prev: () => void
   next: () => void
+  setPendingTmNode: (
+    tmNode: TreeNode<SelectBaseOption> | null,
+    doScroll?: boolean
+  ) => void
 }
 
 export const internalSelectionMenuInjectionKey =

--- a/src/auto-complete/demos/enUS/basic.demo.vue
+++ b/src/auto-complete/demos/enUS/basic.demo.vue
@@ -13,6 +13,7 @@ Start typing to see how this works.
     :options="options"
     placeholder="Email"
     clearable
+    :auto-select="false"
   />
 </template>
 

--- a/src/auto-complete/demos/enUS/group.demo.vue
+++ b/src/auto-complete/demos/enUS/group.demo.vue
@@ -6,6 +6,7 @@
   <n-auto-complete
     v-model:value="value"
     :options="options"
+    :auto-select="false"
     placeholder="Email"
   />
 </template>

--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -239,14 +239,27 @@ export default defineComponent({
           }
           break
         case 'ArrowUp':
-          if (
-            !props.autoSelect &&
-            menuInstRef.value?.getPendingTmNode()?.isFirstChild
-          ) {
-            menuInstRef.value.setPendingTmNode(null)
+          if (!props.autoSelect) {
+            const pendingTmNode = menuInstRef.value?.getPendingTmNode()
+            if (!pendingTmNode) {
+              return
+            }
+
+            if (pendingTmNode.isFirstChild) {
+              if (
+                pendingTmNode.level === 0 ||
+                pendingTmNode.parent?.isFirstChild
+              ) {
+                menuInstRef.value?.setPendingTmNode(null)
+                return
+              }
+              return
+            }
+            menuInstRef.value?.prev()
           } else {
             menuInstRef.value?.prev()
           }
+
           break
       }
     }

--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -91,6 +91,10 @@ export const autoCompleteProps = {
   blurAfterSelect: Boolean,
   clearAfterSelect: Boolean,
   getShow: Function as PropType<(inputValue: string) => boolean>,
+  autoSelect: {
+    type: Boolean,
+    default: true
+  },
   inputProps: Object as PropType<InputHTMLAttributes>,
   renderOption: Function as PropType<RenderOption>,
   renderLabel: Function as PropType<RenderLabel>,
@@ -226,10 +230,23 @@ export default defineComponent({
           }
           break
         case 'ArrowDown':
-          menuInstRef.value?.next()
+          if (menuInstRef.value?.getPendingTmNode()) {
+            menuInstRef.value?.next()
+          } else {
+            menuInstRef.value?.setPendingTmNode(
+              treeMateRef.value.getFirstAvailableNode()
+            )
+          }
           break
         case 'ArrowUp':
-          menuInstRef.value?.prev()
+          if (
+            !props.autoSelect &&
+            menuInstRef.value?.getPendingTmNode()?.isFirstChild
+          ) {
+            menuInstRef.value.setPendingTmNode(null)
+          } else {
+            menuInstRef.value?.prev()
+          }
           break
       }
     }
@@ -416,7 +433,7 @@ export default defineComponent({
                                 this.mergedTheme.peerOverrides
                                   .InternalSelectMenu
                               }
-                              auto-pending
+                              autoPending={this.autoSelect}
                               class={[
                                 `${mergedClsPrefix}-auto-complete-menu`,
                                 this.themeClass,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '2.34.4'
+export default '1.0.1'


### PR DESCRIPTION
我和 [此 issue](https://github.com/tusen-ai/naive-ui/issues/4674) 中的描述有相同的需求
因此給 Auto complete 元件新增一個props，可以控制展開下拉選單後是否要預設選擇到第一個選項

範例我修改在 auto complete basic demo 英文版內