### PR TITLE
Fixed "Avatar Props" not linking to the correct section

### DIFF
--- a/src/avatar/demos/enUS/index.demo-entry.md
+++ b/src/avatar/demos/enUS/index.demo-entry.md
@@ -46,7 +46,7 @@ v-show-debug.vue
 | options | `Array<AvatarOption>` | `[]` | Avatar group options. |
 | vertical | `boolean` | `false` | Whether display a vertical avatar group. |
 
-see [Avatar Props](avatar#Props)
+see [Avatar Props](#Avatar-Props)
 
 ### Avatar Slots
 


### PR DESCRIPTION
The following link does not take to the correct section ID, correct full link should be https://www.naiveui.com/en-US/os-theme/components/avatar#Avatar-Props

![avatar-fi](https://github.com/tusen-ai/naive-ui/assets/64223014/dd116827-e69f-446a-a2b1-73517b0e56d8)
