### PR TITLE
Fixed "Avatar Props" not linking to the correct section for Chinese docs

### DIFF
--- a/src/avatar/demos/zhCN/index.demo-entry.md
+++ b/src/avatar/demos/zhCN/index.demo-entry.md
@@ -48,7 +48,7 @@ rtl-debug.vue
 | options   | `Array<AvatarOption>` | `[]`        | 头像组的选项           |
 | vertical  | `boolean`             | `false`     | 组内头像是否垂直排列   |
 
-参考 [Avatar Props](avatar#Props)
+参考 [Avatar Props](#Avatar-Props)
 
 ### Avatar Slots
 


### PR DESCRIPTION
Pretty much the same edit here but for Chinese docs https://github.com/tusen-ai/naive-ui/pull/5180