### PR TITLE
fix(n-time-picker): time picker formatting (format="HH: mm: ss. SSS") preventing modification of milliseconds in the edit box

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -68,6 +68,7 @@
 - Fix `n-menu` `show` `default` attribute spelling problem, closes [#4750](https://github.com/tusen-ai/naive-ui/issues/4750).
 - Fix `n-icon-wrapper`'s theme error, closes [#4768](https://github.com/tusen-ai/naive-ui/issues/4768).
 - Fix `n-popconfirm`'s action button should not be triggered multiple times，closes [#4687](https://github.com/tusen-ai/naive-ui/issues/4687).
+- Fix `n-time picker` time picker formatting (format="HH: mm: ss. SSS") preventing modification of milliseconds in the edit box, closes [# 5224]（ https://github.com/tusen-ai/naive-ui/issues/5224 ）.
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -69,6 +69,7 @@
 - 修复 `n-menu` `show` `default` 属性拼写问题，关闭 [#4750](https://github.com/tusen-ai/naive-ui/issues/4750)
 - 修复 `n-icon-wrapper` 的主题异常，关闭 [#4768](https://github.com/tusen-ai/naive-ui/issues/4768)
 - 修复 `n-popconfirm` 操作按钮不应该被多次触发，关闭 [#4687][https://github.com/tusen-ai/naive-ui/issues/4687]
+- 修复 `n-time-picker` 时间选择器 Time Picker 格式化(format="HH:mm:ss.SSS")后无法在编辑框内修改毫秒数的问题，关闭 [#5224](https://github.com/tusen-ai/naive-ui/issues/5224)
 
 ### Feats
 

--- a/src/time-picker/src/TimePicker.tsx
+++ b/src/time-picker/src/TimePicker.tsx
@@ -30,7 +30,8 @@ import {
   getTime,
   getMinutes,
   getHours,
-  getSeconds
+  getSeconds,
+  getMilliseconds
 } from 'date-fns/esm'
 import formatInTimeZone from 'date-fns-tz/formatInTimeZone'
 import type { Locale } from 'date-fns'
@@ -660,7 +661,8 @@ export default defineComponent({
           const newTime = set(mergedValue, {
             hours: getHours(time),
             minutes: getMinutes(time),
-            seconds: getSeconds(time)
+            seconds: getSeconds(time),
+            milliseconds: getMilliseconds(time)
           })
           doUpdateValue(getTime(newTime))
         } else {


### PR DESCRIPTION
close #5224