### PR TITLE
refactor: refactor empty slot action then it is an interactive component

### DIFF
--- a/src/_internal/select-menu/src/SelectMenu.tsx
+++ b/src/_internal/select-menu/src/SelectMenu.tsx
@@ -546,7 +546,6 @@ export default defineComponent({
           <div
             class={`${clsPrefix}-base-select-menu__empty`}
             data-empty
-            data-action
           >
             {resolveSlot($slots.empty, () => [
               <NEmpty

--- a/src/popselect/src/PopselectPanel.tsx
+++ b/src/popselect/src/PopselectPanel.tsx
@@ -125,7 +125,7 @@ export default defineComponent({
       toggle(tmNode.key)
     }
     function handleMenuMousedown (e: MouseEvent): void {
-      if (!happensIn(e, 'action')) e.preventDefault()
+      if (!happensIn(e, 'action') && !happensIn(e, 'empty')) e.preventDefault()
     }
     function toggle (value: ValueAtom): void {
       const {


### PR DESCRIPTION
关于https://github.com/tusen-ai/naive-ui/pull/4719
起因是我也发现和[4700](https://github.com/tusen-ai/naive-ui/issues/4700)相同的问题 但是我找到了这条[2812](https://github.com/tusen-ai/naive-ui/issues/2812)issue 我发现在当时修复此issue的commit中使用的方式为修改Select对SelectMenu传入的onMouseDown事件逻辑 而4700中的修复方式为给empty添加了data-action属性
我查看了所有外部嵌套了SelectMenu的组件 发现只有Select与PopSelectPanel 所以我做了如下修改 我想是不是从外部去修复风险更小些