### PR TITLE
fix: typo

### DIFF
--- a/src/button/src/Button.tsx
+++ b/src/button/src/Button.tsx
@@ -654,7 +654,7 @@ type MergedProps = Partial<InternalButtonProps & NativeButtonProps>
 export default Button
 
 // XButton is for tsx type checking
-// It's not compitable with render function `h`
+// It's not compatible with render function `h`
 // Currently we don't expose it as public
 // If there's any issue about this, we may expose it
 // Since most people use template, the type checking phase doesn't work as tsx

--- a/src/mention/src/Mention.tsx
+++ b/src/mention/src/Mention.tsx
@@ -164,7 +164,7 @@ export default defineComponent({
       SelectGroupOption,
       SelectIgnoredOption
       // We need to cast filteredOptionsRef's type since the render function
-      // is not compitable
+      // is not compatible
       // MentionOption { value: string, render?: (value: string) => VNodeChild }
       // SelectOption { value: string | number, render?: (value: string | number) => VNodeChild }
       // The 2 types are not compatible since `render`s are not compatible

--- a/src/notification/src/NotificationEnvironment.tsx
+++ b/src/notification/src/NotificationEnvironment.tsx
@@ -155,7 +155,7 @@ export const NotificationEnvironment = defineComponent({
       <Transition
         name="notification-transition"
         appear={true}
-        // convert to any since Element is not compitable with HTMLElement
+        // convert to any since Element is not compatible with HTMLElement
         onBeforeEnter={this.handleBeforeEnter as any}
         onAfterEnter={this.handleAfterEnter as any}
         onBeforeLeave={this.handleBeforeLeave as any}


### PR DESCRIPTION
Correct 'compitable' to 'compatible' in annotations, but please note that there are numerous variables and function names that include 'useCompitable,' which you may choose to change or leave as is.