### PR TITLE
fix(color2Class):处理rgba中的小数点

### DIFF
--- a/src/_utils/css/color-to-class.ts
+++ b/src/_utils/css/color-to-class.ts
@@ -1,3 +1,3 @@
 export function color2Class (color: string): string {
-  return color.replace(/#|\(|\)|,|\s/g, '_')
+  return color.replace(/#|\(|\)|,|\s/g, '_').replace(/./g, '')
 }


### PR DESCRIPTION
### 背景及现象
- 在n-config-provider组件中设置inline-theme-disabled为true时，以下组件如果使用自定义color，格式为rgba(0,0,0,0.3)
- 导致颜色设置设置不上

### 原因
- color2Class方法未处理小数点，导致类名无法解析

### 影响组件
- tag
- avatar
- badge
- button
- rate