### PR TITLE
fix(image,avatar): not trigger error event when set `lazy` only

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### NEXT_VERSION
+
+### Fixes
+
+- Fix `n-image` and `n-avatar` not trigger `error` event when set `lazy` prop only.
+
 ## 2.41.0
 
 ### Breaking Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-image` 和 `n-avatar` 单独设置 `lazy` 时未触发 `error` 事件
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/avatar/demos/enUS/lazy.demo.vue
+++ b/src/avatar/demos/enUS/lazy.demo.vue
@@ -21,7 +21,10 @@ export default defineComponent({
         'https://picsum.photos/id/9/100/100',
         'https://picsum.photos/id/10/100/100',
         'xxx.png'
-      ]
+      ],
+      handleLoadError(e: Event) {
+        console.error(e)
+      }
     }
   }
 })
@@ -35,7 +38,9 @@ export default defineComponent({
   </n-p>
   <n-avatar
     lazy
-    src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    src="xxx.png"
+    fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    @error="handleLoadError"
   />
   <n-p>
     use <n-text code>
@@ -61,6 +66,7 @@ export default defineComponent({
         :intersection-observer-options="{
           root: '#image-scroll-container',
         }"
+        @error="handleLoadError"
       />
     </n-space>
   </div>

--- a/src/avatar/demos/zhCN/lazy.demo.vue
+++ b/src/avatar/demos/zhCN/lazy.demo.vue
@@ -22,7 +22,10 @@ export default defineComponent({
         'https://picsum.photos/id/9/100/100',
         'https://picsum.photos/id/10/100/100',
         'xxx.png'
-      ]
+      ],
+      handleLoadError(e: Event) {
+        console.error(e)
+      }
     }
   }
 })
@@ -36,7 +39,9 @@ export default defineComponent({
   </n-p>
   <n-avatar
     lazy
-    src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    src="xxx.png"
+    fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    @error="handleLoadError"
   />
   <n-p>
     <n-text code>
@@ -62,6 +67,7 @@ export default defineComponent({
         :intersection-observer-options="{
           root: '#image-scroll-container',
         }"
+        @error="handleLoadError"
       />
     </n-space>
   </div>

--- a/src/image/demos/enUS/lazy.demo.vue
+++ b/src/image/demos/enUS/lazy.demo.vue
@@ -20,8 +20,12 @@ export default defineComponent({
         'https://picsum.photos/id/7/100/100',
         'https://picsum.photos/id/8/100/100',
         'https://picsum.photos/id/9/100/100',
-        'https://picsum.photos/id/10/100/100'
-      ]
+        'https://picsum.photos/id/10/100/100',
+        'xxx.png'
+      ],
+      handleLoadError(e: Event) {
+        console.error(e)
+      }
     }
   }
 })
@@ -36,7 +40,9 @@ export default defineComponent({
   <n-image
     lazy
     width="100"
-    src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    src="xxx.png"
+    fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    @error="handleLoadError"
   />
   <n-p>
     use <n-text code>
@@ -66,6 +72,7 @@ export default defineComponent({
       :intersection-observer-options="{
         root: '#image-scroll-container',
       }"
+      @error="handleLoadError"
     >
       <template #placeholder>
         <div

--- a/src/image/demos/zhCN/lazy.demo.vue
+++ b/src/image/demos/zhCN/lazy.demo.vue
@@ -21,8 +21,12 @@ export default defineComponent({
         'https://picsum.photos/id/7/100/100',
         'https://picsum.photos/id/8/100/100',
         'https://picsum.photos/id/9/100/100',
-        'https://picsum.photos/id/10/100/100'
-      ]
+        'https://picsum.photos/id/10/100/100',
+        'xxx.png'
+      ],
+      handleLoadError(e: Event) {
+        console.error(e)
+      }
     }
   }
 })
@@ -37,7 +41,9 @@ export default defineComponent({
   <n-image
     lazy
     width="100"
-    src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    src="xxx.png"
+    fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
+    @error="handleLoadError"
   />
   <n-p>
     <n-text code>
@@ -64,9 +70,11 @@ export default defineComponent({
       height="100"
       lazy
       :src="src"
+      fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
       :intersection-observer-options="{
         root: '#image-scroll-container',
       }"
+      @error="handleLoadError"
     >
       <template #placeholder>
         <div


### PR DESCRIPTION
closes  #6110

`lazy` 配合 `intersection-observer-options` 配置，使用 observe 实现的懒加载存在问题；改动的思路考虑了以下两种情况：
- 未指定视口元素 root：resolveOptionsAndHash 函数返回的 root 由 `document.documentElement` 改为了 `document` 根节点（应该要跟未指定 root 时一样吧，看了 w3c 的说明 [intersectionobserver-intersection-root ](https://w3c.github.io/IntersectionObserver/#intersectionobserver-intersection-root) 未指定 root 默认也是 document 节点）；否则如果采用 `document.documentElement`（指向 html 元素），html 元素的像素高度可能为 0（例如官方文档布局采用了绝对定位），导致 `entry.isIntersecting` 会永远为 true，图片不管是不是在浏览器视口内都会直接加载，采用 document 就解决了这个问题；
- 指定了 root；则需要观察两个元素的可见性（与浏览器视口是否相交），一个是指定视口相对于浏览器视口的可见性，一个是图片相对于指定视口的可见性，当两个可见性都为 true 才去加载图片；否则当指定视口还未到达浏览器视口，而图片由于是相对于指定视口判断可见性，此时若图片跟指定视口已相交，就会直接加载，应该在指定视口到达浏览器视口且图片跟指定视口相交，再加载图片。

