### PR TITLE
fix(input): Fix readonly mismatch on SSR

### DIFF
--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -1126,7 +1126,12 @@ export default defineComponent({
                         disabled={this.mergedDisabled}
                         maxlength={countGraphemes ? undefined : this.maxlength}
                         minlength={countGraphemes ? undefined : this.minlength}
-                        readonly={this.readonly as any}
+                        {...Object.assign(
+                          {},
+                          ['', true].includes(this.readonly) && {
+                            readonly: true
+                          }
+                        )}
                         tabindex={
                           this.passivelyActivated && !this.activated
                             ? -1
@@ -1209,7 +1214,10 @@ export default defineComponent({
                     ? this.mergedValue[0]
                     : (this.mergedValue as any)
                 }
-                readonly={this.readonly as any}
+                {...Object.assign(
+                  {},
+                  ['', true].includes(this.readonly) && { readonly: true }
+                )}
                 autofocus={this.autofocus}
                 size={this.attrSize}
                 onBlur={this.handleInputBlur}
@@ -1337,7 +1345,10 @@ export default defineComponent({
                     ? this.mergedValue[1]
                     : undefined
                 }
-                readonly={this.readonly as any}
+                {...Object.assign(
+                  {},
+                  ['', true].includes(this.readonly) && { readonly: true }
+                )}
                 style={this.textDecorationStyle[1] as any}
                 onBlur={this.handleInputBlur}
                 onFocus={(e) => {


### PR DESCRIPTION
solves(#5575)

If the attribute `readonly` is present it will be checked for hydration mismatch on `vue` >=v3.4.0  [source](https://github.com/vuejs/core/blob/a3725a729cc99dc0ebe7c50ca65f183b8ff30073/packages/runtime-core/src/hydration.ts#L761
).

The issue is related to the fact that the `key` represents the attribute name which is `readonly`. However the key of the HTML element is `readOnly`. This results to an incorrect evaluation when value is `false`. 

The proposed solution is to ignore the `readonly` attribute when its value is `false`.


