### PR TITLE
fix(image): Fix height & width mismatch on SSR

### DIFF
--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -152,12 +152,13 @@ export default defineComponent({
 
     const placeholderNode = this.$slots.placeholder?.()
     const loadSrc = this.src || imgProps.src
-
+    const imgWidth = this.width || imgProps.width
+    const imgHeight = this.height || imgProps.height
     const imgNode = h('img', {
       ...imgProps,
       ref: 'imageRef',
-      width: this.width || imgProps.width,
-      height: this.height || imgProps.height,
+      ...(imgWidth ? { width: imgWidth } : {}),
+      ...(imgHeight ? { height: imgHeight } : {}),
       src: this.showError
         ? this.fallbackSrc
         : lazy && this.intersectionObserverOptions


### PR DESCRIPTION
solves(#5575)

If the attributes `height` and `width` are present they will be checked for hydration mismatch on `vue` >=v3.4.0 [source](https://github.com/vuejs/core/blob/a3725a729cc99dc0ebe7c50ca65f183b8ff30073/packages/runtime-core/src/hydration.ts#L761).

On mount the `height` and `width` are automaticaly computed if not assigned. That would lead to mismatch. 

The proposed solution is to ignore them when no values are set.