### PR TITLE
fix(tree): Fix draggable mismatch on SSR

### DIFF
--- a/src/tree/src/TreeNodeContent.tsx
+++ b/src/tree/src/TreeNodeContent.tsx
@@ -71,7 +71,7 @@ export default defineComponent({
         ref="selfRef"
         class={[`${clsPrefix}-tree-node-content`, nodeProps?.class]}
         onClick={handleClick}
-        draggable={onDragstart === undefined ? undefined : true}
+        draggable={onDragstart === undefined ? 'false' : 'true'}
         onDragstart={onDragstart}
       >
         {renderPrefix || prefix ? (


### PR DESCRIPTION
solves(#5575)

If the attribute `draggable` is present it will be checked for hydration mismatch on `vue` >=v3.4.0 [source](https://github.com/vuejs/core/blob/a3725a729cc99dc0ebe7c50ca65f183b8ff30073/packages/runtime-core/src/hydration.ts#L761).

The issue is that the draggable attribute is not a Boolean but rather an Enumerated of `true` and `false` [source](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable).

The proposed solution is to convert the boolean value to a string.