### PR TITLE
fix(menu): resolve overflow issue with n-menu root-indent (#5616)

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `n-tree`'s `override-default-node-click-behavior` prop may conflict with default switcher click or checkbox click behavior.
+- Fix overflow issue with `n-menu` `root-indent` `indent`, closes (#5616)
 
 ## 2.37.3
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - 修复 `n-tree` 的 `override-default-node-click-behavior` 属性可能覆盖掉默认展开按钮和选中按钮的行为
+- 修复 `n-menu` `root-indent` `indent` 下内容溢出的问题，关闭(#5616)
 
 ## 2.37.3
 

--- a/src/menu/demos/zhCN/indent.demo.vue
+++ b/src/menu/demos/zhCN/indent.demo.vue
@@ -7,8 +7,8 @@
 <template>
   <n-menu
     v-model:value="activeKey"
-    :root-indent="0"
-    :indent="0"
+    :root-indent="36"
+    :indent="12"
     :options="menuOptions"
   />
 </template>

--- a/src/menu/demos/zhCN/indent.demo.vue
+++ b/src/menu/demos/zhCN/indent.demo.vue
@@ -7,8 +7,8 @@
 <template>
   <n-menu
     v-model:value="activeKey"
-    :root-indent="36"
-    :indent="12"
+    :root-indent="0"
+    :indent="0"
     :options="menuOptions"
   />
 </template>

--- a/src/menu/src/use-menu-child.ts
+++ b/src/menu/src/use-menu-child.ts
@@ -83,6 +83,7 @@ export function useMenuChild (props: UseMenuChildProps): UseMenuChild {
     if (horizontalRef.value) return undefined
     const { collapsedWidth, indent: propsIdent, rootIndent: propsRootIdent } = menuProps
     const { root, isGroup } = props
+    // Fix overflow issue with `n-menu` `root-indent` `indent`, closes (#5616)
     const indent = propsIdent + 8
     const rootIndent = propsRootIdent === undefined ? undefined : propsRootIdent + 8
     const mergedRootIndent = rootIndent === undefined ? indent : rootIndent

--- a/src/menu/src/use-menu-child.ts
+++ b/src/menu/src/use-menu-child.ts
@@ -81,8 +81,10 @@ export function useMenuChild (props: UseMenuChildProps): UseMenuChild {
   })
   const paddingLeftRef = computed(() => {
     if (horizontalRef.value) return undefined
-    const { collapsedWidth, indent, rootIndent } = menuProps
+    const { collapsedWidth, indent: propsIdent, rootIndent: propsRootIdent } = menuProps
     const { root, isGroup } = props
+    const indent = propsIdent + 8
+    const rootIndent = propsRootIdent === undefined ? undefined : propsRootIdent + 8
     const mergedRootIndent = rootIndent === undefined ? indent : rootIndent
     if (root) {
       if (mergedCollapsedRef.value) {
@@ -99,7 +101,7 @@ export function useMenuChild (props: UseMenuChildProps): UseMenuChild {
     if (NSubmenu && typeof NSubmenu.paddingLeftRef.value === 'number') {
       return (isGroup ? indent / 2 : indent) + NSubmenu.paddingLeftRef.value
     }
-    return 0
+    return 8
   })
   const iconMarginRightRef = computed(() => {
     const { collapsedWidth, indent, rootIndent } = menuProps


### PR DESCRIPTION
### Description of Changes
Adjusted the `paddingLeftRef` calculation logic to ensure proper left margin in different scenarios, addressing the issue of content overflow when setting a smaller root-indent in n-menu.

Fixed the calculation of the `::before` pseudo-element's left position, adjusting its default value to match the design expectation and preventing content overflow.
### Related Issue
Fixes #5616
