### PR TITLE
fix(n-result): show icons on re-render after hydration

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -14,6 +14,7 @@
 - Fix `n-form-item`'s feedback may hide and show again, closes [#5583](https://github.com/tusen-ai/naive-ui/issues/5583).
 - Fix `n-popselect`'s header make inner input unavailable, closes [#5494](https://github.com/tusen-ai/naive-ui/pull/5494).
 - Fix `n-qr-code`'s style of size.
+- Fix `n-result` built-in icons not re-rendered after hydration.
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -14,6 +14,7 @@
 - 修复 `n-form-item` 校验结果可能会闪烁的问题，关闭 [#5583](https://github.com/tusen-ai/naive-ui/issues/5583)
 - 修复 `n-popselect` 组件的 header 插槽里 input 无法输入，关闭 [#5494](https://github.com/tusen-ai/naive-ui/pull/5494)
 - 修复 `n-qr-code` 大小样式问题
+- Fix `n-result` built-in icons not re-rendered after hydration.
 
 ### Features
 

--- a/src/result/src/Result.tsx
+++ b/src/result/src/Result.tsx
@@ -25,14 +25,14 @@ import image403 from './403'
 import style from './styles/index.cssr'
 
 const iconMap = {
-  403: image403,
-  404: image404,
-  418: image418,
-  500: image500,
-  info: <InfoIcon />,
-  success: <SuccessIcon />,
-  warning: <WarningIcon />,
-  error: <ErrorIcon />
+  403: () => image403,
+  404: () => image404,
+  418: () => image418,
+  500: () => image500,
+  info: () => <InfoIcon />,
+  success: () => <SuccessIcon />,
+  warning: () => <WarningIcon />,
+  error: () => <ErrorIcon />
 }
 
 export const resultProps = {
@@ -130,7 +130,7 @@ export default defineComponent({
         <div class={`${mergedClsPrefix}-result-icon`}>
           {$slots.icon?.() || (
             <NBaseIcon clsPrefix={mergedClsPrefix}>
-              {{ default: () => iconMap[status] }}
+              {{ default: () => iconMap[status]() }}
             </NBaseIcon>
           )}
         </div>

--- a/src/result/src/Result.tsx
+++ b/src/result/src/Result.tsx
@@ -24,7 +24,7 @@ import image418 from './418'
 import image403 from './403'
 import style from './styles/index.cssr'
 
-const iconMap = {
+const iconRenderMap = {
   403: () => image403,
   404: () => image404,
   418: () => image418,
@@ -130,7 +130,7 @@ export default defineComponent({
         <div class={`${mergedClsPrefix}-result-icon`}>
           {$slots.icon?.() || (
             <NBaseIcon clsPrefix={mergedClsPrefix}>
-              {{ default: () => iconMap[status]() }}
+              {{ default: () => iconRenderMap[status]() }}
             </NBaseIcon>
           )}
         </div>


### PR DESCRIPTION
Related issue #4718 

When re-rendering `n-result` on client-side after hydration, the built-in default icons are not rendered. As mentioned in the related issue, this behaviour had already been solved on other components. The issue is around reactivity as explained in [comment](https://github.com/tusen-ai/naive-ui/issues/2721#issuecomment-1094085633).

This PR is based on the existant solution https://github.com/tusen-ai/naive-ui/commit/deb1a95c9689c225749278f89371f294161b8e23.
