### PR TITLE
Update Mention search mode startsWith to includes

### DIFF
--- a/src/mention/src/Mention.tsx
+++ b/src/mention/src/Mention.tsx
@@ -150,10 +150,10 @@ export default defineComponent({
       return props.options.filter((option) => {
         if (!pattern) return true
         if (typeof option.label === 'string') {
-          return option.label.startsWith(pattern)
+          return option.label.includes(pattern)
         }
         if (typeof option.value === 'string') {
-          return option.value.startsWith(pattern)
+          return option.value.includes(pattern)
         }
         return false
       })


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

采用的是 `startsWith` 进行匹配的 不支持包含 于是改为了 `includes` 进行匹配
远程加载 也是同样的问题 
我觉得如果采用远程搜索了 直接把数据渲染出来即可 不用再自己的搜索逻辑进行搜索了

![image](https://github.com/tusen-ai/naive-ui/assets/13518196/befa5f89-3432-4fab-81fc-1904c20718d1)
![image](https://github.com/tusen-ai/naive-ui/assets/13518196/a77ea142-746b-40a2-b885-efc027232482)
