### PR TITLE
feat(scrollbar): exposes some theme vars

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -17,6 +17,7 @@
 
 - `n-date-picker` adds `default-calendar-start-time` props when `type` is `'date'`/`'datetime'` or `'week'`, closes [#4493](https://github.com/tusen-ai/naive-ui/issues/4493).
 - `n-tree-select` adds `get-children` prop.
+- `n-scrollbar` exposes theme vars such as `width`, `height` and `border-radius`, closes [#5719](https://github.com/tusen-ai/naive-ui/issues/5719).
 
 ## 2.38.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,6 +17,7 @@
 
 - `n-date-picker` 在 `type` 为 `'date'`、`'datetime'` 或 `'week'` 时新增 `default-calendar-start-time` 属性，关闭 [#4493](https://github.com/tusen-ai/naive-ui/issues/4493)
 - `n-tree-select` 新增 `get-children` 属性
+- `n-scrollbar` 暴露主题变量 `width`、`height`、`border-radius`，关闭 [#5719](https://github.com/tusen-ai/naive-ui/issues/5719)
 
 ## 2.38.0
 

--- a/src/_internal/scrollbar/src/Scrollbar.tsx
+++ b/src/_internal/scrollbar/src/Scrollbar.tsx
@@ -646,21 +646,16 @@ const Scrollbar = defineComponent({
     )
     const cssVarsRef = computed(() => {
       const {
-        common: {
-          cubicBezierEaseInOut,
-          scrollbarBorderRadius,
-          scrollbarHeight,
-          scrollbarWidth
-        },
-        self: { color, colorHover }
+        common: { cubicBezierEaseInOut },
+        self: { color, colorHover, borderRadius, height, width }
       } = themeRef.value
       return {
         '--n-scrollbar-bezier': cubicBezierEaseInOut,
         '--n-scrollbar-color': color,
         '--n-scrollbar-color-hover': colorHover,
-        '--n-scrollbar-border-radius': scrollbarBorderRadius,
-        '--n-scrollbar-width': scrollbarWidth,
-        '--n-scrollbar-height': scrollbarHeight
+        '--n-scrollbar-border-radius': borderRadius,
+        '--n-scrollbar-width': width,
+        '--n-scrollbar-height': height
       }
     })
     const themeClassHandle = inlineThemeDisabled

--- a/src/_internal/scrollbar/styles/light.ts
+++ b/src/_internal/scrollbar/styles/light.ts
@@ -3,10 +3,19 @@ import type { ThemeCommonVars } from '../../../_styles/common'
 import type { Theme } from '../../../_mixins'
 
 export const self = (vars: ThemeCommonVars) => {
-  const { scrollbarColor, scrollbarColorHover } = vars
+  const {
+    scrollbarColor,
+    scrollbarColorHover,
+    scrollbarWidth,
+    scrollbarHeight,
+    scrollbarBorderRadius
+  } = vars
   return {
     color: scrollbarColor,
-    colorHover: scrollbarColorHover
+    colorHover: scrollbarColorHover,
+    width: scrollbarWidth,
+    height: scrollbarHeight,
+    borderRadius: scrollbarBorderRadius
   }
 }
 


### PR DESCRIPTION
closes #5719

---
目前 Scrollbar 组件的 `size` prop 只能修改 y bar 的高度，x bar 的宽度，如果主题变量暴露 `scrollbarWidth`，`scrollbarHeight`，对应修改的是 y bar 的宽度，x bar 的高度，这样要调整 Scrollbar 的尺寸就得需要从两个地方去修改，是不是不太好