### PR TITLE
Fix `n-tabs` whose `type` is `'segment'` has capsule with wrong style

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -12,6 +12,7 @@
 - Fix `n-tabs`'s capsule wrong width and position after resize within `n-modal`, closes [#5569](https://github.com/tusen-ai/naive-ui/issues/5569).
 - Fix `n-split` doesn't work with `inline-theme-disabled` prop.
 - Fix `n-float-button` doesn't work with `inline-theme-disabled` prop.
+- Fix `n-tabs` whose `type` is `'segment'` has capsule with wrong style, closes [#5728](https://github.com/tusen-ai/naive-ui/issues/5728).
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -12,6 +12,7 @@
 - 修复 `n-tabs` 在 `n-modal` 内部时，胶囊在 tabs 大小改变后有错误的位置和宽度，关闭 [#5569](https://github.com/tusen-ai/naive-ui/issues/5569)
 - 修复 `n-split` 不支持 `inline-theme-disabled` 属性
 - 修复 `n-float-button` 不支持 `inline-theme-disabled` 属性
+- 修复 `n-tabs` 在 `type` 为 `'segment'` 时候，胶囊样式存在问题， 关闭 [#5728](https://github.com/tusen-ai/naive-ui/issues/5728)
 
 ### Features
 

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -433,9 +433,7 @@ export default defineComponent({
         segmentCapsuleElRef.value.style.width = `${activeTabEl.offsetWidth}px`
         segmentCapsuleElRef.value.style.height = `${activeTabEl.offsetHeight}px`
         segmentCapsuleElRef.value.style.transform = `translateX(${
-          activeTabEl.offsetLeft -
-          tabsEl.offsetLeft -
-          depx(getComputedStyle(tabsEl).paddingLeft)
+          activeTabEl.offsetLeft - depx(getComputedStyle(tabsEl).paddingLeft)
         }px)`
         if (transitionDisabled) {
           void segmentCapsuleElRef.value.offsetWidth

--- a/src/tabs/src/styles/index.cssr.ts
+++ b/src/tabs/src/styles/index.cssr.ts
@@ -96,6 +96,7 @@ export default cB('tabs', `
     `)
   ]),
   cB('tabs-rail', `
+    position: relative;
     padding: 3px;
     border-radius: var(--n-tab-border-radius);
     width: 100%;


### PR DESCRIPTION
closes [#5728](https://github.com/tusen-ai/naive-ui/issues/5728).
