### PR TITLE
fix: get*String() methods for UTC/locale mismatch

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix the get\*String() methods for UTC/locale mismatch
+- Fix the get\*String() methods for UTC/locale mismatch, closes [#5702](closes https://github.com/tusen-ai/naive-ui/issues/5702)
 
 ## 2.38.1
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix the get\*String() methods for UTC/locale mismatch
+
 ## 2.38.1
 
 `2024-02-26`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 get\*String() 方法中 UTC/区域设置不匹配的问题
+
 ## 2.38.1
 
 `2024-02-26`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- 修复 get\*String() 方法中 UTC/区域设置不匹配的问题
+- 修复 get\*String() 方法中 UTC/区域设置不匹配的问题，关闭 [#5702](https://github.com/tusen-ai/naive-ui/issues/5702)
 
 ## 2.38.1
 

--- a/src/date-picker/src/utils.ts
+++ b/src/date-picker/src/utils.ts
@@ -195,7 +195,7 @@ function getMonthString (
   monthFormat: string,
   locale: NDateLocale['locale']
 ): string {
-  const date = Date.UTC(2000, month, 1)
+  const date = new Date(2000, month, 1).getTime()
   return format(date, monthFormat, { locale })
 }
 
@@ -204,7 +204,7 @@ function getYearString (
   yearFormat: string,
   locale: NDateLocale['locale']
 ): string {
-  const date = Date.UTC(year, 1, 1)
+  const date = new Date(year, 1, 1).getTime()
   return format(date, yearFormat, { locale })
 }
 
@@ -213,7 +213,7 @@ function getQuarterString (
   quarterFormat: string,
   locale: NDateLocale['locale']
 ): string {
-  const date = Date.UTC(2000, quarter * 3 - 2, 1)
+  const date = new Date(2000, quarter * 3 - 2, 1).getTime()
   return format(date, quarterFormat, { locale })
 }
 


### PR DESCRIPTION
As noted in https://github.com/tusen-ai/naive-ui/issues/5702, the client is getting a UTC timestamp and then getting a locale-based format. In doing so, the month can be off if your UTC offset takes you into another month. In my case, being GMT-8, the timestamp was at 4pm on the final day of the previous month.

Noticed with getMonthString(), but fixing for the others as well just in case.

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

closes #5702 