### PR TITLE
Fix `n-dialog` throws an error when dialog has been closed

### DIFF
--- a/src/dialog/src/DialogProvider.ts
+++ b/src/dialog/src/DialogProvider.ts
@@ -90,7 +90,7 @@ export const NDialogProvider = defineComponent({
         ...options,
         key,
         destroy: () => {
-          dialogInstRefs[`n-dialog-${key}`].hide()
+          dialogInstRefs[`n-dialog-${key}`]?.hide()
         }
       })
       dialogListRef.value.push(dialogReactive)


### PR DESCRIPTION
added an optional chaining to check if dialog exists
![image](https://github.com/tusen-ai/naive-ui/assets/48887270/72ae15f8-228b-42c0-854f-8a1bd1f76e19)
