### PR TITLE
feat(n-qr-code): adds `type` prop, Customize rendering output by setting `type`, providing two options: `canvas` and `svg`.

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Features
+
+- `n-qr-code` adds `type` prop, Customize rendering output by setting `type`, providing two options: `canvas` and `svg`.
+
 ## 2.38.1
 
 `2024-02-26`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Features
+
+- `n-qr-code` 新增 `type` 属性，设置 `type` 自定义渲染结果，提供 `canvas` 和 `svg` 两个选项
+
 ## 2.38.1
 
 `2024-02-26`

--- a/src/qr-code/demos/enUS/index.demo-entry.md
+++ b/src/qr-code/demos/enUS/index.demo-entry.md
@@ -13,6 +13,7 @@ size.vue
 color.vue
 error-correction.vue
 download.vue
+type.vue
 ```
 
 ## API
@@ -31,6 +32,7 @@ download.vue
 | padding | `number \| string` | `12` | Padding size of the QR Code. | 2.36.0 |
 | value | `string` | `''` | Text information. | 2.36.0 |
 | size | `number` | `100` | Size of the qrcode. | 2.36.0 |
+| type | `'canvas'` \| `'svg'` | `'canvas'` | Customize Render Type. | NEXT_VERSION |
 
 ### About QR code error correction level
 

--- a/src/qr-code/demos/enUS/type.demo.vue
+++ b/src/qr-code/demos/enUS/type.demo.vue
@@ -1,0 +1,26 @@
+<markdown>
+# Customize Render Type
+
+Customize rendering output by setting `type`, providing two options: `canvas` and `svg`.
+
+</markdown>
+
+<template>
+  <n-space>
+    <n-qr-code :value="text" type="canvas" />
+    <n-qr-code :value="text" type="svg" />
+  </n-space>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup () {
+    const text = ref('The rain dampened the sky')
+    return {
+      text
+    }
+  }
+})
+</script>

--- a/src/qr-code/demos/zhCN/index.demo-entry.md
+++ b/src/qr-code/demos/zhCN/index.demo-entry.md
@@ -13,6 +13,7 @@ size.vue
 color.vue
 error-correction.vue
 download.vue
+type.vue
 ```
 
 ## API
@@ -31,6 +32,7 @@ download.vue
 | padding | `number \| string` | `12` | 二维码填充大小 | 2.36.0 |
 | value | `string` | `''` | 文本信息 | 2.36.0 |
 | size | `number` | `100` | 二维码大小 | 2.36.0 |
+| type | `'canvas'` \| `'svg'` | `'canvas'` | 自定义二维码渲染类型 | NEXT_VERSION |
 
 ### 关于二维码纠错级别
 

--- a/src/qr-code/demos/zhCN/type.demo.vue
+++ b/src/qr-code/demos/zhCN/type.demo.vue
@@ -1,0 +1,26 @@
+<markdown>
+# 自定义渲染类型
+
+通过设置 `type` 自定义渲染结果，提供 `canvas` 和 `svg` 两个选项。
+
+</markdown>
+
+<template>
+  <n-space>
+    <n-qr-code :value="text" type="canvas" />
+    <n-qr-code :value="text" type="svg" />
+  </n-space>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup () {
+    const text = ref('雨淋湿了天空')
+    return {
+      text
+    }
+  }
+})
+</script>

--- a/src/qr-code/src/qrcodegen.ts
+++ b/src/qr-code/src/qrcodegen.ts
@@ -265,6 +265,11 @@ namespace qrcodegen {
       )
     }
 
+    // Modified to expose modules for easy access
+    public getModules (): boolean[][] {
+      return this.modules
+    }
+
     /* -- Private helper methods for constructor: Drawing function modules -- */
 
     // Reads this object's version field, and draws and marks all function modules.


### PR DESCRIPTION
closes https://github.com/tusen-ai/naive-ui/issues/5743.