### PR TITLE
fix(auto-complete): use option's `value` instead of `label` for update value

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### NEXT_VERSION
+
+### Fixes
+
+- Fix `n-auto-complete` should use option's `value` instead of `label` for update value, closes [5794](https://github.com/tusen-ai/naive-ui/issues/5794).
+
 ## 2.41.0
 
 ### Breaking Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### NEXT_VERSION
+
+### Fixes
+
+- Fix `n-auto-complete` should use option's `value` instead of `label` for update value, closes [5794](https://github.com/tusen-ai/naive-ui/issues/5794).
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -258,11 +258,11 @@ export default defineComponent({
         if (props.clearAfterSelect) {
           doUpdateValue(null)
         }
-        else if (option.label !== undefined) {
+        else {
           doUpdateValue(
             props.append
-              ? `${mergedValueRef.value}${option.label}`
-              : option.label
+              ? `${mergedValueRef.value}${option.value}`
+              : option.value
           )
         }
         canBeActivatedRef.value = false


### PR DESCRIPTION
closes #5794
