### PR TITLE
fix(n-data-table): chinese garbled characters when exporting `CSV`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -14,6 +14,7 @@
 - Fix `useModal` setting `card` preset without corresponding props in `n-card` slots, closes [#5746](https://github.com/tusen-ai/naive-ui/issues/5746).
 - Fix `Submenu` component's wai-aria role setting error of `n-menu`，closes [#5729](https://github.com/tusen-ai/naive-ui/issues/5729).
 - Fix the `common` type error in the `theme-overrides` prop when modifying components' themes.
+- Fix `n-data-table` Chinese garbled characters when exporting `CSV`, closes [#5819](closes https://github.com/tusen-ai/naive-ui/issues/5819)
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -14,6 +14,7 @@
 - 修复 `n-dialog` / `n-modal` 调用 `destroy` 方法时可能会报错
 - 修复 `useModal` 设置 `card` 预设时 `n-card` 插槽缺少相应属性，关闭 [#5746](https://github.com/tusen-ai/naive-ui/issues/5746)
 - 修复组件调整主题时 `theme-overrides` 属性中的 `common` 类型报错
+- 修复 `n-data-table` 导出 `CSV` 时中文乱码问题，关闭 [#5819](https://github.com/tusen-ai/naive-ui/issues/5819)
 
 ### Features
 

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -111,7 +111,7 @@ export default defineComponent({
     const downloadCsv = (options?: CsvOptionsType): void => {
       const { fileName = 'data.csv', keepOriginalData = false } = options || {}
       const data = keepOriginalData ? props.data : rawPaginatedDataRef.value
-      const csvData = generateCsv(props.columns, data)
+      const csvData = '\uFEFF' + generateCsv(props.columns, data)
       const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' })
       const downloadUrl = URL.createObjectURL(blob)
       download(


### PR DESCRIPTION
close https://github.com/tusen-ai/naive-ui/issues/5819