### PR TITLE
feat(tree): batch render method adds node info `expanded`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -30,6 +30,7 @@
 - `n-form-item` add `feedback-vertical` prop and `feedback-crosswise` prop
 - `n-split` supports setting the pixel value size.
 - `n-scrollbar` adds `content-style` and `content-class` props, closes [#4497](https://github.com/tusen-ai/naive-ui/issues/4497).
+- `n-tree` adds node infomation `expanded` for `render-label`, `render-prefix` and `render-suffix` props, closes [#5865](https://github.com/tusen-ai/naive-ui/issues/5865).
 
 ## 2.38.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -30,6 +30,7 @@
 - `n-form-item` 新增 `feedback-vertical` 和 `feedback-crosswise` 属性
 - `n-split` 支持设置像素值大小
 - `n-scrollbar` 新增 `content-style` 和 `content-class` 属性，关闭 [#4497](https://github.com/tusen-ai/naive-ui/issues/4497)
+- `n-tree` 为 `render-label`、`render-prefix` 和 `render-suffix` 属性添加节点信息 `expanded`，关闭 [#5865](https://github.com/tusen-ai/naive-ui/issues/5865)
 
 ## 2.38.1
 

--- a/src/tree/demos/enUS/file-tree.demo.vue
+++ b/src/tree/demos/enUS/file-tree.demo.vue
@@ -1,7 +1,7 @@
 <markdown>
 # File Tree
 
-Use `on-update:expanded-keys` to change the prefix icon style of the node in different states.
+Use `on-update:expanded-keys` or `render-prefix` to change the prefix icon style of the node in different states.
 </markdown>
 
 <template>
@@ -11,6 +11,13 @@ Use `on-update:expanded-keys` to change the prefix icon style of the node in dif
     :data="data"
     :node-props="nodeProps"
     :on-update:expanded-keys="updatePrefixWithExpaned"
+  />
+  <n-tree
+    block-line
+    expand-on-click
+    :data="data2"
+    :node-props="nodeProps"
+    :render-prefix="renderPrefix"
   />
 </template>
 
@@ -26,14 +33,14 @@ import {
 export default defineComponent({
   setup () {
     const message = useMessage()
-    const updatePrefixWithExpaned = (
+    function updatePrefixWithExpaned (
       _keys: Array<string | number>,
       _option: Array<TreeOption | null>,
       meta: {
         node: TreeOption | null
         action: 'expand' | 'collapse' | 'filter'
       }
-    ) => {
+    ) {
       if (!meta.node) return
       switch (meta.action) {
         case 'expand':
@@ -50,7 +57,26 @@ export default defineComponent({
           break
       }
     }
-    const nodeProps = ({ option }: { option: TreeOption }) => {
+    function renderPrefix ({
+      option,
+      expanded
+    }: {
+      option: TreeOption
+      expanded: boolean
+    }) {
+      return option.children
+        ? expanded
+          ? h(NIcon, null, {
+            default: () => h(FolderOpenOutline)
+          })
+          : h(NIcon, null, {
+            default: () => h(Folder)
+          })
+        : h(NIcon, null, {
+          default: () => h(FileTrayFullOutline)
+        })
+    }
+    function nodeProps ({ option }: { option: TreeOption }) {
       return {
         onClick () {
           if (!option.children && !option.disabled) {
@@ -61,6 +87,7 @@ export default defineComponent({
     }
     return {
       updatePrefixWithExpaned,
+      renderPrefix,
       nodeProps,
       data: [
         {
@@ -95,6 +122,31 @@ export default defineComponent({
                     h(NIcon, null, {
                       default: () => h(FileTrayFullOutline)
                     })
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      data2: [
+        {
+          key: 'Folder',
+          label: 'Folder',
+
+          children: [
+            {
+              key: 'Empty',
+              label: 'Empty',
+              disabled: true
+            },
+            {
+              key: 'MyFiles',
+              label: 'MyFiles',
+
+              children: [
+                {
+                  label: 'template.txt',
+                  key: 'template.txt'
                 }
               ]
             }

--- a/src/tree/demos/zhCN/file-tree.demo.vue
+++ b/src/tree/demos/zhCN/file-tree.demo.vue
@@ -1,7 +1,7 @@
 <markdown>
 # 文件树
 
-使用 `on-update:expanded-keys` 来更改节点在不同状态下的前缀图标样式。
+使用 `on-update:expanded-keys` 或 `render-prefix` 来更改节点在不同状态下的前缀图标样式。
 </markdown>
 
 <template>
@@ -11,6 +11,13 @@
     :data="data"
     :node-props="nodeProps"
     :on-update:expanded-keys="updatePrefixWithExpaned"
+  />
+  <n-tree
+    block-line
+    expand-on-click
+    :data="data2"
+    :node-props="nodeProps"
+    :render-prefix="renderPrefix"
   />
 </template>
 
@@ -26,14 +33,14 @@ import {
 export default defineComponent({
   setup () {
     const message = useMessage()
-    const updatePrefixWithExpaned = (
+    function updatePrefixWithExpaned (
       _keys: Array<string | number>,
       _option: Array<TreeOption | null>,
       meta: {
         node: TreeOption | null
         action: 'expand' | 'collapse' | 'filter'
       }
-    ) => {
+    ) {
       if (!meta.node) return
       switch (meta.action) {
         case 'expand':
@@ -50,7 +57,26 @@ export default defineComponent({
           break
       }
     }
-    const nodeProps = ({ option }: { option: TreeOption }) => {
+    function renderPrefix ({
+      option,
+      expanded
+    }: {
+      option: TreeOption
+      expanded: boolean
+    }) {
+      return option.children
+        ? expanded
+          ? h(NIcon, null, {
+            default: () => h(FolderOpenOutline)
+          })
+          : h(NIcon, null, {
+            default: () => h(Folder)
+          })
+        : h(NIcon, null, {
+          default: () => h(FileTrayFullOutline)
+        })
+    }
+    function nodeProps ({ option }: { option: TreeOption }) {
       return {
         onClick () {
           if (!option.children && !option.disabled) {
@@ -61,6 +87,7 @@ export default defineComponent({
     }
     return {
       updatePrefixWithExpaned,
+      renderPrefix,
       nodeProps,
       data: [
         {
@@ -95,6 +122,29 @@ export default defineComponent({
                     h(NIcon, null, {
                       default: () => h(FileTrayFullOutline)
                     })
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      data2: [
+        {
+          key: '文件夹',
+          label: '文件夹',
+          children: [
+            {
+              key: '空的',
+              label: '空的',
+              disabled: true
+            },
+            {
+              key: '我的文件',
+              label: '我的文件',
+              children: [
+                {
+                  label: 'template.txt',
+                  key: 'template.txt'
                 }
               ]
             }

--- a/src/tree/demos/zhCN/index.demo-entry.md
+++ b/src/tree/demos/zhCN/index.demo-entry.md
@@ -73,9 +73,9 @@ expand-debug.vue
 | on-load | `(node: TreeOption) => Promise<unknown>` | `undefined` | 异步加载数据的回调函数，如果没有加载到数据你应该让 Promise resolve `false` 或者 reject 这个 Promise，否则加载动画不会停止 | 非 void Promise 2.34.3 |
 | override-default-node-click-behavior | `(info: { option: TreeOption }) => 'toggleExpand' \| 'toggleSelect' \| 'toggleCheck' \| 'default' \| 'none'` | `undefined` | 覆盖默认的节点点击行为 | 2.37.0 |
 | pattern | `string` | `''` | 默认搜索的内容 |  |
-| render-label | `(info: { option: TreeOption, checked: boolean, selected: boolean }) => VNodeChild` | `undefined` | 节点内容的渲染函数 |  |
-| render-prefix | `(info: { option: TreeOption, checked: boolean, selected: boolean }) => VNodeChild` | `undefined` | 节点前缀的渲染函数 |  |
-| render-suffix | `(info: { option: TreeOption, checked: boolean, selected: boolean }) => VNodeChild` | `undefined` | 节点后缀的渲染函数 |  |
+| render-label | `(info: { option: TreeOption, checked: boolean, selected: boolean, expanded: boolean }) => VNodeChild` | `undefined` | 节点内容的渲染函数 | `expanded` NEXT_VERSION |
+| render-prefix | `(info: { option: TreeOption, checked: boolean, selected: boolean, expanded: boolean }) => VNodeChild` | `undefined` | 节点前缀的渲染函数 | `expanded` NEXT_VERSION |
+| render-suffix | `(info: { option: TreeOption, checked: boolean, selected: boolean, expanded: boolean }) => VNodeChild` | `undefined` | 节点后缀的渲染函数 | `expanded` NEXT_VERSION |
 | render-switcher-icon | `(props: { option: TreeOption, expanded: boolean, selected: boolean }) => VNodeChild` | `undefined` | 节点展开开关的渲染函数 | 2.24.0, `props` 2.34.0 |
 | scrollbar-props | `object` | `undefined` | 属性参考 [Scrollbar props](scrollbar#Scrollbar-Props) |   |
 | selectable | `boolean` | `true` | 节点是否可以被选中 |  |

--- a/src/tree/src/TreeNode.tsx
+++ b/src/tree/src/TreeNode.tsx
@@ -484,6 +484,7 @@ const TreeNode = defineComponent({
             clsPrefix={clsPrefix}
             checked={checked}
             selected={selected}
+            expanded={this.expanded}
             onClick={this.handleContentClick}
             nodeProps={blockLine ? undefined : nodeProps}
             onDragstart={

--- a/src/tree/src/TreeNodeContent.tsx
+++ b/src/tree/src/TreeNodeContent.tsx
@@ -17,6 +17,7 @@ export default defineComponent({
       required: true
     },
     disabled: Boolean,
+    expanded: Boolean,
     checked: Boolean,
     selected: Boolean,
     onClick: Function as PropType<(e: MouseEvent) => void>,
@@ -55,6 +56,7 @@ export default defineComponent({
       nodeProps,
       checked = false,
       selected = false,
+      expanded,
       renderLabel,
       renderPrefix,
       renderSuffix,
@@ -80,7 +82,8 @@ export default defineComponent({
               ? renderPrefix({
                 option: rawNode,
                 selected,
-                checked
+                checked,
+                expanded
               })
               : render(prefix)}
           </div>
@@ -90,7 +93,8 @@ export default defineComponent({
             ? renderLabel({
               option: rawNode,
               selected,
-              checked
+              checked,
+              expanded
             })
             : render(label)}
         </div>
@@ -100,7 +104,8 @@ export default defineComponent({
               ? renderSuffix({
                 option: rawNode,
                 selected,
-                checked
+                checked,
+                expanded
               })
               : render(suffix)}
           </div>

--- a/src/tree/src/interface.ts
+++ b/src/tree/src/interface.ts
@@ -28,12 +28,14 @@ export interface TreeRenderProps {
   option: TreeOption
   checked: boolean
   selected: boolean
+  expanded: boolean
 }
 
 type RenderTreePart = ({
   option,
   checked,
-  selected
+  selected,
+  expanded
 }: TreeRenderProps) => VNodeChild
 
 export type RenderLabel = RenderTreePart


### PR DESCRIPTION
closes #5865