### PR TITLE
feat(date-picker): customize default year picker range

### DIFF
--- a/src/date-picker/demos/zhCN/index.demo-entry.md
+++ b/src/date-picker/demos/zhCN/index.demo-entry.md
@@ -41,6 +41,7 @@ form-debug.vue
 | --- | --- | --- | --- | --- |
 | clearable | `boolean` | `false` | 是否支持清除 |  |
 | default-value | `number \| [number, number] \| null` | `undefined` | 默认被选中的日期的时间戳 |  |
+| default-year-range | `[number, number]` | `[1901,2100]` | 设置面板中默认的年份选择范围 |  |
 | default-formatted-value | `string \| [string, string] \| null` | `undefined` | Date Picker 格式化后的值 |  |
 | disabled | `boolean` | `false` | 是否禁用 |  |
 | first-day-of-week | `0 \| 1 \| 2 \| 3 \| 4 \| 5 \| 6` | `undefined` | 日历上一周的开始，0 代表周一 |  |

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -91,6 +91,7 @@ export const datePickerProps = {
   defaultValue: [Number, Array] as PropType<Value | null>,
   defaultFormattedValue: [String, Array] as PropType<FormattedValue | null>,
   defaultTime: [Number, String, Array] as PropType<DefaultTime>,
+  defaultYearRange: Array as PropType<number[]>,
   disabled: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined
@@ -790,7 +791,8 @@ export default defineComponent({
       quarterFormatRef: toRef(props, 'quarterFormat'),
       ...uniVaidation,
       ...dualValidation,
-      datePickerSlots: slots
+      datePickerSlots: slots,
+      defaultYearRange: props.defaultYearRange
     })
 
     const exposedMethods: DatePickerInst = {

--- a/src/date-picker/src/config.ts
+++ b/src/date-picker/src/config.ts
@@ -1,4 +1,5 @@
 export const START_YEAR = 1901
+export const DEFAULT_RANGE = 200
 // TODO: we need to remove it to make height customizable
 export const MONTH_ITEM_HEIGHT = 40
 

--- a/src/date-picker/src/interface.ts
+++ b/src/date-picker/src/interface.ts
@@ -126,6 +126,7 @@ export type DatePickerInjection = {
   yearFormatRef: Ref<string>
   quarterFormatRef: Ref<string>
   datePickerSlots: Slots
+  defaultYearRange: number[] | undefined
 } & ReturnType<typeof uniCalendarValidation> &
 ReturnType<typeof dualCalendarValidation>
 

--- a/src/date-picker/src/panel/use-calendar.ts
+++ b/src/date-picker/src/panel/use-calendar.ts
@@ -78,7 +78,8 @@ function useCalendar (
     datePickerSlots,
     yearFormatRef,
     monthFormatRef,
-    quarterFormatRef
+    quarterFormatRef,
+    defaultYearRange
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   } = inject(datePickerInjectionKey)!
   const validation = {
@@ -131,9 +132,14 @@ function useCalendar (
   })
   const yearArrayRef = computed(() => {
     const { value } = props
-    return yearArray(Array.isArray(value) ? null : value, nowRef.value, {
-      yearFormat: yearFormatRef.value
-    })
+    return yearArray(
+      Array.isArray(value) ? null : value,
+      nowRef.value,
+      {
+        yearFormat: yearFormatRef.value
+      },
+      defaultYearRange
+    )
   })
   const quarterArrayRef = computed(() => {
     const { value } = props
@@ -489,6 +495,7 @@ function useCalendar (
 
   function justifyColumnsScrollState (value?: number): void {
     const { value: mergedValue } = props
+    const [startYear = START_YEAR] = defaultYearRange || []
     if (monthScrollbarRef.value) {
       const monthIndex =
         value === undefined
@@ -504,7 +511,7 @@ function useCalendar (
           ? mergedValue === null
             ? getYear(Date.now())
             : getYear(mergedValue as number)
-          : getYear(value)) - START_YEAR
+          : getYear(value)) - startYear
       yearVlRef.value.scrollTo({ top: yearIndex * MONTH_ITEM_HEIGHT })
     }
   }

--- a/src/date-picker/src/panel/use-dual-calendar.ts
+++ b/src/date-picker/src/panel/use-dual-calendar.ts
@@ -81,7 +81,8 @@ function useDualCalendar (
     datePickerSlots,
     monthFormatRef,
     yearFormatRef,
-    quarterFormatRef
+    quarterFormatRef,
+    defaultYearRange
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   } = inject(datePickerInjectionKey)!
   const validation = {
@@ -367,7 +368,9 @@ function useDualCalendar (
   function mergedIsDateDisabled (ts: number): boolean {
     const isDateDisabled = isDateDisabledRef.value
     if (!isDateDisabled) return false
-    if (!Array.isArray(props.value)) { return (isDateDisabled as IsRangeDateDisabled)(ts, 'start', null) }
+    if (!Array.isArray(props.value)) {
+      return (isDateDisabled as IsRangeDateDisabled)(ts, 'start', null)
+    }
     if (selectingPhaseRef.value === 'start') {
       // before you really start to select
       return (isDateDisabled as IsRangeDateDisabled)(ts, 'start', null)
@@ -692,6 +695,7 @@ function useDualCalendar (
     type?: 'start' | 'end' | undefined
   ): void {
     const mergedValue = value === undefined ? props.value : value
+    const [startYear = START_YEAR] = defaultYearRange || []
     if (value === undefined || type === 'start') {
       if (startMonthScrollbarRef.value) {
         const monthIndex = !Array.isArray(mergedValue)
@@ -707,7 +711,7 @@ function useDualCalendar (
         const yearIndex =
           (!Array.isArray(mergedValue)
             ? getYear(Date.now())
-            : getYear(mergedValue[0])) - START_YEAR
+            : getYear(mergedValue[0])) - startYear
         startYearVlRef.value.scrollTo({ index: yearIndex, debounce: false })
       }
     }
@@ -726,7 +730,7 @@ function useDualCalendar (
         const yearIndex =
           (!Array.isArray(mergedValue)
             ? getYear(Date.now())
-            : getYear(mergedValue[1])) - START_YEAR
+            : getYear(mergedValue[1])) - startYear
         endYearVlRef.value.scrollTo({ index: yearIndex, debounce: false })
       }
     }

--- a/src/date-picker/src/utils.ts
+++ b/src/date-picker/src/utils.ts
@@ -21,7 +21,7 @@ import {
   isSameWeek
 } from 'date-fns/esm'
 import type { NDateLocale } from '../../locales'
-import { START_YEAR } from './config'
+import { START_YEAR, DEFAULT_RANGE } from './config'
 import type { FirstDayOfWeek, Value } from './interface'
 
 function getDerivedTimeFromKeyboardEvent (
@@ -445,14 +445,18 @@ function yearArray (
   currentTs: number,
   format: {
     yearFormat: string
-  }
+  },
+  defaultYearRange?: number[]
 ): YearItem[] {
   const calendarYears: YearItem[] = []
-  const time1900 = new Date(START_YEAR, 0, 1)
+  const [startYear = START_YEAR, endYear] = defaultYearRange || []
+  const time1900 = new Date(startYear, 0, 1)
   // 1900 is not a round time, so we use 1911 as start...
   // new Date(1900, 0, 1)
   // 1899-12-31T15:54:17.000Z
-  for (let i = 0; i < 200; i++) {
+  const range = startYear && endYear ? endYear - startYear : DEFAULT_RANGE
+
+  for (let i = 0; i < range; i++) {
     calendarYears.push(
       yearItem(getTime(addYears(time1900, i)), valueTs, currentTs, format)
     )


### PR DESCRIPTION
Configure the maximum and minimum selection range for the year of realization. Normally we shouldn't restrict this range to only a particular interval

<img width="471" alt="2024-05-22 11 44 51" src="https://github.com/tusen-ai/naive-ui/assets/48376511/5c9fd9c9-fc5e-4822-b868-4c89a8ce4f14">
