### PR TITLE
✨ feat(select): Option to keep the label of the selected item if it i…

### DIFF
--- a/src/select/demos/zhCN/index.demo-entry.md
+++ b/src/select/demos/zhCN/index.demo-entry.md
@@ -60,6 +60,7 @@ create-debug.vue
 | filter | `(pattern: string, option: object) => boolean` | 一个简单的字符串搜索算法 | 过滤器函数 |  |
 | ignore-composition | `boolean` | `true` | 忽略输入法 Composition 状态，默认情况下 `filter` 在输入法输入的过程中不会触发 | 2.33.4 |
 | input-props | `InputHTMLAttributes` | `undefined` | 触发器中 input 元素的属性，只在可过滤时有意义 |  |
+| keep-filter-label | `boolean` | `false` | 是否在可过滤且单选的情况下保留选中项的label | |
 | keyboard | `boolean` | `true` | 是否支持键盘操作 | 2.34.4 |
 | label-field | `string` | `'label'` | 选项 label 的字段名 | 2.29.1 |
 | loading | `boolean` | `false` | 是否为加载状态 |  |

--- a/src/select/src/Select.tsx
+++ b/src/select/src/Select.tsx
@@ -98,6 +98,10 @@ export const selectProps = {
     type: [String, Number, Array] as PropType<Value | null>,
     default: null
   },
+  keepFilterLabel: {
+    type: Boolean,
+    default: false
+  },
   keyboard: {
     type: Boolean,
     default: true
@@ -487,7 +491,13 @@ export default defineComponent({
       doUpdateShow(false)
     }
     function handleMenuAfterLeave (): void {
-      patternRef.value = ''
+      const { multiple, keepFilterLabel, filterable } = props
+      if (!multiple && filterable && keepFilterLabel) {
+        patternRef.value = triggerRef.value.label ?? ''
+      } else {
+        patternRef.value = ''
+      }
+      beingCreatedOptionsRef.value = emptyArray
       beingCreatedOptionsRef.value = emptyArray
     }
     const activeWithoutMenuOpenRef = ref(false)


### PR DESCRIPTION
Retaining a label makes it easy to make changes to the original label to quickly re-filter the filter, or to copy the text from the label and use it in other ways

This feature really makes a lot of sense believe me
Hopefully it will be merged soon

If that doesn't work, I hope it's possible to return the patternRef variable from the select