### PR TITLE
docs(customize-theme): get theme vars

### DIFF
--- a/demo/pages/docs/customize-theme/enUS/index.md
+++ b/demo/pages/docs/customize-theme/enUS/index.md
@@ -35,6 +35,10 @@ If `theme` is `undefined` it won't affect the theme of components inside.
 </script>
 ```
 
+## Get theme vars
+
+Whether it's the default light theme (`lightTheme`), the modified dark theme (`darkTheme`), or the custom theme we adjusted, you can get theme variables within the scope of the theme using [useThemeVars](./theme#use-theme-vars).
+
 ## Customizing theme vars (design tokens)
 
 No CSS (Scss, Less) needed.

--- a/demo/pages/docs/customize-theme/zhCN/index.md
+++ b/demo/pages/docs/customize-theme/zhCN/index.md
@@ -35,6 +35,10 @@ Naive UI 通过使用 `n-config-provider` 调整主题。
 </script>
 ```
 
+## 获取主题变量
+
+无论是默认的亮色主题(`lightTheme`)，还是修改后的暗色主题(`darkTheme`)，亦或我们通过调整得到的自定义主题，在该主题生效范围内的组件中都可以通过 [useThemeVars](./theme#use-theme-vars) 来获取主题变量。
+
 ## 调整主题变量
 
 你不需要写任何 CSS（Scss、Less...）。

--- a/volar.d.ts
+++ b/volar.d.ts
@@ -50,6 +50,8 @@ declare module 'vue' {
     NEmpty: (typeof import('naive-ui'))['NEmpty']
     NEquation: (typeof import('naive-ui'))['NEquation']
     NFlex: (typeof import('naive-ui'))['NFlex']
+    NFloatButton: (typeof import('naive-ui'))['NFloatButton']
+    NFloatButtonGroup: (typeof import('naive-ui'))['NFloatButtonGroup']
     NForm: (typeof import('naive-ui'))['NForm']
     NFormItem: (typeof import('naive-ui'))['NFormItem']
     NFormItemCol: (typeof import('naive-ui'))['NFormItemCol']
@@ -72,6 +74,7 @@ declare module 'vue' {
     NIconWrapper: (typeof import('naive-ui'))['NIconWrapper']
     NImage: (typeof import('naive-ui'))['NImage']
     NImageGroup: (typeof import('naive-ui'))['NImageGroup']
+    NInfiniteScroll: (typeof import('naive-ui'))['NInfiniteScroll']
     NInput: (typeof import('naive-ui'))['NInput']
     NInputGroup: (typeof import('naive-ui'))['NInputGroup']
     NInputGroupLabel: (typeof import('naive-ui'))['NInputGroupLabel']
@@ -91,6 +94,7 @@ declare module 'vue' {
     NMenu: (typeof import('naive-ui'))['NMenu']
     NMessageProvider: (typeof import('naive-ui'))['NMessageProvider']
     NModal: (typeof import('naive-ui'))['NModal']
+    NModalProvider: (typeof import('naive-ui'))['NModalProvider']
     NNotificationProvider: (typeof import('naive-ui'))['NNotificationProvider']
     NNumberAnimation: (typeof import('naive-ui'))['NNumberAnimation']
     NOl: (typeof import('naive-ui'))['NOl']
@@ -147,10 +151,6 @@ declare module 'vue' {
     NUploadTrigger: (typeof import('naive-ui'))['NUploadTrigger']
     NVirtualList: (typeof import('naive-ui'))['NVirtualList']
     NWatermark: (typeof import('naive-ui'))['NWatermark']
-    NModalProvider: (typeof import('naive-ui'))['NModalProvider']
-    NFloatButton: (typeof import('naive-ui'))['NFloatButton']
-    NFloatButtonGroup: (typeof import('naive-ui'))['NFloatButtonGroup']
-    NInfiniteScroll: (typeof import('naive-ui'))['NInfiniteScroll']
   }
 }
 export {}


### PR DESCRIPTION
我认为在 "修改主题" 与 "调整主题"之间，增加上 "获取主题" 会对新手更加有好。
并且通过 useThemeVars 的链接跳转至 "创建适配主题的组件" 一文，让整个阅读理解更加通顺。