### PR TITLE
fix: the first letter should be capitalized while used to type

### DIFF
--- a/src/form/demos/enUS/index.demo-entry.md
+++ b/src/form/demos/enUS/index.demo-entry.md
@@ -5,7 +5,7 @@
 The element to collect and validate data.
 
 <n-alert type="warning" title="Caveat" :bordered="false">
-  If you want to apply required rule for a form item with number typed value, you need to set <n-text code>`type: number`</n-text> in the rule object.
+  If you want to apply required rule for a form item with number typed value, you need to set <n-text code>`type: Number`</n-text> in the rule object.
 </n-alert>
 
 ## Demos

--- a/src/form/demos/zhCN/index.demo-entry.md
+++ b/src/form/demos/zhCN/index.demo-entry.md
@@ -5,7 +5,7 @@
 收集、验证信息。
 
 <n-alert type="warning" title="注意" :bordered="false">
-  如果你需要为一个值为 number 类型的表项设定 required，你需要在 rule 对象中设定 <n-text code>`type: number`</n-text>。
+  如果你需要为一个值为 number 类型的表项设定 required，你需要在 rule 对象中设定 <n-text code>`type: Number`</n-text>。
 </n-alert>
 
 ## 演示


### PR DESCRIPTION
`type: number` --> `type: Number`