### PR TITLE
Fix: NDataTable Column sorter adds n-data-table-td-hover class #6118

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -9,6 +9,7 @@
 - Fix `n-input-number` Exception when the value is a string in precision mode, closes [#6091](https://github.com/tusen-ai/naive-ui/issues/6091).
 - `n-form-item` ensure validation state is correctly updated[#6068](https://github.com/tusen-ai/naive-ui/issues/6068)
 - Fix `n-select`'s header make inner input unavailable, closes [#6030](https://github.com/tusen-ai/naive-ui/issues/6030).
+- Fix NDataTable Column sorter adds `n-data-table-td-hover` class, closes [#6118](https://github.com/tusen-ai/naive-ui/issues/6118)
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -9,6 +9,7 @@
 - 修复 `n-input-number` precision 模式下 value 为字符串时的异常问题，关闭 [#6091](https://github.com/tusen-ai/naive-ui/issues/6091)
 - `n-form-item` 确保验证状态正确更新[#6068](https://github.com/tusen-ai/naive-ui/issues/6068)
 - 修复 `n-select` 组件的 header 插槽里 input 无法输入，关闭 [#6030](https://github.com/tusen-ai/naive-ui/issues/6030)
+- Fix NDataTable Column sorter adds `n-data-table-td-hover` class, closes [#6118](https://github.com/tusen-ai/naive-ui/issues/6118)
 
 ### Features
 

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -30,7 +30,7 @@ import {
   type TmNode,
   type RowData
 } from '../interface'
-import { createRowClassName, getColKey, isColumnSorting } from '../utils'
+import { createRowClassName, getColKey } from '../utils'
 import type { ColItem } from '../use-group-header'
 import Cell from './Cell'
 import ExpandTrigger from './ExpandTrigger'
@@ -570,7 +570,6 @@ export default defineComponent({
               fixedColumnRightMap,
               currentPage,
               rowClassName,
-              mergedSortState,
               mergedExpandedRowKeySet,
               stickyExpandedRows,
               componentId,
@@ -824,11 +823,11 @@ export default defineComponent({
                           resolvedCellProps?.class,
                           isSummary &&
                             `${mergedClsPrefix}-data-table-td--summary`,
-                          ((hoverKey !== null &&
+                          hoverKey !== null &&
                             cordKey[displayedRowIndex][colIndex].includes(
                               hoverKey
-                            )) ||
-                            isColumnSorting(column, mergedSortState)) &&
+                            ) &&
+                            // || isColumnSorting(column, mergedSortState)
                             `${mergedClsPrefix}-data-table-td--hover`,
                           column.fixed &&
                             `${mergedClsPrefix}-data-table-td--fixed-${column.fixed}`,


### PR DESCRIPTION
Fix NDataTable Column sorter adds `n-data-table-td-hover` class, closes  [#6118](https://github.com/tusen-ai/naive-ui/issues/6118)
 