### PR TITLE
fix: use correct pattern for ISO weekFormat

### DIFF
--- a/src/locales/common/arDZ.ts
+++ b/src/locales/common/arDZ.ts
@@ -31,7 +31,7 @@ const arDZ: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'مسح',
     now: 'الآن',
     confirm: 'تأكيد',

--- a/src/locales/common/azAZ.ts
+++ b/src/locales/common/azAZ.ts
@@ -31,7 +31,7 @@ const azAZ: NLocale = {
     dateFormat: 'dd MMMM yyyy',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'yyyy-w',
+    weekFormat: 'RRRR-I',
     clear: 'Təmizlə',
     now: 'İndi',
     confirm: 'Təsdiqlə',

--- a/src/locales/common/csCZ.ts
+++ b/src/locales/common/csCZ.ts
@@ -31,7 +31,7 @@ const csCZ: NLocale = {
     dateFormat: 'd-M-yyyy',
     dateTimeFormat: 'd-M-yyyy HH:mm:ss',
     quarterFormat: 'qqq-yyyy',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Vyčistit',
     now: 'Teď',
     confirm: 'Potvrdit',

--- a/src/locales/common/deDE.ts
+++ b/src/locales/common/deDE.ts
@@ -31,7 +31,7 @@ const deDE: NLocale = {
     dateFormat: 'dd.MM.yyyy',
     dateTimeFormat: 'dd.MM.yyyy HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Löschen',
     now: 'Jetzt',
     confirm: 'Bestätigen',

--- a/src/locales/common/enGB.ts
+++ b/src/locales/common/enGB.ts
@@ -31,7 +31,7 @@ const enGB: NLocale = {
     dateFormat: 'yyyy/MM/dd',
     dateTimeFormat: 'yyyy/MM/dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Clear',
     now: 'Now',
     confirm: 'Confirm',

--- a/src/locales/common/enUS.ts
+++ b/src/locales/common/enUS.ts
@@ -29,7 +29,7 @@ const enUS = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Clear',
     now: 'Now',
     confirm: 'Confirm',

--- a/src/locales/common/eo.ts
+++ b/src/locales/common/eo.ts
@@ -31,7 +31,7 @@ const eo: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Malplenigi',
     now: 'Nun',
     confirm: 'Konfirmi',

--- a/src/locales/common/esAR.ts
+++ b/src/locales/common/esAR.ts
@@ -31,7 +31,7 @@ const esAR: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Borrar',
     now: 'Ahora',
     confirm: 'Confirmar',

--- a/src/locales/common/etEE.ts
+++ b/src/locales/common/etEE.ts
@@ -31,7 +31,7 @@ const etEE: NLocale = {
     dateFormat: 'dd.MM.yyyy',
     dateTimeFormat: 'dd.MM.yyyy HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Tühjenda',
     now: 'Nüüd',
     confirm: 'Kinnita',

--- a/src/locales/common/faIR.ts
+++ b/src/locales/common/faIR.ts
@@ -31,7 +31,7 @@ const faIR: NLocale = {
     dateFormat: 'yyyy/MM/dd',
     dateTimeFormat: 'yyyy/MM/dd HH:mm:ss',
     quarterFormat: 'سه ماهه yyyy',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'پاک کردن',
     now: 'اکنون',
     confirm: 'تأیید',

--- a/src/locales/common/frFR.ts
+++ b/src/locales/common/frFR.ts
@@ -31,7 +31,7 @@ const frFR: NLocale = {
     dateFormat: 'dd/MM/yyyy',
     dateTimeFormat: 'dd/MM/yyyy HH:mm:ss',
     quarterFormat: 'qqq yyyy',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Effacer',
     now: 'Maintenant',
     confirm: 'Confirmer',

--- a/src/locales/common/idID.ts
+++ b/src/locales/common/idID.ts
@@ -31,7 +31,7 @@ const idID: NLocale = {
     dateFormat: 'dd-MM-yyyy',
     dateTimeFormat: 'dd-MM-yyyy HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Bersihkan',
     now: 'Sekarang',
     confirm: 'Setuju',

--- a/src/locales/common/itIT.ts
+++ b/src/locales/common/itIT.ts
@@ -31,7 +31,7 @@ const itIT: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Cancella',
     now: 'Adesso',
     confirm: 'Conferma',

--- a/src/locales/common/jaJP.ts
+++ b/src/locales/common/jaJP.ts
@@ -31,7 +31,7 @@ const jaJP: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'クリア',
     now: '現在',
     confirm: 'OK',

--- a/src/locales/common/koKR.ts
+++ b/src/locales/common/koKR.ts
@@ -31,7 +31,7 @@ const koKR: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: '지우기',
     now: '현재',
     confirm: '확인',

--- a/src/locales/common/nbNO.ts
+++ b/src/locales/common/nbNO.ts
@@ -31,7 +31,7 @@ const nbNO: NLocale = {
     dateFormat: 'dd.MM.yyyy',
     dateTimeFormat: 'dd.MM.yyyy HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Tøm',
     now: 'Nå',
     confirm: 'Bekreft',

--- a/src/locales/common/nlNL.ts
+++ b/src/locales/common/nlNL.ts
@@ -31,7 +31,7 @@ const nlNL: NLocale = {
     dateFormat: 'dd/MM/yyyy',
     dateTimeFormat: 'dd/MM/yyyy HH:mm:ss',
     quarterFormat: 'qqq yyyy',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Wis',
     now: 'Nu',
     confirm: 'Bevestig',

--- a/src/locales/common/plPL.ts
+++ b/src/locales/common/plPL.ts
@@ -31,7 +31,7 @@ const plPL: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Wyczyść',
     now: 'Teraz',
     confirm: 'Potwierdź',

--- a/src/locales/common/ptBR.ts
+++ b/src/locales/common/ptBR.ts
@@ -31,7 +31,7 @@ const ptBR: NLocale = {
     dateFormat: 'dd/MM/yyyy',
     dateTimeFormat: 'dd/MM/yyyy HH:mm:ss',
     quarterFormat: 'yyyy/qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Limpar',
     now: 'Agora',
     confirm: 'Confirmar',

--- a/src/locales/common/ruRU.ts
+++ b/src/locales/common/ruRU.ts
@@ -31,7 +31,7 @@ const ruRu: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Очистить',
     now: 'Сейчас',
     confirm: 'Подтвердить',

--- a/src/locales/common/skSK.ts
+++ b/src/locales/common/skSK.ts
@@ -31,7 +31,7 @@ const skSK: NLocale = {
     dateFormat: 'd-M-yyyy',
     dateTimeFormat: 'd-M-yyyy HH:mm:ss',
     quarterFormat: 'qqq-yyyy',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Vyčistiť',
     now: 'Teraz',
     confirm: 'Potvrdiť',

--- a/src/locales/common/svSE.ts
+++ b/src/locales/common/svSE.ts
@@ -31,7 +31,7 @@ const svSE: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Rensa',
     now: 'Nu',
     confirm: 'Bekräfta',

--- a/src/locales/common/thTH.ts
+++ b/src/locales/common/thTH.ts
@@ -31,7 +31,7 @@ const thTH: NLocale = {
     dateFormat: 'dd/MMMM/yyyy',
     dateTimeFormat: 'dd/MMMM/yyyy HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'ล้าง',
     now: 'วันนี้',
     confirm: 'ยืนยัน',

--- a/src/locales/common/trTR.ts
+++ b/src/locales/common/trTR.ts
@@ -31,7 +31,7 @@ const trTR: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Temizle',
     now: 'Şimdi',
     confirm: 'Onayla',

--- a/src/locales/common/ukUA.ts
+++ b/src/locales/common/ukUA.ts
@@ -31,7 +31,7 @@ const ukUA: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Стерти',
     now: 'Зараз',
     confirm: 'Підтвердити',

--- a/src/locales/common/uzUZ.ts
+++ b/src/locales/common/uzUZ.ts
@@ -31,7 +31,7 @@ const uzUZ: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Tozalash',
     now: 'Hozir',
     confirm: 'Tasdiqlash',

--- a/src/locales/common/viVN.ts
+++ b/src/locales/common/viVN.ts
@@ -31,7 +31,7 @@ const viVN: NLocale = {
     dateFormat: 'dd-MM-yyyy',
     dateTimeFormat: 'HH:mm:ss dd-MM-yyyy',
     quarterFormat: 'qqq-yyyy',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: 'Xóa',
     now: 'Hôm nay',
     confirm: 'Xác nhận',

--- a/src/locales/common/zhCN.ts
+++ b/src/locales/common/zhCN.ts
@@ -31,7 +31,7 @@ const zhCN: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w周',
+    weekFormat: 'RRRR-I周',
     clear: '清除',
     now: '此刻',
     confirm: '确认',

--- a/src/locales/common/zhTW.ts
+++ b/src/locales/common/zhTW.ts
@@ -31,7 +31,7 @@ const zhTW: NLocale = {
     dateFormat: 'yyyy-MM-dd',
     dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
     quarterFormat: 'yyyy-qqq',
-    weekFormat: 'RRRR-w',
+    weekFormat: 'RRRR-I',
     clear: '清除',
     now: '現在',
     confirm: '確定',


### PR DESCRIPTION
Should be use `RRRRR` ( ISO week-numbering year ) and `I` (ISO week of year) as default `weekFormat`. See [date-fns docs](https://date-fns.org/v3.6.0/docs/format ).

Another issue, if we use ISO week date we should diable `first-day-of-week` prop for week picker because ISO-week start with Monday. See [wiki](https://en.wikipedia.org/wiki/ISO_week_date#:~:text=Weeks%20start%20with%20Monday%20and%20end%20on%20Sunday.) , [HTML week concept](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#concept-week).
 Different  `first-day-of-week` can break the consistency  of week selection on panel with the week-formatted text.

