### PR TITLE
feat(date-picker): add `close-month-panel-on-select` prop to close the month panel after the user has selected the month

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -31,6 +31,7 @@
 - `n-empty` `size` prop to support `tiny` size.
 - `n-config-provider` adds `style-mount-target` prop to control where to mount components' style.
 - `n-cascader` filter ignore case sensitive
+- `n-date-picker` add `close-month-panel-on-select` prop to close the month panel after the user has selected the month
 
 ## 2.39.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -31,6 +31,7 @@
 - `n-empty` `size` 支持 `tiny` 尺寸
 - `n-config-provider` 新增 `style-mount-target` 属性，用于控制样式的挂载位置
 - `n-cascader` 过滤算法忽略大小写
+- `n-date-picker` 新增 `close-month-panel-on-select` 属性，用于自动关闭月份面板在用户选择完月份后
 
 ## 2.39.0
 

--- a/src/date-picker/demos/enUS/index.demo-entry.md
+++ b/src/date-picker/demos/enUS/index.demo-entry.md
@@ -78,6 +78,7 @@ panel.vue
 | format | `string` | `'yyyy-MM-dd'` | Format of the input. For detail please see [format](https://date-fns.org/v2.23.0/docs/format). |  |
 | is-date-disabled | `(current: number, detail: { type: 'date', year: number, month: number, date: number } \| { type: 'month', year: number, month: number } \| { type: 'year', year: number } \| { type: 'quarter',  year: number, quarter: number } \| { type: 'input' }) => boolean` | `() => false` | Validator of the date. | `detail` 2.37.1 |
 | placeholder | `string` | `'Select Date'` | Placeholder. |  |
+| close-month-panel-on-select | `boolean` | `false` | Whether to close the month panel after the user has selected the month | NEXT_VERSION |
 | on-update:formatted-value | `(value: string \| null, timestampValue: number \| null) => void` | `undefined` | Date selected callback. | 2.24.0 |
 | on-update:value | `(value: number \| null, formattedValue: string \| null) => void` | `undefined` | Date selected callback. | `formattedValue` 2.24.0 |
 
@@ -94,6 +95,7 @@ panel.vue
 | placeholder | `string` | `'Select Date and Time'` | Placeholder. |  |
 | time-picker-props | `TimePickerProps` | `undefined` | Time picker props in the panel. | 2.27.0 |
 | update-value-on-close | `boolean` | `false` | Whether to update value on close. |  |
+| close-month-panel-on-select | `boolean` | `false` | Whether to close the month panel after the user has selected the month | NEXT_VERSION |
 | on-update:formatted-value | `(value: string \| null, timestampValue: number \| null) => void` | `undefined` | Date selected callback. | MEXT_VERSION |
 | on-update:value | `(value: number \| null, formattedValue: string \| null) => void` | `undefined` | Date selected callback. | `formattedValue` 2.24.0 |
 
@@ -113,6 +115,7 @@ panel.vue
 | separator | `string` | internal icon | The separator between the start input and the end input. |  |
 | start-placeholder | `string` | `'Start Date'` | The prompt information at the beginning of the input. |  |
 | update-value-on-close | `boolean` | `false` | Whether to update the value on close. |  |
+| close-month-panel-on-select | `boolean` | `false` | Whether to close the month panel after the user has selected the month | NEXT_VERSION |
 | on-update:formatted-value | `(value: [string, string] \| null, timestampValue: [number, number] \| null) => void` | `undefined` | Formatted range changed callback. | 2.24.0 |
 | on-update:value | `(value: [number, number] \| null, formattedValue: [string, string] \| null) => void` | `undefined` | Range changed callback. | `formattedValue` 2.24.0 |
 
@@ -133,6 +136,7 @@ panel.vue
 | start-placeholder | `string` | `'Start Date and Time'` | The prompt information at the beginning of the input. |  |
 | time-picker-props | `TimePickerProps \| [TimePickerProps, TimePickerProps]` | `undefined` | Time picker props in the panel. | 2.27.0 |
 | update-value-on-close | `boolean` | `false` | Whether to update value on close. |  |
+| close-month-panel-on-select | `boolean` | `false` | Whether to close the month panel after the user has selected the month | NEXT_VERSION |
 | on-update:formatted-value | `(value: [string, string] \| null, timestampValue: [number, number] \| null) => void` | `undefined` | Formatted value changed callback. | 2.24.0 |
 | on-update:value | `(value: [number, number] \| null, formattedValue: [string, string] \| null) => void` | `undefined` | Value changed callback. | `formattedValue` 2.24.0 |
 

--- a/src/date-picker/demos/zhCN/index.demo-entry.md
+++ b/src/date-picker/demos/zhCN/index.demo-entry.md
@@ -80,6 +80,7 @@ form-debug.vue
 | is-date-disabled | `(current: number, detail: { type: 'date', year: number, month: number, date: number } \| { type: 'month', year: number, month: number } \| { type: 'year', year: number } \| { type: 'quarter',  year: number, quarter: number } \| { type: 'input' }) => boolean` | `undefined` | 日期禁用的校验函数 | `detail` 2.37.1 |
 | placeholder | `string` | `'选择日期'` | 没有值时的占位信息 |  |
 | on-update:formatted-value | `(value: string \| null, timestampValue: number \| null) => void` | `undefined` | 受控数据更新时触发的回调函数 | 2.24.0 |
+| close-month-panel-on-select | `boolean` | `false` | 用户选择月份后是否自动关闭月份面板 | NEXT_VERSION |
 | on-update:value | `(value: number \| null, formattedValue: string \| null) => void` | `undefined` | 受控数据更新时触发的回调函数 | `formattedValue` 2.24.0 |
 
 ### DateTime 类型的 Props
@@ -95,6 +96,7 @@ form-debug.vue
 | placeholder | `string` | `'选择日期时间'` | 提示信息 |  |
 | time-picker-props | `TimePickerProps` | `undefined` | 面板中时间选择器的属性 | 2.27.0 |
 | update-value-on-close | `boolean` | `false` | 关闭面板时更新值 |  |
+| close-month-panel-on-select | `boolean` | `false` | 用户选择月份后是否自动关闭月份面板 | NEXT_VERSION |
 | on-update:formatted-value | `(value: string \| null, timestampValue: number \| null) => void` | `undefined` | 数据更新时触发的回调函数 | 2.24.0 |
 | on-update:value | `(value: number \| null, formattedValue: string \| null) => void` | `undefined` | 数据更新时触发的回调函数 | `formattedValue` 2.24.0 |
 
@@ -113,6 +115,7 @@ form-debug.vue
 | separator | `string` | 内置图标 | start 选框与 end 选框之间的分隔符 |  |
 | start-placeholder | `string` | `'开始日期'` | DateRange 中 start 选框的提示信息 |  |
 | update-value-on-close | `boolean` | `false` | 关闭面板时是否更新值 |  |
+| close-month-panel-on-select | `boolean` | `false` | 用户选择月份后是否自动关闭月份面板 | NEXT_VERSION |
 | on-update:formatted-value | `(value: [string, string] \| null, timestampValue: [number, number] \| null) => void` | `undefined` | 数据更新时触发的回调函数 | 2.24.0 |
 | on-update:value | `(value: [number, number] \| null, formattedValue: [string, string] \| null) => void` | `undefined` | 数据更新时触发的回调函数 | `formattedValue` 2.24.0 |
 
@@ -133,6 +136,7 @@ form-debug.vue
 | start-placeholder | `string` | `'开始日期时间'` | DateTimeRange 中 start 选框的提示信息 |  |
 | time-picker-props | `TimePickerProps \| [TimePickerProps, TimePickerProps]` | `undefined` | 面板中时间选择器的属性 | 2.27.0 |
 | update-value-on-close | `boolean` | `false` | 关闭面板时是否更新值 |  |
+| close-month-panel-on-select | `boolean` | `false` | 用户选择月份后是否自动关闭月份面板 | NEXT_VERSION |
 | on-update:formatted-value | `(value: [string, string] \| null, timestampValue: [number, number] \| null) => void` | `undefined` | 数据更新时触发的回调函数 | 2.24.0 |
 | on-update:value | `(value: [number, number] \| null, formattedValue: [string, string] \| null) => void` | `undefined` | 数据更新时触发的回调函数 | `formattedValue` 2.24.0 |
 

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -716,6 +716,7 @@ export default defineComponent({
       rangesRef: toRef(props, 'ranges'),
       timePickerPropsRef: toRef(props, 'timePickerProps'),
       closeOnSelectRef: toRef(props, 'closeOnSelect'),
+      closeMonthPanelOnSelectRef: toRef(props, 'closeMonthPanelOnSelect'),
       updateValueOnCloseRef: toRef(props, 'updateValueOnClose'),
       monthFormatRef: toRef(props, 'monthFormat'),
       yearFormatRef: toRef(props, 'yearFormat'),

--- a/src/date-picker/src/interface.ts
+++ b/src/date-picker/src/interface.ts
@@ -130,6 +130,7 @@ export type DatePickerInjection = {
   isDateDisabledRef: Ref<IsDateDisabled | undefined>
   rangesRef: Ref<Record<string, [number, number]> | undefined>
   closeOnSelectRef: Ref<boolean>
+  closeMonthPanelOnSelectRef: Ref<boolean>
   updateValueOnCloseRef: Ref<boolean>
   firstDayOfWeekRef: Ref<FirstDayOfWeek | undefined>
   monthFormatRef: Ref<string>

--- a/src/date-picker/src/panel/date.tsx
+++ b/src/date-picker/src/panel/date.tsx
@@ -81,6 +81,7 @@ export default defineComponent({
               mergedClsPrefix={mergedClsPrefix}
               calendarMonth={this.calendarMonth}
               calendarYear={this.calendarYear}
+              closeMonthPanelOnSelect={this.closeMonthPanelOnSelect}
             />
             <div
               class={`${mergedClsPrefix}-date-panel-month__next`}

--- a/src/date-picker/src/panel/daterange.tsx
+++ b/src/date-picker/src/panel/daterange.tsx
@@ -72,6 +72,7 @@ export default defineComponent({
               mergedClsPrefix={mergedClsPrefix}
               calendarMonth={this.startCalendarMonth}
               calendarYear={this.startCalendarYear}
+              closeMonthPanelOnSelect={this.closeMonthPanelOnSelect}
             />
             <div
               class={`${mergedClsPrefix}-date-panel-month__next`}
@@ -162,6 +163,7 @@ export default defineComponent({
               mergedClsPrefix={mergedClsPrefix}
               calendarMonth={this.endCalendarMonth}
               calendarYear={this.endCalendarYear}
+              closeMonthPanelOnSelect={this.closeMonthPanelOnSelect}
             />
             <div
               class={`${mergedClsPrefix}-date-panel-month__next`}

--- a/src/date-picker/src/panel/datetime.tsx
+++ b/src/date-picker/src/panel/datetime.tsx
@@ -106,6 +106,7 @@ export default defineComponent({
               mergedClsPrefix={mergedClsPrefix}
               calendarMonth={this.calendarMonth}
               calendarYear={this.calendarYear}
+              closeMonthPanelOnSelect={this.closeMonthPanelOnSelect}
             />
             <div
               class={`${mergedClsPrefix}-date-panel-month__next`}

--- a/src/date-picker/src/panel/datetimerange.tsx
+++ b/src/date-picker/src/panel/datetimerange.tsx
@@ -147,6 +147,7 @@ export default defineComponent({
               mergedClsPrefix={mergedClsPrefix}
               calendarMonth={this.startCalendarMonth}
               calendarYear={this.startCalendarYear}
+              closeMonthPanelOnSelect={this.closeMonthPanelOnSelect}
             />
             <div
               class={`${mergedClsPrefix}-date-panel-month__next`}
@@ -247,6 +248,7 @@ export default defineComponent({
               mergedClsPrefix={mergedClsPrefix}
               calendarMonth={this.endCalendarMonth}
               calendarYear={this.endCalendarYear}
+              closeMonthPanelOnSelect={this.closeMonthPanelOnSelect}
             />
             <div
               class={`${mergedClsPrefix}-date-panel-month__next`}

--- a/src/date-picker/src/panel/month.tsx
+++ b/src/date-picker/src/panel/month.tsx
@@ -36,7 +36,8 @@ export default defineComponent({
       required: true
     },
     // panelHeader prop
-    useAsQuickJump: Boolean
+    useAsQuickJump: Boolean,
+    onUpdateMonthItem: Function
   },
   setup(props) {
     const useCalendarRef = useCalendar(props, props.type)
@@ -111,6 +112,9 @@ export default defineComponent({
             if (useAsQuickJump) {
               handleQuickMonthClick(item, (value) => {
                 ;(props.onUpdateValue as OnPanelUpdateValueImpl)(value, false)
+                if (item.type === 'month') {
+                  props.onUpdateMonthItem?.()
+                }
               })
             }
             else {

--- a/src/date-picker/src/panel/panelHeader.tsx
+++ b/src/date-picker/src/panel/panelHeader.tsx
@@ -33,9 +33,13 @@ export default defineComponent({
     onUpdateValue: {
       type: Function as PropType<(value: number) => void>,
       required: true
+    },
+    closeMonthPanelOnSelect: {
+      type: Boolean,
+      required: true
     }
   },
-  setup() {
+  setup(props) {
     const triggerRef = ref<HTMLElement | null>(null)
     const monthPanelRef = ref<InstanceType<typeof MonthPanel> | null>(null)
     const showRef = ref(false)
@@ -50,12 +54,18 @@ export default defineComponent({
     function handleHeaderClick(): void {
       showRef.value = !showRef.value
     }
+    function handleUpdateMonthItem() {
+      if (props.closeMonthPanelOnSelect) {
+        showRef.value = false
+      }
+    }
     return {
       show: showRef,
       triggerRef,
       monthPanelRef,
       handleHeaderClick,
-      handleClickOutside
+      handleClickOutside,
+      handleUpdateMonthItem
     }
   },
   render() {
@@ -103,6 +113,7 @@ export default defineComponent({
                                 key="month"
                                 useAsQuickJump
                                 value={this.value}
+                                onUpdateMonthItem={this.handleUpdateMonthItem}
                               />,
                               [
                                 [

--- a/src/date-picker/src/panel/use-panel-common.ts
+++ b/src/date-picker/src/panel/use-panel-common.ts
@@ -59,7 +59,8 @@ function usePanelCommon(props: UsePanelCommonProps) {
     timePickerPropsRef,
     localeRef,
     mergedClsPrefixRef,
-    mergedThemeRef
+    mergedThemeRef,
+    closeMonthPanelOnSelectRef
   } = inject(datePickerInjectionKey)!
   const dateFnsOptionsRef = computed(() => {
     return {
@@ -167,6 +168,7 @@ function usePanelCommon(props: UsePanelCommonProps) {
     dateFnsOptions: dateFnsOptionsRef,
     timePickerSize: timePickerSizeRef,
     timePickerProps: timePickerPropsRef,
+    closeMonthPanelOnSelect: closeMonthPanelOnSelectRef,
     selfRef,
     locale: localeRef,
     doConfirm,

--- a/src/date-picker/src/props.ts
+++ b/src/date-picker/src/props.ts
@@ -69,6 +69,7 @@ export const datePickerProps = {
   firstDayOfWeek: Number as PropType<FirstDayOfWeek>,
   inputReadonly: Boolean,
   closeOnSelect: Boolean,
+  closeMonthPanelOnSelect: Boolean,
   status: String as PropType<FormValidationStatus>,
   timePickerProps: [Object, Array] as PropType<
     TimePickerProps | [TimePickerProps, TimePickerProps]


### PR DESCRIPTION
After setting `close-month-panel-on-select`:

![20240806160838_rec_](https://github.com/user-attachments/assets/887d0422-cc67-4c20-ab3b-457b2ca7091d)
