### PR TITLE
feat(components): Config Provider adds global size property

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -39,6 +39,7 @@
 - `n-data-table` adds `allowExport` prop for column.
 - `n-date-picker` adds `year-range` prop.
 - `n-tree-select` adds `header` slot, closes [#5915](https://github.com/tusen-ai/naive-ui/issues/5915).
+- `n-config-provider` add `size` prop closes [#356](https://github.com/tusen-ai/naive-ui/issues/356)
 
 ## 2.39.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -39,6 +39,7 @@
 - `n-data-table` 在列的配置中新增 `allowExport` 属性
 - `n-date-picker` 新增 `year-range` 属性
 - `n-tree-select` 新增 `header` 插槽，关闭 [#5915](https://github.com/tusen-ai/naive-ui/issues/5915)
+- `n-config-provider` 新增 `size` 属性，关闭 [#356](https://github.com/tusen-ai/naive-ui/issues/356)
 
 ## 2.39.0
 

--- a/src/_mixins/use-config.ts
+++ b/src/_mixins/use-config.ts
@@ -1,4 +1,5 @@
 import { type ComputedRef, type Ref, computed, inject, shallowRef } from 'vue'
+import type { GlobalSize } from 'naive-ui'
 import type {
   Breakpoints,
   GlobalComponentConfig,
@@ -6,7 +7,7 @@ import type {
 } from '../config-provider/src/internal-interface'
 import { configProviderInjectionKey } from '../config-provider/src/context'
 
-type UseConfigProps = Readonly<{
+export type UseConfigProps = Readonly<{
   bordered?: boolean
   [key: string]: unknown
 }>
@@ -17,8 +18,10 @@ export default function useConfig(
   props: UseConfigProps = {},
   options: {
     defaultBordered?: boolean
+    defaultSize?: GlobalSize
   } = {
-    defaultBordered: true
+    defaultBordered: true,
+    defaultSize: 'medium'
   }
 ): {
     inlineThemeDisabled: boolean | undefined
@@ -28,6 +31,7 @@ export default function useConfig(
     mergedBreakpointsRef: Ref<Breakpoints> | undefined
     mergedComponentPropsRef: Ref<GlobalComponentConfig | undefined> | undefined
     namespaceRef: ComputedRef<string | undefined>
+    globalSize: Ref<GlobalSize>
   } {
   const NConfigProvider = inject(configProviderInjectionKey, null)
   return {
@@ -49,7 +53,16 @@ export default function useConfig(
     mergedClsPrefixRef: NConfigProvider
       ? NConfigProvider.mergedClsPrefixRef
       : shallowRef(defaultClsPrefix),
-    namespaceRef: computed(() => NConfigProvider?.mergedNamespaceRef.value)
+    namespaceRef: computed(() => NConfigProvider?.mergedNamespaceRef.value),
+    globalSize: computed(() => {
+      if (props && props.size) {
+        return props.size as GlobalSize
+      }
+      if (NConfigProvider?.globalSize.value) {
+        return NConfigProvider?.globalSize.value
+      }
+      return options.defaultSize!
+    })
   }
 }
 

--- a/src/_mixins/use-form-item.ts
+++ b/src/_mixins/use-form-item.ts
@@ -8,6 +8,8 @@ import {
 } from 'vue'
 import type { FormValidationStatus } from '../form/src/interface'
 import { createInjectionKey } from '../_utils'
+import type { UseConfigProps } from './use-config'
+import { useConfig } from './index'
 
 type FormItemSize = 'small' | 'medium' | 'large'
 type AllowedSize = 'tiny' | 'small' | 'medium' | 'large' | 'huge' | number
@@ -58,6 +60,7 @@ export default function useFormItem<T extends AllowedSize = FormItemSize>(
   }: UseFormItemOptions<T> = {}
 ): UseFormItem<T> {
   const NFormItem = inject(formItemInjectionKey, null)
+  const { globalSize } = useConfig(props as UseConfigProps)
   provide(formItemInjectionKey, null)
   const mergedSizeRef = computed(
     mergedSize
@@ -72,6 +75,10 @@ export default function useFormItem<T extends AllowedSize = FormItemSize>(
               return mergedSize.value as T
             }
           }
+
+          if (globalSize.value)
+            return globalSize.value as T
+
           return defaultSize as T
         }
   )

--- a/src/button/src/Button.tsx
+++ b/src/button/src/Button.tsx
@@ -127,6 +127,12 @@ const Button = defineComponent({
       )
     })
     const NButtonGroup = inject(buttonGroupInjectionKey, {})
+    const {
+      inlineThemeDisabled,
+      mergedClsPrefixRef,
+      mergedRtlRef,
+      globalSize
+    } = useConfig(props)
     const { mergedSizeRef } = useFormItem(
       {},
       {
@@ -135,13 +141,18 @@ const Button = defineComponent({
           const { size } = props
           if (size)
             return size
+
           const { size: buttonGroupSize } = NButtonGroup
           if (buttonGroupSize)
             return buttonGroupSize
+
           const { mergedSize: formItemSize } = NFormItem || {}
-          if (formItemSize) {
+          if (formItemSize)
             return formItemSize.value
-          }
+
+          if (globalSize.value)
+            return globalSize.value
+
           return 'medium'
         }
       }
@@ -198,8 +209,6 @@ const Button = defineComponent({
     const handleBlur = (): void => {
       enterPressedRef.value = false
     }
-    const { inlineThemeDisabled, mergedClsPrefixRef, mergedRtlRef }
-      = useConfig(props)
     const themeRef = useTheme(
       'Button',
       '-button',

--- a/src/card/src/Card.tsx
+++ b/src/card/src/Card.tsx
@@ -39,10 +39,7 @@ export const cardBaseProps = {
     type: [Boolean, Object] as PropType<boolean | CardSegmented>,
     default: false
   },
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large' | 'huge'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large' | 'huge'>,
   bordered: {
     type: Boolean,
     default: true
@@ -80,8 +77,12 @@ export default defineComponent({
       if (onClose)
         call(onClose)
     }
-    const { inlineThemeDisabled, mergedClsPrefixRef, mergedRtlRef }
-      = useConfig(props)
+    const {
+      inlineThemeDisabled,
+      mergedClsPrefixRef,
+      mergedRtlRef,
+      globalSize
+    } = useConfig(props)
     const themeRef = useTheme(
       'Card',
       '-card',
@@ -92,7 +93,6 @@ export default defineComponent({
     )
     const rtlEnabledRef = useRtl('Card', mergedRtlRef, mergedClsPrefixRef)
     const cssVarsRef = computed(() => {
-      const { size } = props
       const {
         self: {
           color,
@@ -118,9 +118,9 @@ export default defineComponent({
           colorEmbedded,
           colorEmbeddedModal,
           colorEmbeddedPopover,
-          [createKey('padding', size)]: padding,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey('titleFontSize', size)]: titleFontSize
+          [createKey('padding', globalSize.value)]: padding,
+          [createKey('fontSize', globalSize.value)]: fontSize,
+          [createKey('titleFontSize', globalSize.value)]: titleFontSize
         },
         common: { cubicBezierEaseInOut }
       } = themeRef.value
@@ -166,7 +166,7 @@ export default defineComponent({
       ? useThemeClass(
         'card',
         computed(() => {
-          return props.size[0]
+          return globalSize.value[0]
         }),
         cssVarsRef,
         props

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -96,8 +96,12 @@ export default defineComponent({
     }
     const NCheckboxGroup = inject(checkboxGroupInjectionKey, null)
     const selfRef = ref<HTMLDivElement | null>(null)
-    const { mergedClsPrefixRef, inlineThemeDisabled, mergedRtlRef }
-      = useConfig(props)
+    const {
+      mergedClsPrefixRef,
+      inlineThemeDisabled,
+      mergedRtlRef,
+      globalSize
+    } = useConfig(props)
     const uncontrolledCheckedRef = ref(props.defaultChecked)
     const controlledCheckedRef = toRef(props, 'checked')
     const mergedCheckedRef = useMergedState(
@@ -121,17 +125,23 @@ export default defineComponent({
         const { size } = props
         if (size !== undefined)
           return size
+
         if (NCheckboxGroup) {
           const { value: mergedSize } = NCheckboxGroup.mergedSizeRef
           if (mergedSize !== undefined) {
             return mergedSize
           }
         }
+
         if (NFormItem) {
           const { mergedSize } = NFormItem
           if (mergedSize !== undefined)
             return mergedSize.value
         }
+
+        if (globalSize.value)
+          return globalSize.value
+
         return 'medium'
       },
       mergedDisabled(NFormItem) {

--- a/src/config-provider/demos/enUS/index.demo-entry.md
+++ b/src/config-provider/demos/enUS/index.demo-entry.md
@@ -14,6 +14,7 @@ os-theme.vue
 language.vue
 transparent.vue
 inline-theme-disabled.vue
+size.vue
 ```
 
 ## API
@@ -35,3 +36,4 @@ inline-theme-disabled.vue
 | tag | `string` | `'div'` | What tag `n-config-provider` will be rendered as |  |
 | theme | `Theme \| null` | `undefined` | The theme object to be consumed by its child. If set to `null` it will use the default light theme. If set to `undefined` it will inherit its parent `n-config-provider`. For more details please see [Customizing Theme](../docs/customize-theme). |  |
 | theme-overrides | `ThemeOverrides \| null` | `undefined` | The theme vars overrides to be consumed by its child. If set to `null` it will clear all theme vars. If set to `undefined` it will inherit its parent `n-config-provider`. For more details please see [Customizing Theme](../docs/customize-theme). |  |
+| size | `small \| medium \| large` | `undefined` | Global Component Size. |  |

--- a/src/config-provider/demos/enUS/size.demo.vue
+++ b/src/config-provider/demos/enUS/size.demo.vue
@@ -1,0 +1,50 @@
+<markdown>
+# Component Size
+
+Modify the default component size.
+</markdown>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { GlobalSize } from 'naive-ui'
+
+const size = ref<GlobalSize>('small')
+
+function handleBtnClick(_size: GlobalSize): void {
+  size.value = _size
+}
+</script>
+
+<template>
+  <n-button-group>
+    <n-button @click="handleBtnClick('small')">
+      Smaller
+    </n-button>
+    <n-button @click="handleBtnClick('medium')">
+      Medium
+    </n-button>
+    <n-button @click="handleBtnClick('large')">
+      Larger
+    </n-button>
+  </n-button-group>
+  <n-divider />
+  <n-config-provider :size="size">
+    <n-space vertical>
+      <n-button>Button</n-button>
+      <n-auto-complete />
+      <n-cascader style="width: 240px" />
+      <n-checkbox-group>
+        <n-checkbox>Handsome</n-checkbox>
+        <n-checkbox>Good-looking</n-checkbox>
+      </n-checkbox-group>
+      <n-date-picker />
+      <n-dynamic-tags />
+      <n-input-group>
+        <n-input-group-label> Before </n-input-group-label>
+        <n-input />
+        <n-input-group-label> After </n-input-group-label>
+      </n-input-group>
+      <n-input-number />
+    </n-space>
+  </n-config-provider>
+</template>

--- a/src/config-provider/demos/zhCN/index.demo-entry.md
+++ b/src/config-provider/demos/zhCN/index.demo-entry.md
@@ -14,6 +14,7 @@ os-theme.vue
 language.vue
 transparent.vue
 inline-theme-disabled.vue
+size.vue
 ```
 
 ## API
@@ -35,3 +36,4 @@ inline-theme-disabled.vue
 | tag | `string` | `'div'` | `n-config-provider` 被渲染成的元素 |  |
 | theme | `Theme \| null` | `undefined` | 对后代组件生效的主题对象，为 `null` 时会使用默认亮色，为 `undefined` 时会继承上级 `n-config-provider`。更多信息参见[调整主题](../docs/customize-theme) |  |
 | theme-overrides | `ThemeOverrides \| null` | `undefined` | 对后代组件生效的主题变量覆盖，为 `null` 时会清除全部覆盖变量，为 `undefined` 时会继承上级 `n-config-provider`。更多信息参见[调整主题](../docs/customize-theme) |  |
+| size | `small \| medium \| large` | `undefined` | 全局组件大小。 |  |

--- a/src/config-provider/demos/zhCN/size.demo.vue
+++ b/src/config-provider/demos/zhCN/size.demo.vue
@@ -1,0 +1,50 @@
+<markdown>
+# 组件尺寸
+
+修改默认组件尺寸。
+</markdown>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { GlobalSize } from 'naive-ui'
+
+const size = ref<GlobalSize>('small')
+
+function handleBtnClick(_size: GlobalSize): void {
+  size.value = _size
+}
+</script>
+
+<template>
+  <n-button-group>
+    <n-button @click="handleBtnClick('small')">
+      小一点儿
+    </n-button>
+    <n-button @click="handleBtnClick('medium')">
+      中规中矩
+    </n-button>
+    <n-button @click="handleBtnClick('large')">
+      大一点儿
+    </n-button>
+  </n-button-group>
+  <n-divider />
+  <n-config-provider :size>
+    <n-space vertical>
+      <n-button>按钮</n-button>
+      <n-auto-complete />
+      <n-cascader style="width: 240px" />
+      <n-checkbox-group>
+        <n-checkbox>靓仔</n-checkbox>
+        <n-checkbox>帅哥</n-checkbox>
+      </n-checkbox-group>
+      <n-date-picker />
+      <n-dynamic-tags />
+      <n-input-group>
+        <n-input-group-label> 之前 </n-input-group-label>
+        <n-input />
+        <n-input-group-label> 之后 </n-input-group-label>
+      </n-input-group>
+      <n-input-number />
+    </n-space>
+  </n-config-provider>
+</template>

--- a/src/config-provider/src/ConfigProvider.ts
+++ b/src/config-provider/src/ConfigProvider.ts
@@ -18,9 +18,11 @@ import type { NDateLocale, NLocale } from '../../locales'
 import type {
   GlobalComponentConfig,
   GlobalIconConfig,
+  GlobalSize,
   GlobalTheme,
   GlobalThemeOverrides
 } from './interface'
+
 import type {
   Breakpoints,
   RtlEnabledState,
@@ -48,6 +50,7 @@ export const configProviderProps = {
   katex: Object as PropType<Katex>,
   theme: Object as PropType<GlobalTheme | null>,
   themeOverrides: Object as PropType<GlobalThemeOverrides | null>,
+  size: String as PropType<GlobalSize>,
   componentOptions: Object as PropType<GlobalComponentConfig>,
   icons: Object as PropType<GlobalIconConfig>,
   breakpoints: Object as PropType<Breakpoints>,
@@ -228,7 +231,11 @@ export default defineComponent({
       mergedThemeOverridesRef,
       inlineThemeDisabled: inlineThemeDisabled || false,
       preflightStyleDisabled: preflightStyleDisabled || false,
-      styleMountTarget
+      styleMountTarget,
+      globalSize: computed(() => {
+        const { size } = props
+        return size === undefined ? undefined : size
+      })
     })
     return {
       mergedClsPrefix: mergedClsPrefixRef,

--- a/src/config-provider/src/interface.ts
+++ b/src/config-provider/src/interface.ts
@@ -23,3 +23,5 @@ export type {
   GlobalIconConfig,
   GlobalComponentConfig
 } from './internal-interface'
+
+export type GlobalSize = 'small' | 'medium' | 'large'

--- a/src/config-provider/src/internal-interface.ts
+++ b/src/config-provider/src/internal-interface.ts
@@ -101,7 +101,7 @@ import type { SplitTheme } from '../../split/styles'
 import type { FlexTheme } from '../../flex/styles'
 import type { FloatButtonGroupTheme } from '../../float-button-group/styles'
 import type { Katex } from './katex'
-import type { GlobalTheme, GlobalThemeOverrides } from './interface'
+import type { GlobalSize, GlobalTheme, GlobalThemeOverrides } from './interface'
 
 export interface GlobalThemeWithoutCommon {
   Alert?: AlertTheme
@@ -269,4 +269,5 @@ export interface ConfigProviderInjection {
   inlineThemeDisabled: boolean
   preflightStyleDisabled: boolean
   styleMountTarget: ParentNode | undefined
+  globalSize: Ref<GlobalSize | undefined>
 }

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -82,7 +82,8 @@ export default defineComponent({
       mergedBorderedRef,
       mergedClsPrefixRef,
       inlineThemeDisabled,
-      mergedRtlRef
+      mergedRtlRef,
+      globalSize
     } = useConfig(props)
     const rtlEnabledRef = useRtl('DataTable', mergedRtlRef, mergedClsPrefixRef)
     const mergedBottomBorderedRef = computed(() => {
@@ -303,7 +304,6 @@ export default defineComponent({
       }
     }
     const cssVarsRef = computed(() => {
-      const { size } = props
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -350,9 +350,9 @@ export default defineComponent({
           tdColorStriped,
           tdColorStripedModal,
           tdColorStripedPopover,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey('thPadding', size)]: thPadding,
-          [createKey('tdPadding', size)]: tdPadding
+          [createKey('fontSize', globalSize.value)]: fontSize,
+          [createKey('thPadding', globalSize.value)]: thPadding,
+          [createKey('tdPadding', globalSize.value)]: tdPadding
         }
       } = themeRef.value
       return {
@@ -408,7 +408,7 @@ export default defineComponent({
     const themeClassHandle = inlineThemeDisabled
       ? useThemeClass(
         'data-table',
-        computed(() => props.size[0]),
+        computed(() => globalSize.value[0]),
         cssVarsRef,
         props
       )

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -77,10 +77,7 @@ export const dataTableProps = {
     default: true
   },
   singleColumn: Boolean,
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large'>,
   remote: Boolean,
   defaultExpandedRowKeys: {
     type: Array as PropType<RowKey[]>,

--- a/src/data-table/src/utils.ts
+++ b/src/data-table/src/utils.ts
@@ -207,10 +207,10 @@ function formatCsvCell(value: unknown): string {
 
 export function generateCsv(columns: TableColumn[], data: RowData[]): string {
   const exportableColumns = columns.filter(
-    (column) =>
-      column.type !== 'expand' &&
-      column.type !== 'selection' &&
-      column.allowExport !== false
+    column =>
+      column.type !== 'expand'
+      && column.type !== 'selection'
+      && column.allowExport !== false
   )
   const header = exportableColumns.map((col: any) => col.title).join(',')
   const rows = data.map((row) => {

--- a/src/descriptions/src/Descriptions.tsx
+++ b/src/descriptions/src/Descriptions.tsx
@@ -43,10 +43,7 @@ export const descriptionsProps = {
     type: String,
     default: ':'
   },
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large'>,
   bordered: Boolean,
   labelClass: String,
   labelStyle: [Object, String] as PropType<string | CSSProperties>,
@@ -62,7 +59,8 @@ export default defineComponent({
   name: 'Descriptions',
   props: descriptionsProps,
   setup(props) {
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, globalSize }
+      = useConfig(props)
     const themeRef = useTheme(
       'Descriptions',
       '-descriptions',
@@ -72,7 +70,7 @@ export default defineComponent({
       mergedClsPrefixRef
     )
     const cssVarsRef = computed(() => {
-      const { size, bordered } = props
+      const { bordered } = props
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -91,11 +89,15 @@ export default defineComponent({
           borderColorPopover,
           borderRadius,
           lineHeight,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey(bordered ? 'thPaddingBordered' : 'thPadding', size)]:
-            thPadding,
-          [createKey(bordered ? 'tdPaddingBordered' : 'tdPadding', size)]:
-            tdPadding
+          [createKey('fontSize', globalSize.value)]: fontSize,
+          [createKey(
+            bordered ? 'thPaddingBordered' : 'thPadding',
+            globalSize.value
+          )]: thPadding,
+          [createKey(
+            bordered ? 'tdPaddingBordered' : 'tdPadding',
+            globalSize.value
+          )]: tdPadding
         }
       } = themeRef.value
       return {
@@ -125,10 +127,10 @@ export default defineComponent({
         'descriptions',
         computed(() => {
           let hash = ''
-          const { size, bordered } = props
+          const { bordered } = props
           if (bordered)
             hash += 'a'
-          hash += size[0]
+          hash += globalSize.value[0]
           return hash
         }),
         cssVarsRef,
@@ -141,7 +143,8 @@ export default defineComponent({
       themeClass: themeClassHandle?.themeClass,
       onRender: themeClassHandle?.onRender,
       compitableColumn: useCompitable(props, ['columns', 'column']),
-      inlineThemeDisabled
+      inlineThemeDisabled,
+      globalSize
     }
   },
   render() {
@@ -154,7 +157,7 @@ export default defineComponent({
       compitableColumn,
       labelPlacement,
       labelAlign,
-      size,
+      globalSize,
       bordered,
       title,
       cssVars,
@@ -317,7 +320,7 @@ export default defineComponent({
           this.themeClass,
           `${mergedClsPrefix}-descriptions--${labelPlacement}-label-placement`,
           `${mergedClsPrefix}-descriptions--${labelAlign}-label-align`,
-          `${mergedClsPrefix}-descriptions--${size}-size`,
+          `${mergedClsPrefix}-descriptions--${globalSize}-size`,
           bordered && `${mergedClsPrefix}-descriptions--bordered`
         ]}
       >

--- a/src/dropdown/src/Dropdown.tsx
+++ b/src/dropdown/src/Dropdown.tsx
@@ -78,10 +78,7 @@ const dropdownBaseProps = {
     type: Boolean,
     default: true
   },
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large' | 'huge'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large' | 'huge'>,
   inverted: Boolean,
   placement: {
     type: String as PropType<FollowerPlacement>,
@@ -214,7 +211,8 @@ export default defineComponent({
       keyboardEnabledRef
     )
 
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, globalSize }
+      = useConfig(props)
 
     const themeRef = useTheme(
       'Dropdown',
@@ -343,7 +341,7 @@ export default defineComponent({
       }
     }
     const cssVarsRef = computed(() => {
-      const { size, inverted } = props
+      const { inverted } = props
       const {
         common: { cubicBezierEaseInOut },
         self
@@ -353,13 +351,15 @@ export default defineComponent({
         dividerColor,
         borderRadius,
         optionOpacityDisabled,
-        [createKey('optionIconSuffixWidth', size)]: optionIconSuffixWidth,
-        [createKey('optionSuffixWidth', size)]: optionSuffixWidth,
-        [createKey('optionIconPrefixWidth', size)]: optionIconPrefixWidth,
-        [createKey('optionPrefixWidth', size)]: optionPrefixWidth,
-        [createKey('fontSize', size)]: fontSize,
-        [createKey('optionHeight', size)]: optionHeight,
-        [createKey('optionIconSize', size)]: optionIconSize
+        [createKey('optionIconSuffixWidth', globalSize.value)]:
+          optionIconSuffixWidth,
+        [createKey('optionSuffixWidth', globalSize.value)]: optionSuffixWidth,
+        [createKey('optionIconPrefixWidth', globalSize.value)]:
+          optionIconPrefixWidth,
+        [createKey('optionPrefixWidth', globalSize.value)]: optionPrefixWidth,
+        [createKey('fontSize', globalSize.value)]: fontSize,
+        [createKey('optionHeight', globalSize.value)]: optionHeight,
+        [createKey('optionIconSize', globalSize.value)]: optionIconSize
       } = self
       const vars: any = {
         '--n-bezier': cubicBezierEaseInOut,
@@ -408,7 +408,7 @@ export default defineComponent({
     const themeClassHandle = inlineThemeDisabled
       ? useThemeClass(
         'dropdown',
-        computed(() => `${props.size[0]}${props.inverted ? 'i' : ''}`),
+        computed(() => `${globalSize.value[0]}${props.inverted ? 'i' : ''}`),
         cssVarsRef,
         props
       )

--- a/src/dynamic-tags/src/DynamicTags.tsx
+++ b/src/dynamic-tags/src/DynamicTags.tsx
@@ -42,10 +42,7 @@ import style from './styles/index.cssr'
 export const dynamicTagsProps = {
   ...(useTheme.props as ThemeProps<DynamicTagsTheme>),
   ...commonProps,
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large'>,
   closable: {
     type: Boolean,
     default: true
@@ -91,7 +88,8 @@ export default defineComponent({
         }
       })
     }
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, globalSize }
+      = useConfig(props)
     const { localeRef } = useLocale('DynamicTags')
     const formItem = useFormItem(props)
     const { mergedDisabledRef } = formItem
@@ -117,7 +115,7 @@ export default defineComponent({
       return localeRef.value.add
     })
     const inputSizeRef = computed(() => {
-      return smallerSize(props.size)
+      return smallerSize(globalSize.value)
     })
     const triggerDisabledRef = computed(() => {
       return (
@@ -190,6 +188,7 @@ export default defineComponent({
       inputInstRef,
       localizedAdd: localizedAddRef,
       inputSize: inputSizeRef,
+      globalSize,
       inputValue: inputValueRef,
       showInput: showInputRef,
       inputForceFocused: inputForceFocusedRef,
@@ -227,7 +226,7 @@ export default defineComponent({
               tagStyle,
               type,
               round,
-              size,
+              globalSize,
               color,
               closable,
               mergedDisabled,
@@ -258,7 +257,7 @@ export default defineComponent({
                     style={tagStyle}
                     type={type}
                     round={round}
-                    size={size}
+                    size={globalSize}
                     color={color}
                     closable={closable}
                     disabled={mergedDisabled}

--- a/src/form/src/utils.ts
+++ b/src/form/src/utils.ts
@@ -1,6 +1,7 @@
 import { type ComputedRef, computed, inject, ref } from 'vue'
 import { get } from 'lodash-es'
 import { formatLength } from '../../_utils'
+import { useConfig } from '../../_mixins'
 import type { FormItemSetupProps } from './FormItem'
 import { formInjectionKey } from './context'
 import type { FormItemRule, Size } from './interface'
@@ -9,12 +10,18 @@ export function formItemSize(props: FormItemSetupProps): {
   mergedSize: ComputedRef<Size>
 } {
   const NForm = inject(formInjectionKey, null)
+  const { globalSize } = useConfig(props)
   return {
     mergedSize: computed(() => {
       if (props.size !== undefined)
         return props.size
+
       if (NForm?.props.size !== undefined)
         return NForm.props.size
+
+      if (globalSize.value !== undefined)
+        return globalSize.value
+
       return 'medium'
     })
   }

--- a/src/input/src/InputGroupLabel.tsx
+++ b/src/input/src/InputGroupLabel.tsx
@@ -1,5 +1,5 @@
 import { type PropType, computed, defineComponent, h } from 'vue'
-import { useConfig, useTheme, useThemeClass } from '../../_mixins'
+import { useConfig, useFormItem, useTheme, useThemeClass } from '../../_mixins'
 import type { ThemeProps } from '../../_mixins'
 import { createKey } from '../../_utils'
 import type { ExtractPublicPropTypes } from '../../_utils'
@@ -10,10 +10,7 @@ import type { Size } from './interface'
 
 export const inputGroupLabelProps = {
   ...(useTheme.props as ThemeProps<InputTheme>),
-  size: {
-    type: String as PropType<Size>,
-    default: 'medium'
-  },
+  size: String as PropType<Size>,
   bordered: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined
@@ -38,8 +35,8 @@ export default defineComponent({
       props,
       mergedClsPrefixRef
     )
+    const { mergedSizeRef } = useFormItem(props)
     const cssVarsRef = computed(() => {
-      const { size } = props
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -48,8 +45,8 @@ export default defineComponent({
           groupLabelTextColor,
           lineHeight,
           groupLabelBorder,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey('height', size)]: height
+          [createKey('fontSize', mergedSizeRef.value)]: fontSize,
+          [createKey('height', mergedSizeRef.value)]: height
         }
       } = themeRef.value
       return {
@@ -66,7 +63,7 @@ export default defineComponent({
     const themeClassHandle = inlineThemeDisabled
       ? useThemeClass(
         'input-group-label',
-        computed(() => props.size[0]),
+        computed(() => mergedSizeRef.value[0]),
         cssVarsRef,
         props
       )

--- a/src/pagination/src/Pagination.tsx
+++ b/src/pagination/src/Pagination.tsx
@@ -79,10 +79,7 @@ export const paginationProps = {
     }
   },
   showQuickJumper: Boolean,
-  size: {
-    type: String as PropType<Size>,
-    default: 'medium'
-  },
+  size: String as PropType<Size>,
   disabled: Boolean,
   pageSlot: {
     type: Number,
@@ -153,7 +150,8 @@ export default defineComponent({
       mergedComponentPropsRef,
       mergedClsPrefixRef,
       inlineThemeDisabled,
-      mergedRtlRef
+      mergedRtlRef,
+      globalSize
     } = useConfig(props)
     const themeRef = useTheme(
       'Pagination',
@@ -258,13 +256,13 @@ export default defineComponent({
     const inputSizeRef = computed<InputSize>(() => {
       return (
         mergedComponentPropsRef?.value?.Pagination?.inputSize
-        || smallerSize(props.size)
+        || smallerSize(globalSize.value)
       )
     })
     const selectSizeRef = computed<SelectSize>(() => {
       return (
         mergedComponentPropsRef?.value?.Pagination?.selectSize
-        || smallerSize(props.size)
+        || smallerSize(globalSize.value)
       )
     })
     const startIndexRef = computed(() => {
@@ -405,7 +403,6 @@ export default defineComponent({
       disableTransitionOneTick()
     })
     const cssVarsRef = computed(() => {
-      const { size } = props
       const {
         self: {
           buttonBorder,
@@ -436,20 +433,22 @@ export default defineComponent({
           buttonColor,
           buttonColorHover,
           buttonColorPressed,
-          [createKey('itemPadding', size)]: itemPadding,
-          [createKey('itemMargin', size)]: itemMargin,
-          [createKey('inputWidth', size)]: inputWidth,
-          [createKey('selectWidth', size)]: selectWidth,
-          [createKey('inputMargin', size)]: inputMargin,
-          [createKey('selectMargin', size)]: selectMargin,
-          [createKey('jumperFontSize', size)]: jumperFontSize,
-          [createKey('prefixMargin', size)]: prefixMargin,
-          [createKey('suffixMargin', size)]: suffixMargin,
-          [createKey('itemSize', size)]: itemSize,
-          [createKey('buttonIconSize', size)]: buttonIconSize,
-          [createKey('itemFontSize', size)]: itemFontSize,
-          [`${createKey('itemMargin', size)}Rtl` as const]: itemMarginRtl,
-          [`${createKey('inputMargin', size)}Rtl` as const]: inputMarginRtl
+          [createKey('itemPadding', globalSize.value)]: itemPadding,
+          [createKey('itemMargin', globalSize.value)]: itemMargin,
+          [createKey('inputWidth', globalSize.value)]: inputWidth,
+          [createKey('selectWidth', globalSize.value)]: selectWidth,
+          [createKey('inputMargin', globalSize.value)]: inputMargin,
+          [createKey('selectMargin', globalSize.value)]: selectMargin,
+          [createKey('jumperFontSize', globalSize.value)]: jumperFontSize,
+          [createKey('prefixMargin', globalSize.value)]: prefixMargin,
+          [createKey('suffixMargin', globalSize.value)]: suffixMargin,
+          [createKey('itemSize', globalSize.value)]: itemSize,
+          [createKey('buttonIconSize', globalSize.value)]: buttonIconSize,
+          [createKey('itemFontSize', globalSize.value)]: itemFontSize,
+          [`${createKey('itemMargin', globalSize.value)}Rtl` as const]:
+            itemMarginRtl,
+          [`${createKey('inputMargin', globalSize.value)}Rtl` as const]:
+            inputMarginRtl
         },
         common: { cubicBezierEaseInOut }
       } = themeRef.value
@@ -504,8 +503,7 @@ export default defineComponent({
         'pagination',
         computed(() => {
           let hash = ''
-          const { size } = props
-          hash += size[0]
+          hash += globalSize.value[0]
           return hash
         }),
         cssVarsRef,

--- a/src/popselect/src/PopselectPanel.tsx
+++ b/src/popselect/src/PopselectPanel.tsx
@@ -46,10 +46,7 @@ export const panelProps = {
     type: Array as PropType<SelectMixedOption[]>,
     default: () => []
   },
-  size: {
-    type: String as PropType<PopselectSize>,
-    default: 'medium'
-  },
+  size: String as PropType<PopselectSize>,
   scrollable: Boolean,
   'onUpdate:value': [Function, Array] as PropType<MaybeArray<OnUpdateValue>>,
   onUpdateValue: [Function, Array] as PropType<MaybeArray<OnUpdateValue>>,
@@ -85,7 +82,8 @@ export default defineComponent({
 
     const NPopselect = inject(popselectInjectionKey)!
 
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, globalSize }
+      = useConfig(props)
 
     const themeRef = useTheme(
       'Popselect',
@@ -212,7 +210,8 @@ export default defineComponent({
       handleMenuMousedown,
       cssVars: inlineThemeDisabled ? undefined : cssVarsRef,
       themeClass: themeClassHandle?.themeClass,
-      onRender: themeClassHandle?.onRender
+      onRender: themeClassHandle?.onRender,
+      globalSize
     }
   },
   render() {
@@ -228,7 +227,7 @@ export default defineComponent({
         themeOverrides={this.mergedTheme.peerOverrides.InternalSelectMenu}
         multiple={this.multiple}
         treeMate={this.treeMate}
-        size={this.size}
+        size={this.globalSize}
         value={this.value}
         virtualScroll={this.virtualScroll}
         scrollable={this.scrollable}

--- a/src/radio/src/use-radio.ts
+++ b/src/radio/src/use-radio.ts
@@ -82,6 +82,7 @@ function setup(props: ExtractPropTypes<typeof radioBaseProps>): UseRadio {
     })
   }
   const NRadioGroup = inject(radioGroupInjectionKey, null)
+  const { mergedClsPrefixRef, globalSize } = useConfig(props)
   const formItem = useFormItem(props, {
     mergedSize(NFormItem) {
       const { size } = props
@@ -98,6 +99,8 @@ function setup(props: ExtractPropTypes<typeof radioBaseProps>): UseRadio {
       if (NFormItem) {
         return NFormItem.mergedSize.value
       }
+      if (globalSize.value)
+        return globalSize.value
       return 'medium'
     },
     mergedDisabled(NFormItem) {
@@ -175,7 +178,7 @@ function setup(props: ExtractPropTypes<typeof radioBaseProps>): UseRadio {
   return {
     mergedClsPrefix: NRadioGroup
       ? NRadioGroup.mergedClsPrefixRef
-      : useConfig(props).mergedClsPrefixRef,
+      : mergedClsPrefixRef,
     inputRef,
     labelRef,
     mergedName: mergedNameRef,

--- a/src/rate/src/Rate.tsx
+++ b/src/rate/src/Rate.tsx
@@ -33,10 +33,7 @@ export const rateProps = {
     default: null
   },
   readonly: Boolean,
-  size: {
-    type: [String, Number] as PropType<number | 'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: [String, Number] as PropType<RateSize>,
   clearable: Boolean,
   color: String,
   onClear: Function as PropType<() => void>,
@@ -47,6 +44,7 @@ export const rateProps = {
 } as const
 
 export type RateProps = ExtractPublicPropTypes<typeof rateProps>
+type RateSize = number | 'small' | 'medium' | 'large'
 
 export default defineComponent({
   name: 'Rate',
@@ -64,7 +62,7 @@ export default defineComponent({
     const controlledValueRef = toRef(props, 'value')
     const uncontrolledValueRef = ref(props.defaultValue)
     const hoverIndexRef = ref<number | null>(null)
-    const formItem = useFormItem(props)
+    const formItem = useFormItem<RateSize>(props)
     const mergedValue = useMergedState(controlledValueRef, uncontrolledValueRef)
     function doUpdateValue(value: number | null): void {
       const { 'onUpdate:value': _onUpdateValue, onUpdateValue } = props
@@ -121,13 +119,13 @@ export default defineComponent({
       cleared = false
     }
     const mergedSizeRef = computed(() => {
-      const { size } = props
+      const { mergedSizeRef: size } = formItem
       const { self } = themeRef.value
-      if (typeof size === 'number') {
-        return `${size}px`
+      if (typeof size.value === 'number') {
+        return `${size.value}px`
       }
       else {
-        return self[createKey('size', size)]
+        return self[createKey('size', size.value)]
       }
     })
     const cssVarsRef = computed(() => {

--- a/src/result/src/Result.tsx
+++ b/src/result/src/Result.tsx
@@ -37,10 +37,7 @@ const iconRenderMap = {
 
 export const resultProps = {
   ...(useTheme.props as ThemeProps<ResultTheme>),
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large' | 'huge'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large' | 'huge'>,
   status: {
     type: String as PropType<
       'info' | 'success' | 'warning' | 'error' | '404' | '403' | '500' | '418'
@@ -57,7 +54,8 @@ export default defineComponent({
   name: 'Result',
   props: resultProps,
   setup(props) {
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, globalSize }
+      = useConfig(props)
     const themeRef = useTheme(
       'Result',
       '-result',
@@ -67,7 +65,7 @@ export default defineComponent({
       mergedClsPrefixRef
     )
     const cssVarsRef = computed(() => {
-      const { size, status } = props
+      const { status } = props
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -76,9 +74,9 @@ export default defineComponent({
           titleTextColor,
           titleFontWeight,
           [createKey('iconColor', status)]: iconColor,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey('titleFontSize', size)]: titleFontSize,
-          [createKey('iconSize', size)]: iconSize
+          [createKey('fontSize', globalSize.value)]: fontSize,
+          [createKey('titleFontSize', globalSize.value)]: titleFontSize,
+          [createKey('iconSize', globalSize.value)]: iconSize
         }
       } = themeRef.value
       return {
@@ -97,10 +95,10 @@ export default defineComponent({
       ? useThemeClass(
         'result',
         computed(() => {
-          const { size, status } = props
+          const { status } = props
           let hash = ''
-          if (size) {
-            hash += size[0]
+          if (globalSize.value) {
+            hash += globalSize.value[0]
           }
           if (status) {
             hash += status[0]

--- a/src/skeleton/src/Skeleton.tsx
+++ b/src/skeleton/src/Skeleton.tsx
@@ -44,7 +44,9 @@ export default defineComponent({
   props: skeletonProps,
   setup(props) {
     useHoudini()
-    const { mergedClsPrefixRef } = useConfig(props)
+    const { mergedClsPrefixRef, globalSize } = useConfig(props, {
+      defaultSize: undefined
+    })
     const themeRef = useTheme(
       'Skeleton',
       '-skeleton',
@@ -63,10 +65,9 @@ export default defineComponent({
         const selfThemeVars = theme.self
         const { color, colorEnd, borderRadius } = selfThemeVars
         let sizeHeight: string | undefined
-        const { circle, sharp, round, width, height, size, text, animated }
-          = props
-        if (size !== undefined) {
-          sizeHeight = selfThemeVars[createKey('height', size)]
+        const { circle, sharp, round, width, height, text, animated } = props
+        if (globalSize.value !== undefined) {
+          sizeHeight = selfThemeVars[createKey('height', globalSize.value)]
         }
         const mergedWidth = circle ? (width ?? height ?? sizeHeight) : width
         const mergedHeight = (circle ? (width ?? height) : height) ?? sizeHeight

--- a/src/space/src/Space.tsx
+++ b/src/space/src/Space.tsx
@@ -43,12 +43,7 @@ export const spaceProps = {
   inline: Boolean,
   vertical: Boolean,
   reverse: Boolean,
-  size: {
-    type: [String, Number, Array] as PropType<
-      'small' | 'medium' | 'large' | number | [number, number]
-    >,
-    default: 'medium'
-  },
+  size: [String, Number, Array] as PropType<Size>,
   wrapItem: {
     type: Boolean,
     default: true
@@ -67,12 +62,13 @@ export const spaceProps = {
 } as const
 
 export type SpaceProps = ExtractPublicPropTypes<typeof spaceProps>
+type Size = 'small' | 'medium' | 'large' | number | [number, number]
 
 export default defineComponent({
   name: 'Space',
   props: spaceProps,
   setup(props) {
-    const { mergedClsPrefixRef, mergedRtlRef } = useConfig(props)
+    const { mergedClsPrefixRef, mergedRtlRef, globalSize } = useConfig(props)
     const themeRef = useTheme(
       'Space',
       '-space',
@@ -87,21 +83,20 @@ export default defineComponent({
       rtlEnabled: rtlEnabledRef,
       mergedClsPrefix: mergedClsPrefixRef,
       margin: computed<{ horizontal: number, vertical: number }>(() => {
-        const { size } = props
-        if (Array.isArray(size)) {
+        if (Array.isArray(globalSize.value)) {
           return {
-            horizontal: size[0],
-            vertical: size[1]
+            horizontal: globalSize.value[0],
+            vertical: globalSize.value[1]
           }
         }
-        if (typeof size === 'number') {
+        if (typeof (globalSize.value as Size) === 'number') {
           return {
-            horizontal: size,
-            vertical: size
+            horizontal: globalSize.value,
+            vertical: globalSize.value
           }
         }
         const {
-          self: { [createKey('gap', size)]: gap }
+          self: { [createKey('gap', globalSize.value)]: gap }
         } = themeRef.value
         const { row, col } = getGap(gap)
         return {

--- a/src/switch/src/Switch.tsx
+++ b/src/switch/src/Switch.tsx
@@ -28,10 +28,7 @@ import style from './styles/index.cssr'
 
 export const switchProps = {
   ...(useTheme.props as ThemeProps<SwitchTheme>),
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large'>,
   value: {
     type: [String, Number, Boolean] as PropType<
       string | number | boolean | undefined

--- a/src/table/src/Table.tsx
+++ b/src/table/src/Table.tsx
@@ -30,10 +30,7 @@ export const tableProps = {
   },
   striped: Boolean,
   singleColumn: Boolean,
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
-    default: 'medium'
-  }
+  size: String as PropType<'small' | 'medium' | 'large'>
 }
 
 export type TableProps = ExtractPublicPropTypes<typeof tableProps>
@@ -42,8 +39,12 @@ export default defineComponent({
   name: 'Table',
   props: tableProps,
   setup(props) {
-    const { mergedClsPrefixRef, inlineThemeDisabled, mergedRtlRef }
-      = useConfig(props)
+    const {
+      mergedClsPrefixRef,
+      inlineThemeDisabled,
+      mergedRtlRef,
+      globalSize
+    } = useConfig(props)
     const themeRef = useTheme(
       'Table',
       '-table',
@@ -54,7 +55,6 @@ export default defineComponent({
     )
     const rtlEnabledRef = useRtl('Table', mergedRtlRef, mergedClsPrefixRef)
     const cssVarsRef = computed(() => {
-      const { size } = props
       const {
         self: {
           borderColor,
@@ -74,9 +74,9 @@ export default defineComponent({
           tdColorStriped,
           tdColorStripedModal,
           tdColorStripedPopover,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey('tdPadding', size)]: tdPadding,
-          [createKey('thPadding', size)]: thPadding
+          [createKey('fontSize', globalSize.value)]: fontSize,
+          [createKey('tdPadding', globalSize.value)]: tdPadding,
+          [createKey('thPadding', globalSize.value)]: thPadding
         },
         common: { cubicBezierEaseInOut }
       } = themeRef.value
@@ -108,7 +108,7 @@ export default defineComponent({
       ? useThemeClass(
         'table',
         computed(() => {
-          return props.size[0]
+          return globalSize.value[0]
         }),
         cssVarsRef,
         props

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -76,10 +76,7 @@ export const tabsProps = {
     | 'start'
     | 'end'
   >,
-  size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: String as PropType<'small' | 'medium' | 'large'>,
   placement: {
     type: String as PropType<'top' | 'left' | 'right' | 'bottom'>,
     default: 'top'
@@ -141,7 +138,8 @@ export default defineComponent({
       })
     }
 
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, globalSize }
+      = useConfig(props)
     const themeRef = useTheme(
       'Tabs',
       '-tabs',
@@ -164,6 +162,15 @@ export default defineComponent({
     const endReachedRef = ref(true)
 
     const compitableSizeRef = useCompitable(props, ['labelSize', 'size'])
+    const mergedSizeRef = computed(() => {
+      if (compitableSizeRef.value)
+        return compitableSizeRef.value
+
+      if (globalSize.value)
+        return globalSize.value
+
+      return 'medium'
+    })
     const compitableValueRef = useCompitable(props, ['activeName', 'value'])
     const uncontrolledValueRef = ref(
       compitableValueRef.value
@@ -668,7 +675,7 @@ export default defineComponent({
     }
 
     const cssVarsRef = computed(() => {
-      const { value: size } = compitableSizeRef
+      const { value: size } = mergedSizeRef
       const { type } = props
       const typeSuffix = (
         {
@@ -752,7 +759,7 @@ export default defineComponent({
       ? useThemeClass(
         'tabs',
         computed(() => {
-          return `${compitableSizeRef.value[0]}${props.type[0]}`
+          return `${mergedSizeRef.value[0]}${props.type[0]}`
         }),
         cssVarsRef,
         props
@@ -773,7 +780,7 @@ export default defineComponent({
       addTabFixed: addTabFixedRef,
       tabWrapperStyle: tabWrapperStyleRef,
       handleNavResize,
-      mergedSize: compitableSizeRef,
+      mergedSize: mergedSizeRef,
       handleScroll,
       handleTabsResize,
       cssVars: inlineThemeDisabled ? undefined : cssVarsRef,

--- a/src/tag/src/Tag.tsx
+++ b/src/tag/src/Tag.tsx
@@ -92,7 +92,8 @@ export default defineComponent({
       mergedBorderedRef,
       mergedClsPrefixRef,
       inlineThemeDisabled,
-      mergedRtlRef
+      mergedRtlRef,
+      globalSize
     } = useConfig(props)
     const themeRef = useTheme(
       'Tag',
@@ -143,7 +144,7 @@ export default defineComponent({
     }
     const rtlEnabledRef = useRtl('Tag', mergedRtlRef, mergedClsPrefixRef)
     const cssVarsRef = computed(() => {
-      const { type, size, color: { color, textColor } = {} } = props
+      const { type, color: { color, textColor } = {} } = props
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -164,10 +165,10 @@ export default defineComponent({
           closeBorderRadius,
           fontWeightStrong,
           [createKey('colorBordered', type)]: colorBordered,
-          [createKey('closeSize', size)]: closeSize,
-          [createKey('closeIconSize', size)]: closeIconSize,
-          [createKey('fontSize', size)]: fontSize,
-          [createKey('height', size)]: height,
+          [createKey('closeSize', globalSize.value)]: closeSize,
+          [createKey('closeIconSize', globalSize.value)]: closeIconSize,
+          [createKey('fontSize', globalSize.value)]: fontSize,
+          [createKey('height', globalSize.value)]: height,
           [createKey('color', type)]: typedColor,
           [createKey('textColor', type)]: typeTextColor,
           [createKey('border', type)]: border,
@@ -222,9 +223,9 @@ export default defineComponent({
         'tag',
         computed(() => {
           let hash = ''
-          const { type, size, color: { color, textColor } = {} } = props
+          const { type, color: { color, textColor } = {} } = props
           hash += type[0]
-          hash += size[0]
+          hash += globalSize.value[0]
           if (color) {
             hash += `a${color2Class(color)}`
           }

--- a/src/tag/src/common-props.ts
+++ b/src/tag/src/common-props.ts
@@ -15,10 +15,7 @@ export default {
     default: 'default'
   },
   round: Boolean,
-  size: {
-    type: String as PropType<'tiny' | 'small' | 'medium' | 'large'>,
-    default: 'medium'
-  },
+  size: String as PropType<'tiny' | 'small' | 'medium' | 'large'>,
   closable: Boolean,
   disabled: {
     type: Boolean as PropType<boolean | undefined>,


### PR DESCRIPTION
-This modification involves 32 components
-The code that needs to be modified is：button、card、dropdown、tag、checkbox、dynamic-tags、form、input、radio、rate、switch、data-table、descriptions、table、pagination、tabs、popselect、result、skeleton、space、config-provider 
-There are influences：auto-complete、cascader、color-picker、date-picker、input-number、mention、select、time-picker、transfer、tree-select、legacy-transfer

Closes #356

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
