### PR TITLE
Fix `n-avatar` `n-carousel` `n-back-top` ... that use the vueuc toolk…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -23,7 +23,7 @@
 - Fix `n-icon`'s `component` prop not accepting FunctionalComponent.
 - Fix `n-mention`'s panel is misplaced if `placement` is set to `'top'` or padding is set to component's style, closes [#6241](https://github.com/tusen-ai/naive-ui/issues/6241).
 - Fix `n-carousel` transition not working as expected, closes [#5993](https://github.com/tusen-ai/naive-ui/issues/5993).
-- Fix `n-avatar` `n-carousel` `n-back-top` ... that use the vueuc toolkit fail to build on nuxt
+- Fix `n-avatar` `n-carousel` `n-back-top` ... that use the vueuc toolkit fail to build on nuxt.
 
 ### Features
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -23,6 +23,7 @@
 - Fix `n-icon`'s `component` prop not accepting FunctionalComponent.
 - Fix `n-mention`'s panel is misplaced if `placement` is set to `'top'` or padding is set to component's style, closes [#6241](https://github.com/tusen-ai/naive-ui/issues/6241).
 - Fix `n-carousel` transition not working as expected, closes [#5993](https://github.com/tusen-ai/naive-ui/issues/5993).
+- Fix `n-avatar` `n-carousel` `n-back-top` ... that use the vueuc toolkit fail to build on nuxt
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,6 +23,7 @@
 - 修复 `n-icon` 的 `component` 属性不接受 FunctionalComponent 问题
 - 修复 `n-mention` 的面板在 `placement` 设为 `'top'` 或者组件设定的 padding 的时候位置有问题，关闭 [#6241](https://github.com/tusen-ai/naive-ui/issues/6241)
 - 修复 `n-carousel` 中轮播图的过渡行为不符合预期问题，关闭 [#5993](https://github.com/tusen-ai/naive-ui/issues/5993)
+- 修复 `n-avatar` `n-carousel` `n-back-top` 等使用了vueuc工具库的组件在nuxt下构建失败的问题
 
 ### Features
 

--- a/src/_internal/scrollbar/src/Scrollbar.tsx
+++ b/src/_internal/scrollbar/src/Scrollbar.tsx
@@ -12,7 +12,7 @@ import {
 } from 'vue'
 import type { CSSProperties, HTMLAttributes, PropType, VNode } from 'vue'
 import { off, on } from 'evtd'
-import { VResizeObserver } from 'vueuc'
+import { VResizeObserver } from 'vueuc/es'
 import { useIsIos } from 'vooks'
 import { depx, getPreciseEventTarget } from 'seemly'
 import { useConfig, useRtl, useTheme, useThemeClass } from '../../../_mixins'

--- a/src/_internal/select-menu/src/SelectMenu.tsx
+++ b/src/_internal/select-menu/src/SelectMenu.tsx
@@ -14,7 +14,7 @@ import {
   watch
 } from 'vue'
 import { type TreeNode, createIndexGetter } from 'treemate'
-import { VirtualList, type VirtualListInst } from 'vueuc'
+import { VirtualList, type VirtualListInst } from 'vueuc/es'
 import { depx, getPadding, happensIn } from 'seemly'
 import { NEmpty } from '../../../empty'
 import { NScrollbar } from '../../scrollbar'

--- a/src/_internal/selection/src/Selection.tsx
+++ b/src/_internal/selection/src/Selection.tsx
@@ -14,7 +14,7 @@ import {
   watch,
   watchEffect
 } from 'vue'
-import { VOverflow, type VOverflowInst } from 'vueuc'
+import { VOverflow, type VOverflowInst } from 'vueuc/es'
 import { getPadding } from 'seemly'
 import type {
   RenderLabel,

--- a/src/_utils/composable/use-resize.ts
+++ b/src/_utils/composable/use-resize.ts
@@ -1,5 +1,5 @@
 import { type Ref, onBeforeUnmount, onMounted } from 'vue'
-import { resizeObserverManager } from 'vueuc'
+import { resizeObserverManager } from 'vueuc/es'
 
 export function useOnResize(
   elRef: Ref<HTMLElement | null>,

--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -13,7 +13,7 @@ import {
   withDirectives
 } from 'vue'
 import { type TreeNode, createTreeMate } from 'treemate'
-import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc'
+import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import { getPreciseEventTarget } from 'seemly'

--- a/src/avatar/src/Avatar.tsx
+++ b/src/avatar/src/Avatar.tsx
@@ -12,7 +12,7 @@ import {
   watch,
   watchEffect
 } from 'vue'
-import { VResizeObserver } from 'vueuc'
+import { VResizeObserver } from 'vueuc/es'
 import { isImageSupportNativeLazy } from '../../_utils/env/is-native-lazy-load'
 import {
   type IntersectionObserverOptions,

--- a/src/back-top/src/BackTop.tsx
+++ b/src/back-top/src/BackTop.tsx
@@ -13,7 +13,7 @@ import {
   watch,
   watchEffect
 } from 'vue'
-import { VLazyTeleport } from 'vueuc'
+import { VLazyTeleport } from 'vueuc/es'
 import { useIsMounted, useMergedState } from 'vooks'
 import { getScrollParent, unwrapElement } from 'seemly'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
@@ -291,10 +291,10 @@ export default defineComponent({
                         'div',
                         mergeProps(this.$attrs, {
                           class: [
-                              `${mergedClsPrefix}-back-top`,
-                              this.themeClass,
-                              this.transitionDisabled
-                              && `${mergedClsPrefix}-back-top--transition-disabled`
+                            `${mergedClsPrefix}-back-top`,
+                            this.themeClass,
+                            this.transitionDisabled
+                            && `${mergedClsPrefix}-back-top--transition-disabled`
                           ],
                           style: [this.style, this.cssVars],
                           onClick: this.handleClick

--- a/src/carousel/src/Carousel.tsx
+++ b/src/carousel/src/Carousel.tsx
@@ -17,7 +17,7 @@ import {
   withDirectives
 } from 'vue'
 import type { CSSProperties, PropType, Ref, TransitionProps, VNode } from 'vue'
-import { VResizeObserver } from 'vueuc'
+import { VResizeObserver } from 'vueuc/es'
 import { useMergedState } from 'vooks'
 import { off, on } from 'evtd'
 import { getPreciseEventTarget } from 'seemly'

--- a/src/cascader/src/Cascader.tsx
+++ b/src/cascader/src/Cascader.tsx
@@ -26,7 +26,7 @@ import {
   VBinder,
   VFollower,
   VTarget
-} from 'vueuc'
+} from 'vueuc/es'
 import { changeColor, depx, getPreciseEventTarget, happensIn } from 'seemly'
 import { useIsMounted, useMergedState } from 'vooks'
 import type { FormValidationStatus } from '../../form/src/interface'

--- a/src/cascader/src/CascaderMenu.tsx
+++ b/src/cascader/src/CascaderMenu.tsx
@@ -7,7 +7,7 @@ import {
   ref,
   withDirectives
 } from 'vue'
-import type { FollowerPlacement } from 'vueuc'
+import type { FollowerPlacement } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import FocusDetector from '../../_internal/focus-detector'
 import type { MenuMaskRef } from '../../_internal/menu-mask'

--- a/src/cascader/src/CascaderSubmenu.tsx
+++ b/src/cascader/src/CascaderSubmenu.tsx
@@ -1,5 +1,5 @@
 import { type PropType, computed, defineComponent, h, inject, ref } from 'vue'
-import { VirtualList, type VirtualListInst } from 'vueuc'
+import { VirtualList, type VirtualListInst } from 'vueuc/es'
 import { depx } from 'seemly'
 import { NScrollbar } from '../../_internal'
 import type { ScrollbarInst } from '../../_internal'

--- a/src/color-picker/src/ColorPicker.tsx
+++ b/src/color-picker/src/ColorPicker.tsx
@@ -39,7 +39,7 @@ import {
   toRgbaString
 } from 'seemly'
 import { useIsMounted, useMergedState } from 'vooks'
-import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc'
+import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import { colorPickerLight } from '../styles'
 import type { ColorPickerTheme } from '../styles'

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -12,7 +12,7 @@ import {
   watchEffect
 } from 'vue'
 import { pxfy, repeat } from 'seemly'
-import { VResizeObserver, VirtualList, type VirtualListInst } from 'vueuc'
+import { VResizeObserver, VirtualList, type VirtualListInst } from 'vueuc/es'
 import type { CNode } from 'css-render'
 import { useMemo } from 'vooks'
 import { cssrAnchorMetaName } from '../../../_mixins/common'

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -14,7 +14,7 @@ import {
   watchEffect,
   withDirectives
 } from 'vue'
-import { VBinder, VFollower, VTarget } from 'vueuc'
+import { VBinder, VFollower, VTarget } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import { format, getTime, isValid } from 'date-fns'
 import { useIsMounted, useMergedState } from 'vooks'

--- a/src/date-picker/src/interface.ts
+++ b/src/date-picker/src/interface.ts
@@ -1,5 +1,5 @@
 import type { Ref, Slots, UnwrapNestedRefs } from 'vue'
-import type { VirtualListInst } from 'vueuc'
+import type { VirtualListInst } from 'vueuc/es'
 import type { NDateLocale, NLocale } from '../../locales'
 import type { ScrollbarInst } from '../../_internal'
 import type {

--- a/src/date-picker/src/panel/month.tsx
+++ b/src/date-picker/src/panel/month.tsx
@@ -1,5 +1,5 @@
 import { type PropType, type VNode, defineComponent, h, onMounted } from 'vue'
-import { VirtualList } from 'vueuc'
+import { VirtualList } from 'vueuc/es'
 import { useLocale } from '../../../_mixins'
 import { NButton, NxButton } from '../../../button'
 import { NBaseFocusDetector, NScrollbar } from '../../../_internal'

--- a/src/date-picker/src/panel/monthrange.tsx
+++ b/src/date-picker/src/panel/monthrange.tsx
@@ -7,7 +7,7 @@ import {
   renderSlot,
   watchEffect
 } from 'vue'
-import { VirtualList } from 'vueuc'
+import { VirtualList } from 'vueuc/es'
 import { useLocale } from '../../../_mixins'
 import { NxButton } from '../../../button'
 import { NBaseFocusDetector, NScrollbar } from '../../../_internal'

--- a/src/date-picker/src/panel/panelHeader.tsx
+++ b/src/date-picker/src/panel/panelHeader.tsx
@@ -6,7 +6,7 @@ import {
   ref,
   withDirectives
 } from 'vue'
-import { VBinder, VFollower, VTarget } from 'vueuc'
+import { VBinder, VFollower, VTarget } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import { getPreciseEventTarget } from 'seemly'
 import MonthPanel from './month'

--- a/src/date-picker/src/panel/use-calendar.ts
+++ b/src/date-picker/src/panel/use-calendar.ts
@@ -27,7 +27,7 @@ import {
   startOfWeek,
   startOfYear
 } from 'date-fns'
-import type { VirtualListInst } from 'vueuc'
+import type { VirtualListInst } from 'vueuc/es'
 import type { ScrollbarInst } from '../../../_internal'
 import {
   dateArray,

--- a/src/date-picker/src/panel/use-dual-calendar.ts
+++ b/src/date-picker/src/panel/use-dual-calendar.ts
@@ -13,7 +13,7 @@ import {
   startOfQuarter,
   startOfSecond
 } from 'date-fns'
-import type { VirtualListInst } from 'vueuc'
+import type { VirtualListInst } from 'vueuc/es'
 import {
   type DateItem,
   type MonthItem,

--- a/src/date-picker/src/props.ts
+++ b/src/date-picker/src/props.ts
@@ -1,5 +1,5 @@
 import type { PropType } from 'vue'
-import type { FollowerPlacement } from 'vueuc'
+import type { FollowerPlacement } from 'vueuc/es'
 import type { ThemeProps } from '../../_mixins'
 import { useTheme } from '../../_mixins'
 import type { MaybeArray } from '../../_utils'

--- a/src/drawer/src/Drawer.tsx
+++ b/src/drawer/src/Drawer.tsx
@@ -11,7 +11,7 @@ import {
   watchEffect,
   withDirectives
 } from 'vue'
-import { VLazyTeleport } from 'vueuc'
+import { VLazyTeleport } from 'vueuc/es'
 import { zindexable } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'

--- a/src/drawer/src/DrawerBodyWrapper.tsx
+++ b/src/drawer/src/DrawerBodyWrapper.tsx
@@ -16,7 +16,7 @@ import {
   watchEffect,
   withDirectives
 } from 'vue'
-import { VFocusTrap } from 'vueuc'
+import { VFocusTrap } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import { useConfig, useRtl } from '../../_mixins'
 import { popoverBodyInjectionKey } from '../../popover/src/interface'
@@ -272,28 +272,28 @@ export default defineComponent({
                             ref: 'bodyRef',
                             'aria-modal': 'true',
                             class: [
-                                `${mergedClsPrefix}-drawer`,
-                                this.rtlEnabled
-                                && `${mergedClsPrefix}-drawer--rtl`,
-                                `${mergedClsPrefix}-drawer--${this.placement}-placement`,
-                                /**
-                                 * When the mouse is pressed to resize the drawer,
-                                 * disable text selection
-                                 */
-                                this.isDragging
-                                && `${mergedClsPrefix}-drawer--unselectable`,
-                                this.nativeScrollbar
-                                && `${mergedClsPrefix}-drawer--native-scrollbar`
+                              `${mergedClsPrefix}-drawer`,
+                              this.rtlEnabled
+                              && `${mergedClsPrefix}-drawer--rtl`,
+                              `${mergedClsPrefix}-drawer--${this.placement}-placement`,
+                              /**
+                               * When the mouse is pressed to resize the drawer,
+                               * disable text selection
+                               */
+                              this.isDragging
+                              && `${mergedClsPrefix}-drawer--unselectable`,
+                              this.nativeScrollbar
+                              && `${mergedClsPrefix}-drawer--native-scrollbar`
                             ]
                           }),
                           [
                             this.resizable ? (
                               <div
                                 class={[
-                                    `${mergedClsPrefix}-drawer__resize-trigger`,
-                                    (this.isDragging
-                                    || this.isHoverOnResizeTrigger)
-                                    && `${mergedClsPrefix}-drawer__resize-trigger--hover`
+                                  `${mergedClsPrefix}-drawer__resize-trigger`,
+                                  (this.isDragging
+                                  || this.isHoverOnResizeTrigger)
+                                  && `${mergedClsPrefix}-drawer__resize-trigger--hover`
                                 ]}
                                 onMouseenter={
                                   this.handleMouseenterResizeTrigger
@@ -309,8 +309,8 @@ export default defineComponent({
                             this.nativeScrollbar ? (
                               <div
                                 class={[
-                                    `${mergedClsPrefix}-drawer-content-wrapper`,
-                                    this.contentClass
+                                  `${mergedClsPrefix}-drawer-content-wrapper`,
+                                  this.contentClass
                                 ]}
                                 style={this.contentStyle}
                                 role="none"
@@ -322,8 +322,8 @@ export default defineComponent({
                                 {...this.scrollbarProps}
                                 contentStyle={this.contentStyle}
                                 contentClass={[
-                                    `${mergedClsPrefix}-drawer-content-wrapper`,
-                                    this.contentClass
+                                  `${mergedClsPrefix}-drawer-content-wrapper`,
+                                  this.contentClass
                                 ]}
                                 theme={this.mergedTheme.peers.Scrollbar}
                                 themeOverrides={

--- a/src/dropdown/src/Dropdown.tsx
+++ b/src/dropdown/src/Dropdown.tsx
@@ -12,7 +12,7 @@ import {
 } from 'vue'
 import { type Key, type TreeNode, createTreeMate } from 'treemate'
 import { useKeyboard, useMemo, useMergedState } from 'vooks'
-import type { FollowerPlacement } from 'vueuc'
+import type { FollowerPlacement } from 'vueuc/es'
 import type { InternalRenderBody } from '../../popover/src/interface'
 import { popoverBaseProps } from '../../popover/src/Popover'
 import type { PopoverInternalProps } from '../../popover/src/Popover'

--- a/src/dropdown/src/DropdownOption.tsx
+++ b/src/dropdown/src/DropdownOption.tsx
@@ -12,7 +12,7 @@ import {
   provide,
   ref
 } from 'vue'
-import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc'
+import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc/es'
 import { useMemo } from 'vooks'
 import { happensIn } from 'seemly'
 import type { TreeNode } from 'treemate'

--- a/src/grid/src/Grid.tsx
+++ b/src/grid/src/Grid.tsx
@@ -15,7 +15,7 @@ import {
   vShow
 } from 'vue'
 import { useBreakpoints, useMemo } from 'vooks'
-import { VResizeObserver, type VResizeObserverOnResize } from 'vueuc'
+import { VResizeObserver, type VResizeObserverOnResize } from 'vueuc/es'
 import { beforeNextFrameOnce, parseResponsivePropValue, pxfy } from 'seemly'
 import { defaultBreakpoints } from '../../config-provider/src/config'
 import { useConfig } from '../../_mixins'

--- a/src/image/src/ImagePreview.tsx
+++ b/src/image/src/ImagePreview.tsx
@@ -18,7 +18,7 @@ import {
 } from 'vue'
 import { zindexable } from 'vdirs'
 import { useIsMounted } from 'vooks'
-import { LazyTeleport } from 'vueuc'
+import { LazyTeleport } from 'vueuc/es'
 import { off, on } from 'evtd'
 import { beforeNextFrameOnce } from 'seemly'
 import { kebabCase } from 'lodash-es'

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -21,7 +21,7 @@ import {
 } from 'vue'
 import { useMemo, useMergedState } from 'vooks'
 import { getPadding } from 'seemly'
-import { VResizeObserver } from 'vueuc'
+import { VResizeObserver } from 'vueuc/es'
 import { off, on } from 'evtd'
 import { isSafari } from '../../_utils/env/browser'
 import type { FormValidationStatus } from '../../form/src/interface'

--- a/src/legacy-transfer/src/TransferList.tsx
+++ b/src/legacy-transfer/src/TransferList.tsx
@@ -8,7 +8,7 @@ import {
   inject,
   ref
 } from 'vue'
-import { VirtualList, type VirtualListInst } from 'vueuc'
+import { VirtualList, type VirtualListInst } from 'vueuc/es'
 import { NEmpty } from '../../empty'
 import { NScrollbar, type ScrollbarInst } from '../../_internal'
 import { type Option, transferInjectionKey } from './interface'

--- a/src/mention/src/Mention.tsx
+++ b/src/mention/src/Mention.tsx
@@ -16,7 +16,7 @@ import {
   VBinder,
   VFollower,
   VTarget
-} from 'vueuc'
+} from 'vueuc/es'
 import { useIsMounted, useMergedState } from 'vooks'
 import type { FormValidationStatus } from '../../form/src/interface'
 import type { RenderLabel } from '../../_internal/select-menu/src/interface'

--- a/src/menu/src/Menu.tsx
+++ b/src/menu/src/Menu.tsx
@@ -20,7 +20,7 @@ import {
   VOverflow,
   type VOverflowInst,
   VResizeObserver
-} from 'vueuc'
+} from 'vueuc/es'
 import { createId } from 'seemly'
 import { layoutSiderInjectionKey } from '../../layout/src/interface'
 import type { DropdownProps } from '../../dropdown'

--- a/src/menu/src/use-menu-child.ts
+++ b/src/menu/src/use-menu-child.ts
@@ -1,6 +1,6 @@
 import type { Key } from 'treemate'
 import { type ComputedRef, type Ref, computed, inject } from 'vue'
-import type { FollowerPlacement } from 'vueuc'
+import type { FollowerPlacement } from 'vueuc/es'
 import type { MergedTheme } from '../../_mixins/use-theme'
 import type { MenuTheme } from '../styles'
 import type { OnUpdateValueImpl } from './interface'

--- a/src/modal/src/BodyWrapper.tsx
+++ b/src/modal/src/BodyWrapper.tsx
@@ -20,7 +20,7 @@ import {
   withDirectives
 } from 'vue'
 import { clickoutside } from 'vdirs'
-import { VFocusTrap } from 'vueuc'
+import { VFocusTrap } from 'vueuc/es'
 import { dialogPropKeys } from '../../dialog/src/dialogProps'
 import { NDialog } from '../../dialog/src/Dialog'
 import { cardBasePropKeys } from '../../card/src/Card'
@@ -260,8 +260,8 @@ export default defineComponent({
                                     <NDialog
                                       {...this.$attrs}
                                       class={[
-                                      `${mergedClsPrefix}-modal`,
-                                      this.$attrs.class
+                                        `${mergedClsPrefix}-modal`,
+                                        this.$attrs.class
                                       ]}
                                       ref="bodyRef"
                                       theme={this.mergedTheme.peers.Dialog}
@@ -278,8 +278,8 @@ export default defineComponent({
                                       {...this.$attrs}
                                       ref="bodyRef"
                                       class={[
-                                      `${mergedClsPrefix}-modal`,
-                                      this.$attrs.class
+                                        `${mergedClsPrefix}-modal`,
+                                        this.$attrs.class
                                       ]}
                                       theme={this.mergedTheme.peers.Card}
                                       themeOverrides={

--- a/src/modal/src/Modal.tsx
+++ b/src/modal/src/Modal.tsx
@@ -13,7 +13,7 @@ import {
 } from 'vue'
 import { zindexable } from 'vdirs'
 import { useClickPosition, useClicked, useIsMounted } from 'vooks'
-import { VLazyTeleport } from 'vueuc'
+import { VLazyTeleport } from 'vueuc/es'
 import { getPreciseEventTarget } from 'seemly'
 import { dialogProviderInjectionKey } from '../../dialog/src/context'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'

--- a/src/popover/index.ts
+++ b/src/popover/index.ts
@@ -1,4 +1,4 @@
 export { default as NPopover, popoverProps } from './src/Popover'
 export type { PopoverProps } from './src/Popover'
 export type { PopoverTrigger, PopoverInst } from './src/interface'
-export type { FollowerPlacement as PopoverPlacement } from 'vueuc'
+export type { FollowerPlacement as PopoverPlacement } from 'vueuc/es'

--- a/src/popover/src/Popover.tsx
+++ b/src/popover/src/Popover.tsx
@@ -20,7 +20,7 @@ import {
   type FollowerPlacement,
   VBinder,
   VTarget
-} from 'vueuc'
+} from 'vueuc/es'
 import { useCompitable, useIsMounted, useMemo, useMergedState } from 'vooks'
 import { zindexable } from 'vdirs'
 import {

--- a/src/popover/src/PopoverBody.tsx
+++ b/src/popover/src/PopoverBody.tsx
@@ -25,7 +25,7 @@ import {
   type FollowerPlacement,
   VFocusTrap,
   VFollower
-} from 'vueuc'
+} from 'vueuc/es'
 import { clickoutside, mousemoveoutside } from 'vdirs'
 import { getPreciseEventTarget } from 'seemly'
 import { NxScrollbar } from '../../_internal/scrollbar'
@@ -373,8 +373,8 @@ export default defineComponent({
                 hasHeaderOrFooter
                   ? undefined
                   : `${mergedClsPrefix}-popover__content ${
-                      props.contentClass ?? ''
-                    }`
+                    props.contentClass ?? ''
+                  }`
               }
               contentStyle={hasHeaderOrFooter ? undefined : props.contentStyle}
             >

--- a/src/popover/src/styles/index.cssr.ts
+++ b/src/popover/src/styles/index.cssr.ts
@@ -1,6 +1,6 @@
 import type { CNode } from 'css-render'
 import { map } from 'lodash-es'
-import type { FollowerPlacement } from 'vueuc'
+import type { FollowerPlacement } from 'vueuc/es'
 import { c, cB, cCB, cE, cM, cNotM } from '../../../_utils/cssr'
 
 const oppositePlacement = {

--- a/src/select/src/Select.tsx
+++ b/src/select/src/Select.tsx
@@ -21,7 +21,7 @@ import {
   VBinder,
   VFollower,
   VTarget
-} from 'vueuc'
+} from 'vueuc/es'
 import { useCompitable, useIsMounted, useMergedState } from 'vooks'
 import { clickoutside } from 'vdirs'
 import type {

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -19,7 +19,7 @@ import {
   VBinder,
   VFollower,
   VTarget
-} from 'vueuc'
+} from 'vueuc/es'
 import { useIsMounted, useMergedState } from 'vooks'
 import { off, on } from 'evtd'
 import {

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -20,7 +20,7 @@ import {
   watchEffect,
   withDirectives
 } from 'vue'
-import { VResizeObserver, VXScroll, type VXScrollInst } from 'vueuc'
+import { VResizeObserver, VXScroll, type VXScrollInst } from 'vueuc/es'
 import { throttle } from 'lodash-es'
 import { onFontsReady, useCompitable, useMergedState } from 'vooks'
 import { depx, getPadding } from 'seemly'

--- a/src/time-picker/src/TimePicker.tsx
+++ b/src/time-picker/src/TimePicker.tsx
@@ -14,7 +14,7 @@ import {
   withDirectives
 } from 'vue'
 import { useIsMounted, useKeyboard, useMergedState } from 'vooks'
-import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc'
+import { type FollowerPlacement, VBinder, VFollower, VTarget } from 'vueuc/es'
 import { clickoutside } from 'vdirs'
 import { getPreciseEventTarget, happensIn } from 'seemly'
 import {

--- a/src/transfer/src/TransferList.tsx
+++ b/src/transfer/src/TransferList.tsx
@@ -1,5 +1,5 @@
 import { type PropType, defineComponent, h, inject, ref } from 'vue'
-import { VirtualList, type VirtualListInst } from 'vueuc'
+import { VirtualList, type VirtualListInst } from 'vueuc/es'
 import { NEmpty } from '../../empty'
 import { NScrollbar, type ScrollbarInst } from '../../_internal'
 import { type Option, transferInjectionKey } from './interface'

--- a/src/tree-select/src/TreeSelect.tsx
+++ b/src/tree-select/src/TreeSelect.tsx
@@ -19,7 +19,7 @@ import {
   VBinder,
   VFollower,
   VTarget
-} from 'vueuc'
+} from 'vueuc/es'
 import { useIsMounted, useMergedState } from 'vooks'
 import { clickoutside } from 'vdirs'
 import { type CheckStrategy, createTreeMate } from 'treemate'

--- a/src/tree/src/Tree.tsx
+++ b/src/tree/src/Tree.tsx
@@ -26,7 +26,7 @@ import {
   VVirtualList,
   type VirtualListInst,
   type VirtualListScrollToOptions
-} from 'vueuc'
+} from 'vueuc/es'
 import { depx, getPadding, pxfy } from 'seemly'
 import { treeSelectInjectionKey } from '../../tree-select/src/interface'
 import { useConfig, useRtl, useTheme, useThemeClass } from '../../_mixins'

--- a/src/tree/src/interface.ts
+++ b/src/tree/src/interface.ts
@@ -1,6 +1,6 @@
 import type { CheckStrategy, TreeNode } from 'treemate'
 import type { HTMLAttributes, Ref, VNodeChild } from 'vue'
-import type { VirtualListScrollTo } from 'vueuc'
+import type { VirtualListScrollTo } from 'vueuc/es'
 import type { MergedTheme } from '../../_mixins'
 import { createInjectionKey } from '../../_utils'
 import type { TreeTheme } from '../styles'

--- a/src/virtual-list/src/VirtualList.tsx
+++ b/src/virtual-list/src/VirtualList.tsx
@@ -4,12 +4,12 @@ import {
   type VirtualListInst,
   type VirtualListItemData,
   type VirtualListScrollToOptions
-} from 'vueuc'
+} from 'vueuc/es'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { ScrollbarProps } from '../../scrollbar/src/Scrollbar'
 import { NxScrollbar, type ScrollbarInst } from '../../_internal'
 
-export { type VirtualListInst } from 'vueuc'
+export { type VirtualListInst } from 'vueuc/es'
 
 export const virtualListProps = {
   scrollbarProps: Object as PropType<ScrollbarProps>,


### PR DESCRIPTION
There may have been other considerations in the vueuc toolkit package.json and the type field is not configured. The default export is not es, and packaging under spa is normal. Nuxt packaging reports the error 'The requested module' node_modules/vueuc/lib/index. js' does not provide an export named 'VLazyTeleport'. I changed the naive-ui in node_modules to vueuc/es where vueuc is used, and it can be packaged and run normally locally. However, I cannot do this during Vercel deployment. I am not sure if this issue is due to better compatibility between naive ui or vueuc with a type field. Both libraries are created by the same authors. You, please consider it carefully 🤦 .
![企业微信截图_17243435135801](https://github.com/user-attachments/assets/6dacc4c9-900e-4c2a-a381-1e4b93374858)
![企业微信截图_17243434838041](https://github.com/user-attachments/assets/15c3d8e4-3b65-486c-b61b-c8783866889a)
