### PR TITLE
fix(popover): `PopoverProps` type to include `theme-overrides`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### NEXT_VERSION
+
+### Fixes
+
+- Fix `n-popover`'s `PopoverProps` type to include `theme-overrides`, closes [#6292](https://github.com/tusen-ai/naive-ui/issues/6292).
+
 ## 2.41.0
 
 ### Breaking Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-popover` 的 `PopoverProps` 类型未包含 `theme-overrides`, 关闭 [#6292](https://github.com/tusen-ai/naive-ui/issues/6292)
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/popover/src/Popover.tsx
+++ b/src/popover/src/Popover.tsx
@@ -220,7 +220,7 @@ export const popoverProps = {
   internalRenderBody: Function as PropType<InternalRenderBody>
 }
 
-export type PopoverProps = ExtractPublicPropTypes<typeof popoverBaseProps>
+export type PopoverProps = ExtractPublicPropTypes<typeof popoverProps>
 export type PopoverInternalProps = ExtractInternalPropTypes<typeof popoverProps>
 
 export interface PopoverSlots {


### PR DESCRIPTION
closes #6292
