### PR TITLE
fix(input): `readonly` prop should only be Boolean

### DIFF
--- a/src/input/demos/enUS/disabled.demo.vue
+++ b/src/input/demos/enUS/disabled.demo.vue
@@ -1,5 +1,5 @@
 <markdown>
-# Disabled
+# Disabled & Readonly
 
 Inputs can also be disabled.
 </markdown>
@@ -12,7 +12,8 @@ export default defineComponent({
   setup() {
     return {
       FlashOutline,
-      active: ref(false)
+      disabled: ref(false),
+      readonly: ref(false)
     }
   }
 })
@@ -24,21 +25,35 @@ export default defineComponent({
       type="text"
       size="small"
       placeholder="Oops! It is disabled."
-      :disabled="!active"
       round
+      clearable
+      :disabled="disabled"
+      :readonly="readonly"
     />
     <n-input
       type="textarea"
       size="small"
       placeholder="Oops! It is disabled."
-      :disabled="!active"
       round
+      clearable
+      :disabled="disabled"
+      :readonly="readonly"
     />
-    <n-input pair separator="to" clearable :disabled="!active">
-      <template #affix>
+    <n-input
+      pair
+      separator="to"
+      :placeholder="['from', 'to']"
+      clearable
+      :disabled="disabled"
+      :readonly="readonly"
+    >
+      <template #prefix>
         <n-icon :component="FlashOutline" />
       </template>
     </n-input>
-    <n-switch v-model:value="active" />
+    <n-flex>
+      <n-flex>Disabled <n-switch v-model:value="disabled" /> </n-flex>
+      <n-flex>Readonly <n-switch v-model:value="readonly" /> </n-flex>
+    </n-flex>
   </n-space>
 </template>

--- a/src/input/demos/zhCN/disabled.demo.vue
+++ b/src/input/demos/zhCN/disabled.demo.vue
@@ -1,5 +1,5 @@
 <markdown>
-# 禁用
+# 禁用 & 只读
 
 文本输入可以被禁用。
 </markdown>
@@ -12,7 +12,8 @@ export default defineComponent({
   setup() {
     return {
       FlashOutline,
-      active: ref(false)
+      disabled: ref(false),
+      readonly: ref(false)
     }
   }
 })
@@ -24,21 +25,35 @@ export default defineComponent({
       type="text"
       size="small"
       placeholder="噢！它被禁用了。"
-      :disabled="!active"
       round
+      clearable
+      :disabled="disabled"
+      :readonly="readonly"
     />
     <n-input
       type="textarea"
       size="small"
       placeholder="噢！它被禁用了。"
-      :disabled="!active"
       round
+      clearable
+      :disabled="disabled"
+      :readonly="readonly"
     />
-    <n-input pair separator="to" clearable :disabled="!active">
-      <template #affix>
+    <n-input
+      pair
+      separator="to"
+      :placeholder="['from', 'to']"
+      clearable
+      :disabled="disabled"
+      :readonly="readonly"
+    >
+      <template #prefix>
         <n-icon :component="FlashOutline" />
       </template>
     </n-input>
-    <n-switch v-model:value="active" />
+    <n-flex>
+      <n-flex>禁用 <n-switch v-model:value="disabled" /> </n-flex>
+      <n-flex>只读 <n-switch v-model:value="readonly" /> </n-flex>
+    </n-flex>
   </n-space>
 </template>

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -103,10 +103,7 @@ export const inputProps = {
   },
   pair: Boolean,
   separator: String,
-  readonly: {
-    type: [String, Boolean],
-    default: false
-  },
+  readonly: Boolean,
   passivelyActivated: Boolean,
   showPasswordOn: String as PropType<'mousedown' | 'click'>,
   stateful: {
@@ -1197,7 +1194,7 @@ export default defineComponent({
                         disabled={this.mergedDisabled}
                         maxlength={countGraphemes ? undefined : this.maxlength}
                         minlength={countGraphemes ? undefined : this.minlength}
-                        readonly={this.readonly as any}
+                        readonly={this.readonly}
                         tabindex={
                           this.passivelyActivated && !this.activated
                             ? -1
@@ -1280,7 +1277,7 @@ export default defineComponent({
                     ? this.mergedValue[0]
                     : (this.mergedValue as any)
                 }
-                readonly={this.readonly as any}
+                readonly={this.readonly}
                 autofocus={this.autofocus}
                 size={this.attrSize}
                 onBlur={this.handleInputBlur}
@@ -1414,7 +1411,7 @@ export default defineComponent({
                     ? this.mergedValue[1]
                     : undefined
                 }
-                readonly={this.readonly as any}
+                readonly={this.readonly}
                 style={this.textDecorationStyle[1] as any}
                 onBlur={this.handleInputBlur}
                 onFocus={(e) => {


### PR DESCRIPTION
```
readonly: {
   type: [String, Boolean]
}
```
```vue
<!-- parsed as an empty string -> readonly="" -->
<n-input readonly  />
```
The `readonly` prop used to accept both String and Boolean, but was parsed as `readonly=""`, which made the clear icon show up.

<img width="585" alt="image" src="https://github.com/user-attachments/assets/d749d6f2-60a0-4e9c-9340-d2bd7c1cd2c4">




