### PR TITLE
feat(n-datatable): where data containing `,` is truncated when exporting using the `downloadCsv` method 

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- Fix the issue where Chinese column names are encoded when exporting using the `downloadCsv` method of `n-data-table`
+- Fix the issue where data containing `,` is truncated when exporting using the `downloadCsv` method of `n-data-table`
+
 ## 2.40.1
 
 `2024-09-26`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- 修复 `n-data-table` 的 `downloadCsv` 方法在导出中文列名的时候，中文列名会被编码的问题
+- 修复 `n-data-table` 的 `downloadCsv` 方法在导出包含 `,` 的数据时，数据会被截断的问题
+
 ## 2.40.1
 
 `2024-09-26`

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -137,7 +137,7 @@ export default defineComponent({
     const downloadCsv = (options?: CsvOptionsType): void => {
       const { fileName = 'data.csv', keepOriginalData = false } = options || {}
       const data = keepOriginalData ? props.data : rawPaginatedDataRef.value
-      const csvData = generateCsv(props.columns, data)
+      const csvData = `\uFEFF${generateCsv(props.columns, data)}`
       const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' })
       const downloadUrl = URL.createObjectURL(blob)
       download(

--- a/src/data-table/src/utils.ts
+++ b/src/data-table/src/utils.ts
@@ -194,15 +194,19 @@ export function isColumnSorting(
 }
 
 function formatCsvCell(value: unknown): string {
-  if (typeof value === 'string') {
-    return value.replace(/,/g, '\\,')
-  }
-  else if (value === null || value === undefined) {
+  if (value === null || value === undefined) {
     return ''
   }
-  else {
-    return `${value}`.replace(/,/g, '\\,')
+  const stringValue = String(value)
+  if (
+    stringValue.includes('"')
+    || stringValue.includes(',')
+    || stringValue.includes('\n')
+  ) {
+    const escapedValue = stringValue.replace(/"/g, '""')
+    return `"${escapedValue}"`
   }
+  return stringValue
 }
 
 export function generateCsv(columns: TableColumn[], data: RowData[]): string {


### PR DESCRIPTION
close https://github.com/tusen-ai/naive-ui/issues/6409   https://github.com/tusen-ai/naive-ui/issues/5819