### PR TITLE
fix(select): issue 6451, fix showOnFocus attr cause  first click open…

### DIFF
--- a/src/select/src/Select.tsx
+++ b/src/select/src/Select.tsx
@@ -252,6 +252,7 @@ export default defineComponent({
       props,
       mergedClsPrefixRef
     )
+    const preOpenMenu = ref(false)
     const uncontrolledValueRef = ref(props.defaultValue)
     const controlledValueRef = toRef(props, 'value')
     const mergedValueRef = useMergedState(
@@ -443,6 +444,7 @@ export default defineComponent({
     function doFocus(e: FocusEvent): void {
       const { onFocus, showOnFocus } = props
       const { nTriggerFormFocus } = formItem
+      preOpenMenu.value = true
       if (onFocus)
         call(onFocus, e)
       nTriggerFormFocus()
@@ -525,6 +527,10 @@ export default defineComponent({
       }
     }
     function handleTriggerClick(): void {
+      if (preOpenMenu.value) {
+        uncontrolledShowRef.value = false
+        preOpenMenu.value = false
+      }
       if (mergedDisabledRef.value)
         return
       if (!mergedShowRef.value) {


### PR DESCRIPTION
close https://github.com/tusen-ai/naive-ui/issues/6451


Fix: `select`组件, Issue:6451， 问题缘由：点击时focus和click都可以openMenu，导致click时判定为closeMenu。解决方案：设置一个新值判断是否第一次focus解决问题。

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
