### PR TITLE
fix: the disabled dates in the `n-date-picker` can still be triggered

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - Fix `n-time-picker`'s `use-12-hours` type error warning, closes [#4308](https://github.com/tusen-ai/naive-ui/issues/4308)
+- Fix the problem that the disabled dates in the `n-date-picker` can still be triggered, closes [#6503](https://github.com/tusen-ai/naive-ui/issues/6503)
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `n-time-picker` 的 `use-12-hours` 类型错误警告，关闭 [#4308](https://github.com/tusen-ai/naive-ui/issues/4308)
+- 修复 `n-date-picker` 禁用的日期还可以触发的问题，关闭 [#6503](https://github.com/tusen-ai/naive-ui/issues/6503)
 
 ### Features
 

--- a/src/date-picker/src/panel/use-dual-calendar.ts
+++ b/src/date-picker/src/panel/use-dual-calendar.ts
@@ -423,6 +423,8 @@ function useDualCalendar(
   }
   // for daterange & datetimerange
   function handleDateClick(dateItem: DateItem): void {
+    if (mergedIsDateDisabled(dateItem.ts))
+      return
     if (!isSelectingRef.value) {
       isSelectingRef.value = true
       memorizedStartDateTimeRef.value = dateItem.ts


### PR DESCRIPTION
Fixes #6503.