### PR TITLE
feat(n-split): support multiple panel

### DIFF
--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -15,6 +15,8 @@ slot.vue
 controlled.vue
 pixel-value.vue
 snap-offset.vue
+mutil-panel.vue
+mutil-panel-nest.vue
 ```
 
 ## API

--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -36,6 +36,7 @@ mutil-panel-nest.vue
 | pane2-style | `Object \| string` | `undefined` | The Style of the second pane | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Size of the resize trigger. | 2.36.0 |
 | size | `string \| number \| (string \| number)[]` | `undefined` | Split is the controlled split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| snap-to-center | `boolean` | `false` | Whether to enable center snapping. | NEXT_VERSION |
 | snap-offset | `number` | `undefined` | The snap offset of the split. | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | Default prop names that needed to be watched. Components will be updated after the prop is changed. Note: the `watch-props` itself is not reactive. | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | Callback function when drag start. | 2.36.0 |

--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -13,6 +13,8 @@ nest.vue
 event.vue
 slot.vue
 controlled.vue
+pixel-value.vue
+snap-offset.vue
 ```
 
 ## API

--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -23,17 +23,18 @@ snap-offset.vue
 
 | Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
-| default-size | `number` | `0.5` | Default split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2 |
+| default-size | `number` | `0.5` | Default split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2, `(string \| number)[]` NEXT_VERSION |
 | direction | `'horizontal' \| 'vertical'` | `'horizontal'` | The direction of the split. | 2.36.0 |
 | disabled | `boolean` | `false` | Whether to disable the split. | 2.36.0 |
-| max | `string \| number` | `1` | The maximum split threshold, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2 |
-| min | `string \| number` | `0` | The minimum threshold for splitting, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2 |
+| max | `string \| number` | `1` | The maximum split threshold, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| min | `string \| number` | `0` | The minimum threshold for splitting, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | pane1-class | `string` | `undefined` | The class name of the first pane. | 2.38.2 |
 | pane1-style | `Object \| string` | `undefined` | The Style of the first pane | 2.38.2 |
 | pane2-class | `string` | `undefined` | The class name of the second pane. | 2.38.2 |
 | pane2-style | `Object \| string` | `undefined` | The Style of the second pane | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Size of the resize trigger. | 2.36.0 |
-| size | `string \| number` | `undefined` | Split is the controlled split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.38.0, `string` 2.38.2 |
+| size | `string \| number` | `undefined` | Split is the controlled split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| snap-offset | `number` | `undefined` | The snap offset of the split. | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | Default prop names that needed to be watched. Components will be updated after the prop is changed. Note: the `watch-props` itself is not reactive. | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | Callback function when drag start. | 2.36.0 |
 | on-drag-move | `(e: Event) => void` | `undefined` | Callback function when dragging. | 2.36.0 |
@@ -42,8 +43,9 @@ snap-offset.vue
 
 ### Split Slots
 
-| Name           | Parameters | Description              | Version |
-| -------------- | ---------- | ------------------------ | ------- |
-| 1              | `()`       | The first pane content.  | 2.36.0  |
-| 2              | `()`       | The Second pane content. | 2.36.0  |
-| resize-trigger | `()`       | Split bar content.       | 2.36.0  |
+| Name           | Parameters | Description              | Version      |
+| -------------- | ---------- | ------------------------ | ------------ |
+| 1              | `()`       | The first pane content.  | 2.36.0       |
+| 2              | `()`       | The Second pane content. | 2.36.0       |
+| \*             | `()`       | The \* pane content.     | NEXT_VERSION |
+| resize-trigger | `()`       | Split bar content.       | 2.36.0       |

--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -23,17 +23,17 @@ snap-offset.vue
 
 | Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
-| default-size | `number` | `0.5` | Default split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2, `(string \| number)[]` NEXT_VERSION |
+| default-size | `number \| string \| (string \| number)[]` | `0.5` | Default split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2, `(string \| number)[]` NEXT_VERSION |
 | direction | `'horizontal' \| 'vertical'` | `'horizontal'` | The direction of the split. | 2.36.0 |
 | disabled | `boolean` | `false` | Whether to disable the split. | 2.36.0 |
-| max | `string \| number` | `1` | The maximum split threshold, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
-| min | `string \| number` | `0` | The minimum threshold for splitting, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| max | `string \| number \| (string \| number)[]` | `1` | The maximum split threshold, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| min | `string \| number \| (string \| number)[]` | `0` | The minimum threshold for splitting, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | pane1-class | `string` | `undefined` | The class name of the first pane. | 2.38.2 |
 | pane1-style | `Object \| string` | `undefined` | The Style of the first pane | 2.38.2 |
 | pane2-class | `string` | `undefined` | The class name of the second pane. | 2.38.2 |
 | pane2-style | `Object \| string` | `undefined` | The Style of the second pane | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Size of the resize trigger. | 2.36.0 |
-| size | `string \| number` | `undefined` | Split is the controlled split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| size | `string \| number \| (string \| number)[]` | `undefined` | Split is the controlled split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | snap-offset | `number` | `undefined` | The snap offset of the split. | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | Default prop names that needed to be watched. Components will be updated after the prop is changed. Note: the `watch-props` itself is not reactive. | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | Callback function when drag start. | 2.36.0 |

--- a/src/split/demos/enUS/mutil-panel-nest.demo.vue
+++ b/src/split/demos/enUS/mutil-panel-nest.demo.vue
@@ -1,0 +1,30 @@
+<markdown>
+# Multiple Panels Nest
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      <n-split direction="vertical" style="height: 200px">
+        <template #1>
+          Pane 1
+        </template>
+        <template #2>
+          Pane 2
+        </template>
+        <template #3>
+          Pane 3
+        </template>
+        <template #4>
+          Pane 4
+        </template>
+      </n-split>
+    </template>
+    <template #3>
+      Pane 3
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/enUS/mutil-panel.demo.vue
+++ b/src/split/demos/enUS/mutil-panel.demo.vue
@@ -1,17 +1,37 @@
-<markdown>
-# Multiple Panels
-</markdown>
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'SplitMultiPanel'
+})
+</script>
 
 <template>
-  <n-split direction="horizontal" style="height: 200px">
+  <n-split style="height: 200px" :default-size="[0.2, 0.4, 0.4]">
     <template #1>
-      Pane 1
+      <div class="split-panel">
+        Panel 1
+      </div>
     </template>
     <template #2>
-      Pane 2
+      <div class="split-panel">
+        Panel 2
+      </div>
     </template>
     <template #3>
-      Pane 3
+      <div class="split-panel">
+        Panel 3
+      </div>
     </template>
   </n-split>
 </template>
+
+<style scoped>
+.split-panel {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(128, 128, 128, 0.3);
+}
+</style>

--- a/src/split/demos/enUS/mutil-panel.demo.vue
+++ b/src/split/demos/enUS/mutil-panel.demo.vue
@@ -1,0 +1,17 @@
+<markdown>
+# Multiple Panels
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+    <template #3>
+      Pane 3
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/enUS/pixel-value.demo.vue
+++ b/src/split/demos/enUS/pixel-value.demo.vue
@@ -1,7 +1,7 @@
 <markdown>
-# 使用像素值控制尺寸
+# Use Pixel Value to Control Size
 
-自 `2.38.2` 开始，`min`、`max`、`size` 和 `default-size` 属性可以接受像素值。
+Since `2.38.2`, the `min`, `max`, `size` and `default-size` properties can accept pixel values.
 </markdown>
 
 <template>

--- a/src/split/demos/enUS/snap-offset.demo.vue
+++ b/src/split/demos/enUS/snap-offset.demo.vue
@@ -1,5 +1,5 @@
 <markdown>
-# 吸附偏移
+# Snap Offset
 </markdown>
 
 <template>

--- a/src/split/demos/enUS/snap-offset.demo.vue
+++ b/src/split/demos/enUS/snap-offset.demo.vue
@@ -1,0 +1,14 @@
+<markdown>
+# 吸附偏移
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" :snap-offset="75">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/enUS/snap-offset.demo.vue
+++ b/src/split/demos/enUS/snap-offset.demo.vue
@@ -1,14 +1,39 @@
 <markdown>
-# Snap Offset
+  # Snap Offset
+
+  Set `snap-to-center` to enable center snapping
 </markdown>
 
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup() {
+    return {
+      snapToCenter: ref(false)
+    }
+  }
+})
+</script>
+
 <template>
-  <n-split direction="horizontal" style="height: 200px" :snap-offset="75">
-    <template #1>
-      Pane 1
-    </template>
-    <template #2>
-      Pane 2
-    </template>
-  </n-split>
+  <n-flex align="center">
+    <n-switch v-model:value="snapToCenter" />
+
+    <span> Enable center snapping </span>
+
+    <n-split
+      direction="horizontal"
+      :snap-to-center="snapToCenter"
+      style="height: 200px"
+      :snap-offset="75"
+    >
+      <template #1>
+        Pane 1
+      </template>
+      <template #2>
+        Pane 2
+      </template>
+    </n-split>
+  </n-flex>
 </template>

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -23,17 +23,17 @@ snap-offset.vue
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
 | --- | --- | --- | --- | --- |
-| default-size | `string \| number` | `0.5` | Split 的默认分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| default-size | `string \| number \| (string \| number)[]` | `0.5` | Split 的默认分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | direction | `'horizontal' \| 'vertical'` | `'horizontal'` | Split 的分割方向 | 2.36.0 |
 | disabled | `boolean` | `false` | 是否禁用 | 2.36.0 |
-| max | `string \| number` | `1` | Split 的分割最大阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
-| min | `string \| number` | `0` | Split 的分割最小阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| max | `string \| number \| (string \| number)[]` | `1` | Split 的分割最大阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| min | `string \| number \| (string \| number)[]` | `0` | Split 的分割最小阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | pane1-class | `string` | `undefined` | 第一个面板的类名 | 2.38.2 |
 | pane1-style | `Object \| string` | `undefined` | 第一个面板的样式 | 2.38.2 |
 | pane2-class | `string` | `undefined` | 第二个面板的类名 | 2.38.2 |
 | pane2-style | `Object \| string` | `undefined` | 第二个面板的样式 | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Split 的分隔条大小 | 2.36.0 |
-| size | `string \| number` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| size | `string \| number \| (string \| number)[]` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | snap-offset | `number` | `undefined` | Split 的吸附偏移量 | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | 需要检测变更的默认属性，检测后组件状态会更新。注意：`watch-props` 本身不是响应式的 | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | 开始拖拽的回调函数 | 2.36.0 |

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -15,6 +15,8 @@ slot.vue
 controlled.vue
 pixel-value.vue
 snap-offset.vue
+mutil-panel.vue
+mutil-panel-nest.vue
 ```
 
 ## API

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -17,6 +17,12 @@ pixel-value.vue
 snap-offset.vue
 mutil-panel.vue
 mutil-panel-nest.vue
+single-px-size-debug.vue
+single-number-size-debug.vue
+single-px-default-size-debug.vue
+single-number-default-size-debug.vue
+single-px-size-threshold-debug.vue
+single-number-size-threshold-debug.vue
 ```
 
 ## API

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -14,6 +14,7 @@ event.vue
 slot.vue
 controlled.vue
 pixel-value.vue
+snap-offset.vue
 ```
 
 ## API
@@ -33,6 +34,7 @@ pixel-value.vue
 | pane2-style | `Object \| string` | `undefined` | 第二个面板的样式 | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Split 的分隔条大小 | 2.36.0 |
 | size | `string \| number` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2 |
+| snap-offset | `number` | `undefined` | Split 的吸附偏移量 | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | 需要检测变更的默认属性，检测后组件状态会更新。注意：`watch-props` 本身不是响应式的 | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | 开始拖拽的回调函数 | 2.36.0 |
 | on-drag-move | `(e: Event) => void` | `undefined` | 拖拽中的回调函数 | 2.36.0 |

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -42,6 +42,7 @@ single-number-size-threshold-debug.vue
 | pane2-style | `Object \| string` | `undefined` | 第二个面板的样式 | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Split 的分隔条大小 | 2.36.0 |
 | size | `string \| number \| (string \| number)[]` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| snap-to-center | `boolean` | `false` | 是否启用中间吸附 | NEXT_VERSION |
 | snap-offset | `number` | `undefined` | Split 的吸附偏移量 | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | 需要检测变更的默认属性，检测后组件状态会更新。注意：`watch-props` 本身不是响应式的 | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | 开始拖拽的回调函数 | 2.36.0 |

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -23,17 +23,17 @@ snap-offset.vue
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
 | --- | --- | --- | --- | --- |
-| default-size | `string \| number` | `0.5` | Split 的默认分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2 |
+| default-size | `string \| number` | `0.5` | Split 的默认分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | direction | `'horizontal' \| 'vertical'` | `'horizontal'` | Split 的分割方向 | 2.36.0 |
 | disabled | `boolean` | `false` | 是否禁用 | 2.36.0 |
-| max | `string \| number` | `1` | Split 的分割最大阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2 |
-| min | `string \| number` | `0` | Split 的分割最小阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2 |
+| max | `string \| number` | `1` | Split 的分割最大阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
+| min | `string \| number` | `0` | Split 的分割最小阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | pane1-class | `string` | `undefined` | 第一个面板的类名 | 2.38.2 |
 | pane1-style | `Object \| string` | `undefined` | 第一个面板的样式 | 2.38.2 |
 | pane2-class | `string` | `undefined` | 第二个面板的类名 | 2.38.2 |
 | pane2-style | `Object \| string` | `undefined` | 第二个面板的样式 | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Split 的分隔条大小 | 2.36.0 |
-| size | `string \| number` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2 |
+| size | `string \| number` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2,`(string \| number)[]` NEXT_VERSION |
 | snap-offset | `number` | `undefined` | Split 的吸附偏移量 | NEXT_VERSION |
 | watch-props | `Array<'defaultSize'>` | `undefined` | 需要检测变更的默认属性，检测后组件状态会更新。注意：`watch-props` 本身不是响应式的 | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | 开始拖拽的回调函数 | 2.36.0 |
@@ -43,8 +43,9 @@ snap-offset.vue
 
 ### Split Slots
 
-| 名称           | 参数 | 说明           | 版本   |
-| -------------- | ---- | -------------- | ------ |
-| 1              | `()` | 第一个面板内容 | 2.36.0 |
-| 2              | `()` | 第二个面板内容 | 2.36.0 |
-| resize-trigger | `()` | 分割条内容     | 2.36.0 |
+| 名称           | 参数 | 说明             | 版本         |
+| -------------- | ---- | ---------------- | ------------ |
+| 1              | `()` | 第一个面板内容   | 2.36.0       |
+| 2              | `()` | 第二个面板内容   | 2.36.0       |
+| \*             | `()` | 第 \* 个面板内容 | NEXT_VERSION |
+| resize-trigger | `()` | 分割条内容       | 2.36.0       |

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -23,6 +23,12 @@ single-px-default-size-debug.vue
 single-number-default-size-debug.vue
 single-px-size-threshold-debug.vue
 single-number-size-threshold-debug.vue
+mutil-number-default-size-debug.vue
+mutil-number-size-debug.vue
+mutil-number-size-threshold-debug.vue
+mutil-px-default-size-debug.vue
+mutil-px-size-debug.vue
+mutil-px-size-threshold-debug.vue
 ```
 
 ## API

--- a/src/split/demos/zhCN/mutil-number-default-size-debug.demo.vue
+++ b/src/split/demos/zhCN/mutil-number-default-size-debug.demo.vue
@@ -1,20 +1,21 @@
 <markdown>
-# 单 number 类型 default-size threshold 调试
-</markdown>
+  # 多个 number 类型 default-size 调试
+  </markdown>
 
 <template>
   <n-split
     direction="horizontal"
     style="height: 200px"
-    :default-size="0.7"
-    :min="0.1"
-    :max="0.9"
+    :default-size="[0.3, 0.2, 0.5]"
   >
     <template #1>
       Pane 1
     </template>
     <template #2>
       Pane 2
+    </template>
+    <template #3>
+      Pane 3
     </template>
   </n-split>
 </template>

--- a/src/split/demos/zhCN/mutil-number-size-debug.demo.vue
+++ b/src/split/demos/zhCN/mutil-number-size-debug.demo.vue
@@ -1,0 +1,17 @@
+<markdown>
+# 多个 number 类型 size 调试
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" :size="[0.3, 0.2, 0.5]">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+    <template #3>
+      Pane 3
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/mutil-number-size-threshold-debug.demo.vue
+++ b/src/split/demos/zhCN/mutil-number-size-threshold-debug.demo.vue
@@ -1,20 +1,23 @@
 <markdown>
-# 单 number 类型 default-size threshold 调试
+# 多个 number 类型 size threshold 调试
 </markdown>
 
 <template>
   <n-split
     direction="horizontal"
     style="height: 200px"
-    :default-size="0.7"
-    :min="0.1"
-    :max="0.9"
+    :size="[0.3, 0.2, 0.5]"
+    :min="[0.1, 0.2, 0.3]"
+    :max="[0.4, 0.5, 0.9]"
   >
     <template #1>
       Pane 1
     </template>
     <template #2>
       Pane 2
+    </template>
+    <template #3>
+      Pane 3
     </template>
   </n-split>
 </template>

--- a/src/split/demos/zhCN/mutil-panel-nest.demo.vue
+++ b/src/split/demos/zhCN/mutil-panel-nest.demo.vue
@@ -1,0 +1,30 @@
+<markdown>
+# 多个面板嵌套
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      <n-split direction="vertical" style="height: 200px">
+        <template #1>
+          Pane 1
+        </template>
+        <template #2>
+          Pane 2
+        </template>
+        <template #3>
+          Pane 3
+        </template>
+        <template #4>
+          Pane 4
+        </template>
+      </n-split>
+    </template>
+    <template #3>
+      Pane 3
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/mutil-panel.demo.vue
+++ b/src/split/demos/zhCN/mutil-panel.demo.vue
@@ -1,0 +1,17 @@
+<markdown>
+# 多个面板
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+    <template #3>
+      Pane 3
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/mutil-px-default-size-debug.demo.vue
+++ b/src/split/demos/zhCN/mutil-px-default-size-debug.demo.vue
@@ -1,20 +1,21 @@
 <markdown>
-# 单 number 类型 default-size threshold 调试
+# 多个 px 类型 default-size 调试
 </markdown>
 
 <template>
   <n-split
     direction="horizontal"
     style="height: 200px"
-    :default-size="0.7"
-    :min="0.1"
-    :max="0.9"
+    :default-size="['200px', '200px', '200px']"
   >
     <template #1>
       Pane 1
     </template>
     <template #2>
       Pane 2
+    </template>
+    <template #3>
+      Pane 3
     </template>
   </n-split>
 </template>

--- a/src/split/demos/zhCN/mutil-px-size-debug.demo.vue
+++ b/src/split/demos/zhCN/mutil-px-size-debug.demo.vue
@@ -1,20 +1,21 @@
 <markdown>
-# 单 number 类型 default-size threshold 调试
+# 多个 px 类型 size 调试
 </markdown>
 
 <template>
   <n-split
     direction="horizontal"
     style="height: 200px"
-    :default-size="0.7"
-    :min="0.1"
-    :max="0.9"
+    :size="['200px', '200px', '200px']"
   >
     <template #1>
       Pane 1
     </template>
     <template #2>
       Pane 2
+    </template>
+    <template #3>
+      Pane 3
     </template>
   </n-split>
 </template>

--- a/src/split/demos/zhCN/mutil-px-size-threshold-debug.demo.vue
+++ b/src/split/demos/zhCN/mutil-px-size-threshold-debug.demo.vue
@@ -1,20 +1,23 @@
 <markdown>
-# 单 number 类型 default-size threshold 调试
+# 多个 px 类型 size threshold 调试
 </markdown>
 
 <template>
   <n-split
     direction="horizontal"
     style="height: 200px"
-    :default-size="0.7"
-    :min="0.1"
-    :max="0.9"
+    :size="['200px', '200px', '200px']"
+    :min="['100px', '100px', '100px']"
+    :max="['400px', '400px', '400px']"
   >
     <template #1>
       Pane 1
     </template>
     <template #2>
       Pane 2
+    </template>
+    <template #3>
+      Pane 3
     </template>
   </n-split>
 </template>

--- a/src/split/demos/zhCN/pixel-value.demo.vue
+++ b/src/split/demos/zhCN/pixel-value.demo.vue
@@ -8,7 +8,7 @@
   <n-split
     direction="horizontal"
     style="height: 200px"
-    max="300px"
+    max="600px"
     min="100px"
     default-size="200px"
   >

--- a/src/split/demos/zhCN/single-number-default-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-number-default-size-debug.demo.vue
@@ -1,0 +1,14 @@
+<markdown>
+# 单 number 类型 default size 调试 &#10004;
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" :default-size="0.8">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/single-number-default-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-number-default-size-debug.demo.vue
@@ -1,5 +1,5 @@
 <markdown>
-# 单 number 类型 default size 调试 &#10004;
+# 单 number 类型 default-size 调试
 </markdown>
 
 <template>

--- a/src/split/demos/zhCN/single-number-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-number-size-debug.demo.vue
@@ -1,0 +1,14 @@
+<markdown>
+# 单 number 类型 size 调试 &#10004;
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" :size="0.8">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/single-number-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-number-size-debug.demo.vue
@@ -1,5 +1,5 @@
 <markdown>
-# 单 number 类型 size 调试 &#10004;
+# 单 number 类型 size 调试
 </markdown>
 
 <template>

--- a/src/split/demos/zhCN/single-number-size-threshold-debug.demo.vue
+++ b/src/split/demos/zhCN/single-number-size-threshold-debug.demo.vue
@@ -1,0 +1,20 @@
+<markdown>
+# 单 number 类型 default size threshold 调试 &#10004;
+</markdown>
+
+<template>
+  <n-split
+    direction="horizontal"
+    style="height: 200px"
+    :default-size="0.7"
+    :min="0.1"
+    :max="0.9"
+  >
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/single-px-default-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-px-default-size-debug.demo.vue
@@ -1,5 +1,5 @@
 <markdown>
-# 单 px 类型 default size 调试
+# 单 px 类型 default-size 调试
 </markdown>
 
 <template>

--- a/src/split/demos/zhCN/single-px-default-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-px-default-size-debug.demo.vue
@@ -1,0 +1,14 @@
+<markdown>
+# 单 px 类型 default size 调试
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" default-size="500px">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/single-px-size-debug.demo.vue
+++ b/src/split/demos/zhCN/single-px-size-debug.demo.vue
@@ -1,0 +1,14 @@
+<markdown>
+# 单 px 类型 size 调试
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" size="500px">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/single-px-size-threshold-debug.demo.vue
+++ b/src/split/demos/zhCN/single-px-size-threshold-debug.demo.vue
@@ -1,0 +1,20 @@
+<markdown>
+# 单 px 类型 size threshold 调试
+</markdown>
+
+<template>
+  <n-split
+    direction="horizontal"
+    style="height: 200px"
+    size="300px"
+    min="100px"
+    max="400px"
+  >
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/snap-offset.demo.vue
+++ b/src/split/demos/zhCN/snap-offset.demo.vue
@@ -1,0 +1,14 @@
+<markdown>
+# 吸附偏移
+</markdown>
+
+<template>
+  <n-split direction="horizontal" style="height: 200px" :snap-offset="75">
+    <template #1>
+      Pane 1
+    </template>
+    <template #2>
+      Pane 2
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/snap-offset.demo.vue
+++ b/src/split/demos/zhCN/snap-offset.demo.vue
@@ -1,14 +1,39 @@
 <markdown>
-# 吸附偏移
+  # 吸附偏移
+
+  设置 `snap-to-center` 后，启用中间吸附
 </markdown>
 
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup() {
+    return {
+      snapToCenter: ref(false)
+    }
+  }
+})
+</script>
+
 <template>
-  <n-split direction="horizontal" style="height: 200px" :snap-offset="75">
-    <template #1>
-      Pane 1
-    </template>
-    <template #2>
-      Pane 2
-    </template>
-  </n-split>
+  <n-flex align="center">
+    <n-switch v-model:value="snapToCenter" />
+
+    <span> 开启中心吸附 </span>
+
+    <n-split
+      direction="horizontal"
+      :snap-to-center="snapToCenter"
+      style="height: 200px"
+      :snap-offset="75"
+    >
+      <template #1>
+        Pane 1
+      </template>
+      <template #2>
+        Pane 2
+      </template>
+    </n-split>
+  </n-flex>
 </template>

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -121,15 +121,10 @@ export default defineComponent({
 
     const mouseMoveEvent = 'mousemove'
     const mouseUpEvent = 'mouseup'
-    const getMousePosition = (e: MouseEvent | TouchEvent) => {
-      const clientAxis
-        = props.direction === 'horizontal' ? 'clientX' : 'clientY'
-      if ('touches' in e)
-        return e.touches[0][clientAxis]
-      return e[clientAxis]
-    }
+    const getMousePosition = (e: MouseEvent) =>
+      e[props.direction === 'horizontal' ? 'clientX' : 'clientY']
 
-    const onDraging = (e: MouseEvent | TouchEvent) => {
+    const onDraging = (e: MouseEvent) => {
       if (props.onDragMove)
         props.onDragMove(e)
 

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -1,21 +1,21 @@
-import type { SplitOnUpdateSize } from './types'
-import { off, on } from 'evtd'
-import { depx } from 'seemly'
-import { useMergedState } from 'vooks'
 import {
-  computed,
   type CSSProperties,
+  Fragment,
+  type PropType,
+  type StyleValue,
+  computed,
   defineComponent,
   h,
-  type PropType,
-  ref,
-  toRef,
-  watchEffect
+  onMounted,
+  ref
 } from 'vue'
+import { off, on } from 'evtd'
+import { VResizeObserver } from 'vueuc'
 import { type ThemeProps, useTheme, useThemeClass } from '../../_mixins'
 import useConfig from '../../_mixins/use-config'
-import { call, type ExtractPublicPropTypes, resolveSlot } from '../../_utils'
-import { splitLight, type SplitTheme } from '../styles'
+import type { ExtractPublicPropTypes } from '../../_utils'
+import { type SplitTheme, splitLight } from '../styles'
+import type { SizeType, SplitOnUpdateSize } from './types'
 import style from './styles/index.cssr'
 
 export const splitProps = {
@@ -30,8 +30,8 @@ export const splitProps = {
   },
   disabled: Boolean,
   defaultSize: {
-    type: [String, Number] as PropType<string | number>,
-    default: 0.5
+    type: [Number, String, Array] as PropType<SizeType>,
+    default: undefined
   },
   'onUpdate:size': [Function, Array] as PropType<
     SplitOnUpdateSize | SplitOnUpdateSize[]
@@ -39,14 +39,21 @@ export const splitProps = {
   onUpdateSize: [Function, Array] as PropType<
     SplitOnUpdateSize | SplitOnUpdateSize[]
   >,
-  size: [String, Number] as PropType<string | number>,
+  size: {
+    type: [Number, String, Array] as PropType<SizeType>,
+    default: undefined
+  },
   min: {
-    type: [String, Number] as PropType<string | number>,
-    default: 0
+    type: [Number, String, Array] as PropType<SizeType>,
+    default: undefined
   },
   max: {
-    type: [String, Number] as PropType<string | number>,
-    default: 1
+    type: [Number, String, Array] as PropType<SizeType>,
+    default: undefined
+  },
+  snapOffset: {
+    type: Number,
+    default: 0
   },
   pane1Class: String,
   pane1Style: [Object, String] as PropType<CSSProperties | string>,
@@ -62,8 +69,9 @@ export type SplitProps = ExtractPublicPropTypes<typeof splitProps>
 
 export default defineComponent({
   name: 'Split',
+  inheritAttrs: false,
   props: splitProps,
-  setup(props) {
+  setup(props, { slots }) {
     const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
     const themeRef = useTheme(
       'Split',
@@ -85,202 +93,292 @@ export default defineComponent({
         '--n-resize-trigger-color-hover': resizableTriggerColorHover
       }
     })
-    const resizeTriggerElRef = ref<HTMLElement | null>(null)
-    const isDraggingRef = ref(false)
-    const controlledSizeRef = toRef(props, 'size')
-    const uncontrolledSizeRef = ref(props.defaultSize)
-    if (props.watchProps?.includes('defaultSize')) {
-      watchEffect(() => (uncontrolledSizeRef.value = props.defaultSize))
-    }
-    // use to update controlled or uncontrolled values
-    const doUpdateSize = (size: number | string): void => {
-      const _onUpdateSize = props['onUpdate:size']
-      if (props.onUpdateSize)
-        call(props.onUpdateSize, size as string & number)
-      if (_onUpdateSize)
-        call(_onUpdateSize, size as string & number)
-      uncontrolledSizeRef.value = size
-    }
-    const mergedSizeRef = useMergedState(controlledSizeRef, uncontrolledSizeRef)
-
-    const firstPaneStyle = computed(() => {
-      const sizeValue = mergedSizeRef.value
-      if (typeof sizeValue === 'string') {
-        return {
-          flex: `0 0 ${sizeValue}`
-        }
-      }
-      else if (typeof sizeValue === 'number') {
-        const size = sizeValue * 100
-        return {
-          flex: `0 0 calc(${size}% - ${
-            (props.resizeTriggerSize * size) / 100
-          }px)`
-        }
-      }
-    })
-
-    const resizeTriggerStyle = computed(() => {
-      return props.direction === 'horizontal'
-        ? {
-            width: `${props.resizeTriggerSize}px`,
-            height: '100%'
-          }
-        : {
-            width: '100%',
-            height: `${props.resizeTriggerSize}px`
-          }
-    })
-
-    const resizeTriggerWrapperStyle = computed(() => {
-      const horizontal = props.direction === 'horizontal'
-      return {
-        width: horizontal ? `${props.resizeTriggerSize}px` : '',
-        height: horizontal ? '' : `${props.resizeTriggerSize}px`,
-        cursor: props.direction === 'horizontal' ? 'col-resize' : 'row-resize'
-      }
-    })
-
-    let offset = 0
-    const handleMouseDown = (e: MouseEvent): void => {
-      e.preventDefault()
-      isDraggingRef.value = true
-      if (props.onDragStart)
-        props.onDragStart(e)
-      const mouseMoveEvent = 'mousemove'
-      const mouseUpEvent = 'mouseup'
-      const onMouseMove = (e: MouseEvent): void => {
-        updateSize(e)
-        if (props.onDragMove)
-          props.onDragMove(e)
-      }
-      const onMouseUp = (): void => {
-        off(mouseMoveEvent, document, onMouseMove)
-        off(mouseUpEvent, document, onMouseUp)
-        isDraggingRef.value = false
-        if (props.onDragEnd)
-          props.onDragEnd(e)
-        document.body.style.cursor = ''
-      }
-      document.body.style.cursor = resizeTriggerWrapperStyle.value.cursor
-      on(mouseMoveEvent, document, onMouseMove)
-      on(mouseUpEvent, document, onMouseUp)
-
-      const resizeTriggerEl = resizeTriggerElRef.value
-      if (resizeTriggerEl) {
-        const elRect = resizeTriggerEl.getBoundingClientRect()
-        if (props.direction === 'horizontal') {
-          offset = e.clientX - elRect.left
-        }
-        else {
-          offset = elRect.top - e.clientY
-        }
-      }
-      updateSize(e)
-    }
-
-    function updateSize(event: MouseEvent): void {
-      const containerRect
-        = resizeTriggerElRef.value?.parentElement?.getBoundingClientRect()
-      if (!containerRect)
-        return
-
-      const { direction } = props
-
-      const containerUsableWidth = containerRect.width - props.resizeTriggerSize
-      const containerUsableHeight
-        = containerRect.height - props.resizeTriggerSize
-      const containerUsableSize
-        = direction === 'horizontal'
-          ? containerUsableWidth
-          : containerUsableHeight
-
-      const newPxSize
-        = direction === 'horizontal'
-          ? event.clientX - containerRect.left - offset
-          : event.clientY - containerRect.top + offset
-
-      const { min, max } = props
-
-      const pxMin
-        = typeof min === 'string' ? depx(min) : min * containerUsableSize
-      const pxMax
-        = typeof max === 'string' ? depx(max) : max * containerUsableSize
-
-      let nextPxSize = newPxSize
-      nextPxSize = Math.max(nextPxSize, pxMin)
-      nextPxSize = Math.min(nextPxSize, pxMax, containerUsableSize)
-      // in pixel mode
-      if (typeof mergedSizeRef.value === 'string') {
-        doUpdateSize(`${nextPxSize}px`)
-      }
-      else {
-        // in percentage mode
-        doUpdateSize(nextPxSize / containerUsableSize)
-      }
-    }
 
     const themeClassHandle = inlineThemeDisabled
       ? useThemeClass('split', undefined, cssVarsRef, props)
       : undefined
 
+    const isHorizontal = props.direction === 'horizontal'
+    const isDraggingRef = ref(false)
+    const containerElSizeRef = ref(0)
+    const panelSizes = ref<number[]>([])
+    const triggerIndex = ref(-1)
+    const dragStartPos = ref(0)
+
+    // if (props.watchProps?.includes('defaultSize')) {
+    //   watchEffect(() => (uncontrolledSizeRef.value = props.defaultSize))
+    // }
+
+    const convertToPercentage = (value: number | string): number => {
+      if (typeof value === 'number') {
+        return value
+      }
+      if (typeof value === 'string' && value.endsWith('px')) {
+        return Number.parseInt(value) / containerElSizeRef.value
+      }
+      return 0
+    }
+
+    const mouseMoveEvent = 'mousemove'
+    const mouseUpEvent = 'mouseup'
+    const getMousePosition = (e: MouseEvent | TouchEvent) => {
+      const clientAxis
+        = props.direction === 'horizontal' ? 'clientX' : 'clientY'
+      if ('touches' in e)
+        return e.touches[0][clientAxis]
+      return e[clientAxis]
+    }
+
+    const onDraging = (e: MouseEvent | TouchEvent) => {
+      if (isDraggingRef.value)
+        return
+
+      const currentPosition = getMousePosition(e)
+      const mouseMoved = currentPosition - dragStartPos.value
+      const percentageMoved = mouseMoved / containerElSizeRef.value
+
+      const aSize = panelSizes.value[triggerIndex.value]
+      const bSize = panelSizes.value[triggerIndex.value + 1]
+
+      let newASize = aSize + percentageMoved
+      let newBSize = bSize - percentageMoved
+
+      const minSizeA = Array.isArray(props.min)
+        ? convertToPercentage(props.min[triggerIndex.value] ?? 0)
+        : convertToPercentage(props.min ?? 0)
+      const minSizeB = Array.isArray(props.min)
+        ? convertToPercentage(props.min[triggerIndex.value + 1] ?? 0)
+        : convertToPercentage(props.min ?? 0)
+
+      const maxSizeA = Array.isArray(props.max)
+        ? convertToPercentage(props.max[triggerIndex.value] ?? 1)
+        : convertToPercentage(props.max ?? 1)
+      const maxSizeB = Array.isArray(props.max)
+        ? convertToPercentage(props.max[triggerIndex.value + 1] ?? 1)
+        : convertToPercentage(props.max ?? 1)
+
+      const snapOffset = props.snapOffset / containerElSizeRef.value
+      let snapped = false
+
+      // 检查最小值约束
+      if (newASize < minSizeA + snapOffset) {
+        newASize = minSizeA
+        newBSize = aSize + bSize - minSizeA
+        snapped = true
+      }
+      else if (newBSize < minSizeB + snapOffset) {
+        newBSize = minSizeB
+        newASize = aSize + bSize - minSizeB
+        snapped = true
+      }
+
+      // 检查最大值约束
+      if (minSizeA !== 0 && newASize > maxSizeA - snapOffset) {
+        newASize = maxSizeA
+        newBSize = aSize + bSize - maxSizeA
+        snapped = true
+      }
+      else if (minSizeB !== 0 && newBSize > maxSizeB - snapOffset) {
+        newBSize = maxSizeB
+        newASize = aSize + bSize - maxSizeB
+        snapped = true
+      }
+
+      if (
+        newASize >= minSizeA
+        && newBSize >= minSizeB
+        && (minSizeA === 0 || newASize <= maxSizeA)
+        && (minSizeB === 0 || newBSize <= maxSizeB)
+      ) {
+        panelSizes.value[triggerIndex.value] = newASize
+        panelSizes.value[triggerIndex.value + 1] = newBSize
+
+        if (!snapped) {
+          dragStartPos.value = currentPosition
+        }
+      }
+    }
+
+    const onStopDrag = () => {
+      isDraggingRef.value = false
+      off(mouseMoveEvent, document, onDraging)
+      off(mouseUpEvent, document, onStopDrag)
+    }
+
+    const handleOnMouseDown = (
+      e: MouseEvent | TouchEvent,
+      gutterIndex: number
+    ) => {
+      e.preventDefault()
+      triggerIndex.value = gutterIndex
+      dragStartPos.value = getMousePosition(e)
+      on(mouseMoveEvent, document, onDraging)
+      on(mouseUpEvent, document, onStopDrag)
+    }
+
+    const getNumericSlotsLength = () =>
+      Object.keys(slots).filter(key => /^\d+$/.test(key)).length
+
+    const initializeSingleValue = (value: number | string) => {
+      const panelSlotLength = getNumericSlotsLength()
+      const percentage = convertToPercentage(value)
+      return [
+        percentage,
+        ...Array(panelSlotLength - 1).fill(
+          (1 - percentage) / (panelSlotLength - 1)
+        )
+      ]
+    }
+
+    const initializeArrayValue = (value: (number | string)[]) => {
+      const panelSlotLength = getNumericSlotsLength()
+      const percentages = value.map(v => convertToPercentage(v))
+      return percentages.length >= panelSlotLength
+        ? percentages.slice(0, panelSlotLength)
+        : [
+            ...percentages,
+            ...Array(panelSlotLength - percentages.length).fill(
+              1 / panelSlotLength
+            )
+          ]
+    }
+
+    const initializeSplit = () => {
+      if (Array.isArray(props.size)) {
+        panelSizes.value = initializeArrayValue(props.size)
+      }
+      else if (props.size !== undefined) {
+        panelSizes.value = initializeSingleValue(props.size)
+      }
+      else if (Array.isArray(props.defaultSize)) {
+        panelSizes.value = initializeArrayValue(props.defaultSize)
+      }
+      else if (props.defaultSize !== undefined) {
+        panelSizes.value = initializeSingleValue(props.defaultSize)
+      }
+      else {
+        const panelSlotLength = getNumericSlotsLength()
+        panelSizes.value = Array(panelSlotLength).fill(1 / panelSlotLength)
+      }
+    }
+
+    onMounted(() => {
+      initializeSplit()
+    })
+
+    const getPanelStyle = (index: number) => {
+      const size = panelSizes.value[index]
+      const totalTriggerSize
+        = (getNumericSlotsLength() - 1) * props.resizeTriggerSize
+      const availableSpace
+        = 100 - (totalTriggerSize / containerElSizeRef.value) * 100
+      return {
+        'flex-basis': `calc(${size * 100}% * ${availableSpace / 100})`
+      }
+    }
+
+    const resizeTriggerStyle = computed(() => {
+      if (isHorizontal) {
+        return {
+          width: `${props.resizeTriggerSize}px`,
+          flexBasis: `${props.resizeTriggerSize}px`,
+          cursor: 'col-resize'
+        }
+      }
+      else {
+        return {
+          height: `${props.resizeTriggerSize}px`,
+          flexBasis: `${props.resizeTriggerSize}px`,
+          cursor: 'row-resize'
+        }
+      }
+    })
+
+    const onContainerResize = (e: ResizeObserverEntry) => {
+      containerElSizeRef.value = isHorizontal
+        ? e.contentRect.width
+        : e.contentRect.height
+    }
+
+    // const resizeTriggerWrapperStyle = computed(() => {
+    //   return {
+    //     width: isHorizontal ? `${props.resizeTriggerSize}px` : '',
+    //     height: isHorizontal ? '' : `${props.resizeTriggerSize}px`,
+    //     cursor: isHorizontal ? 'col-resize' : 'row-resize'
+    //   }
+    // })
+
     return {
       themeClass: themeClassHandle?.themeClass,
       onRender: themeClassHandle?.onRender,
       cssVars: inlineThemeDisabled ? undefined : cssVarsRef,
-      resizeTriggerElRef,
       isDragging: isDraggingRef,
       mergedClsPrefix: mergedClsPrefixRef,
-      resizeTriggerWrapperStyle,
       resizeTriggerStyle,
-      handleMouseDown,
-      firstPaneStyle
+      panelSizes,
+      handleOnMouseDown,
+      getPanelStyle,
+      getNumericSlotsLength,
+      onContainerResize
     }
   },
   render() {
     this.onRender?.()
+    const {
+      handleOnMouseDown,
+      getPanelStyle,
+      resizeTriggerStyle,
+      getNumericSlotsLength,
+      onContainerResize,
+      $attrs,
+      mergedClsPrefix,
+      themeClass,
+      isDragging,
+      direction,
+      $slots,
+      cssVars
+    } = this
     return (
-      <div
-        class={[
-          `${this.mergedClsPrefix}-split`,
-          `${this.mergedClsPrefix}-split--${this.direction}`,
-          this.themeClass
-        ]}
-        style={this.cssVars as CSSProperties}
-      >
-        <div
-          class={[`${this.mergedClsPrefix}-split-pane-1`, this.pane1Class]}
-          style={[this.firstPaneStyle, this.pane1Style]}
-        >
-          {this.$slots[1]?.()}
-        </div>
-        {!this.disabled && (
-          <div
-            ref="resizeTriggerElRef"
-            class={`${this.mergedClsPrefix}-split__resize-trigger-wrapper`}
-            style={this.resizeTriggerWrapperStyle}
-            onMousedown={this.handleMouseDown}
-          >
-            {resolveSlot(this.$slots['resize-trigger'], () => [
-              <div
-                style={this.resizeTriggerStyle}
-                class={[
-                  `${this.mergedClsPrefix}-split__resize-trigger`,
-                  this.isDragging
-                  && `${this.mergedClsPrefix}-split__resize-trigger--hover`
-                ]}
-              >
-              </div>
-            ])}
-          </div>
-        )}
-        <div
-          class={[`${this.mergedClsPrefix}-split-pane-2`, this.pane2Class]}
-          style={this.pane2Style}
-        >
-          {this.$slots[2]?.()}
-        </div>
-      </div>
+      <VResizeObserver onResize={onContainerResize}>
+        {{
+          default: () => (
+            <div
+              {...$attrs}
+              class={[
+                $attrs.class,
+                `${mergedClsPrefix}-split`,
+                `${mergedClsPrefix}-split--${direction}`,
+                themeClass
+              ]}
+              style={[$attrs.style as StyleValue, cssVars as CSSProperties]}
+            >
+              {Array.from({ length: getNumericSlotsLength() }).map(
+                (_, index) => (
+                  <Fragment key={index}>
+                    <div
+                      style={getPanelStyle(index)}
+                      class={[`${mergedClsPrefix}-split-pane`]}
+                    >
+                      {$slots[`${index + 1}`]?.()}
+                    </div>
+                    {index < getNumericSlotsLength() - 1 && (
+                      <div
+                        class={[
+                          `${mergedClsPrefix}-split__resize-trigger`,
+                          isDragging
+                          && `${mergedClsPrefix}-split__resize-trigger--hover`
+                        ]}
+                        style={resizeTriggerStyle}
+                        onMousedown={e => handleOnMouseDown(e, index)}
+                      />
+                    )}
+                  </Fragment>
+                )
+              )}
+            </div>
+          )
+        }}
+      </VResizeObserver>
     )
   }
 })

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -186,34 +186,43 @@ export default defineComponent({
         snapped = true
       }
 
-      if (
-        newASizeInPx >= minA
-        && newBSizeInPx >= minB
-        && (minA === 0 || newASizeInPx <= maxA)
-        && (minB === 0 || newBSizeInPx <= maxB)
-      ) {
-        if (typeof aSize === 'number') {
-          panelSizes.value[triggerIndex.value]
-            = newASizeInPx / containerElSizeRef.value
-        }
-        else {
-          panelSizes.value[triggerIndex.value] = `${newASizeInPx}px`
-        }
+      const halfSize = containerElSizeRef.value / 2
+      if (Math.abs(newASizeInPx - halfSize) <= snapOffset) {
+        newASizeInPx = halfSize
+        newBSizeInPx = aSizeInPx + bSizeInPx - halfSize
+        snapped = true
+      }
 
-        if (bSize === 'auto') {
-          panelSizes.value[triggerIndex.value + 1] = `${newBSizeInPx}px`
-        }
-        else if (typeof bSize === 'number') {
-          panelSizes.value[triggerIndex.value + 1]
-            = newBSizeInPx / containerElSizeRef.value
-        }
-        else {
-          panelSizes.value[triggerIndex.value + 1] = `${newBSizeInPx}px`
-        }
+      newASizeInPx = Math.max(
+        minA,
+        Math.min(maxA || containerElSizeRef.value, newASizeInPx)
+      )
+      newBSizeInPx = Math.max(
+        minB,
+        Math.min(maxB || containerElSizeRef.value, newBSizeInPx)
+      )
 
-        if (!snapped) {
-          dragStartPos.value = currentPosition
-        }
+      if (typeof aSize === 'number') {
+        panelSizes.value[triggerIndex.value]
+          = newASizeInPx / containerElSizeRef.value
+      }
+      else {
+        panelSizes.value[triggerIndex.value] = `${newASizeInPx}px`
+      }
+
+      if (bSize === 'auto') {
+        panelSizes.value[triggerIndex.value + 1] = `${newBSizeInPx}px`
+      }
+      else if (typeof bSize === 'number') {
+        panelSizes.value[triggerIndex.value + 1]
+          = newBSizeInPx / containerElSizeRef.value
+      }
+      else {
+        panelSizes.value[triggerIndex.value + 1] = `${newBSizeInPx}px`
+      }
+
+      if (!snapped) {
+        dragStartPos.value = currentPosition
       }
     }
 

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -99,7 +99,7 @@ export default defineComponent({
       : undefined
 
     const isHorizontal = props.direction === 'horizontal'
-    const isDraggingRef = ref(false)
+    const isDraggingRef = ref(-1)
     const containerElSizeRef = ref(0)
     const panelSizes = ref<Array<string | number>>([])
     const triggerIndex = ref(-1)
@@ -218,7 +218,7 @@ export default defineComponent({
     }
 
     const onStopDrag = (e: MouseEvent) => {
-      isDraggingRef.value = false
+      isDraggingRef.value = -1
       if (props.onDragEnd)
         props.onDragEnd(e)
       off(mouseMoveEvent, document, onDraging)
@@ -230,6 +230,7 @@ export default defineComponent({
       if (props.onDragStart)
         props.onDragStart(e)
       triggerIndex.value = index
+      isDraggingRef.value = index
       dragStartPos.value = getMousePosition(e)
       on(mouseMoveEvent, document, onDraging)
       on(mouseUpEvent, document, onStopDrag)
@@ -413,7 +414,7 @@ export default defineComponent({
                       <div
                         class={[
                           `${mergedClsPrefix}-split__resize-trigger`,
-                          isDragging
+                          isDragging === index
                           && `${mergedClsPrefix}-split__resize-trigger--hover`
                         ]}
                         style={resizeTriggerStyle}

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -55,6 +55,10 @@ export const splitProps = {
     type: Number,
     default: 0
   },
+  snapToCenter: {
+    type: Boolean,
+    default: false
+  },
   pane1Class: String,
   pane1Style: [Object, String] as PropType<CSSProperties | string>,
   pane2Class: String,
@@ -187,7 +191,10 @@ export default defineComponent({
       }
 
       const halfSize = containerElSizeRef.value / 2
-      if (Math.abs(newASizeInPx - halfSize) <= snapOffset) {
+      if (
+        props.snapToCenter
+        && Math.abs(newASizeInPx - halfSize) <= snapOffset
+      ) {
         newASizeInPx = halfSize
         newBSizeInPx = aSizeInPx + bSizeInPx - halfSize
         snapped = true

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -130,8 +130,8 @@ export default defineComponent({
     }
 
     const onDraging = (e: MouseEvent | TouchEvent) => {
-      if (isDraggingRef.value)
-        return
+      if (props.onDragMove)
+        props.onDragMove(e)
 
       const currentPosition = getMousePosition(e)
       const mouseMoved = currentPosition - dragStartPos.value
@@ -160,7 +160,6 @@ export default defineComponent({
       const snapOffset = props.snapOffset / containerElSizeRef.value
       let snapped = false
 
-      // 检查最小值约束
       if (newASize < minSizeA + snapOffset) {
         newASize = minSizeA
         newBSize = aSize + bSize - minSizeA
@@ -172,7 +171,6 @@ export default defineComponent({
         snapped = true
       }
 
-      // 检查最大值约束
       if (minSizeA !== 0 && newASize > maxSizeA - snapOffset) {
         newASize = maxSizeA
         newBSize = aSize + bSize - maxSizeA
@@ -199,18 +197,19 @@ export default defineComponent({
       }
     }
 
-    const onStopDrag = () => {
+    const onStopDrag = (e: MouseEvent) => {
       isDraggingRef.value = false
+      if (props.onDragEnd)
+        props.onDragEnd(e)
       off(mouseMoveEvent, document, onDraging)
       off(mouseUpEvent, document, onStopDrag)
     }
 
-    const handleOnMouseDown = (
-      e: MouseEvent | TouchEvent,
-      gutterIndex: number
-    ) => {
+    const handleOnMouseDown = (e: MouseEvent, index: number) => {
       e.preventDefault()
-      triggerIndex.value = gutterIndex
+      if (props.onDragStart)
+        props.onDragStart(e)
+      triggerIndex.value = index
       dragStartPos.value = getMousePosition(e)
       on(mouseMoveEvent, document, onDraging)
       on(mouseUpEvent, document, onStopDrag)

--- a/src/split/src/styles/index.cssr.ts
+++ b/src/split/src/styles/index.cssr.ts
@@ -15,12 +15,10 @@ export default cB('split', `
   cM('vertical', `
     flex-direction: column;
   `),
-  cB('split-pane-1', `
+  cB('split-pane', `
     overflow: hidden;
-  `),
-  cB('split-pane-2', `
-    overflow: hidden;
-    flex: 1;
+    flex-grow: 0;
+    flex-shrink: 0;
   `),
   cE('resize-trigger', `
     background-color: var(--n-resize-trigger-color);

--- a/src/split/src/types.ts
+++ b/src/split/src/types.ts
@@ -1,1 +1,3 @@
 export type SplitOnUpdateSize = (size: string & number) => void
+
+export type SizeType = string | number | (string | number)[]

--- a/volar.d.ts
+++ b/volar.d.ts
@@ -68,6 +68,7 @@ declare module 'vue' {
     NH4: (typeof import('naive-ui'))['NH4']
     NH5: (typeof import('naive-ui'))['NH5']
     NH6: (typeof import('naive-ui'))['NH6']
+    NHighlight: (typeof import('naive-ui'))['NHighlight']
     NHr: (typeof import('naive-ui'))['NHr']
     NIcon: (typeof import('naive-ui'))['NIcon']
     NIconWrapper: (typeof import('naive-ui'))['NIconWrapper']
@@ -89,6 +90,7 @@ declare module 'vue' {
     NListItem: (typeof import('naive-ui'))['NListItem']
     NLoadingBarProvider: (typeof import('naive-ui'))['NLoadingBarProvider']
     NLog: (typeof import('naive-ui'))['NLog']
+    NMarqueue: (typeof import('naive-ui'))['NMarqueue']
     NMention: (typeof import('naive-ui'))['NMention']
     NMenu: (typeof import('naive-ui'))['NMenu']
     NMessageProvider: (typeof import('naive-ui'))['NMessageProvider']
@@ -150,8 +152,6 @@ declare module 'vue' {
     NUploadTrigger: (typeof import('naive-ui'))['NUploadTrigger']
     NVirtualList: (typeof import('naive-ui'))['NVirtualList']
     NWatermark: (typeof import('naive-ui'))['NWatermark']
-    NHighlight: (typeof import('naive-ui'))['NHighlight']
-    NMarqueue: (typeof import('naive-ui'))['NMarqueue']
   }
 }
 export {}


### PR DESCRIPTION
close https://github.com/tusen-ai/naive-ui/issues/6518

改动：

- 新增多面板
- 新增吸附 & 中心吸附
- 根据插槽为 `number` 类型推断为面板插槽
- 新增 `number[]` 类型的 `panelSizes` 存储每个面板的 `size`
- 不再根据 `trigger` 的 `offset` 更新面板大小
- 去除了 `pane1-class`  `pane1-style`  `pane2-class`  `pane2-style`



未能解决的问题：

- `defaultSize` `size` 合并
- `disable`
- `watchProps`
-  多个 `resize-trigger` 插槽
- 每个面板的 `class`  `style`
- 代码可能需要优化 （ 像素转化部分 ，面板大小更新的逻辑 ）
