### PR TITLE
fix: `n-modal` has log warnings of console when use `aria-hidden` attribute.

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -9,7 +9,7 @@
 - Fix `n-time-picker`'s `use-12-hours` type error warning, closes [#4308](https://github.com/tusen-ai/naive-ui/issues/4308)
 - Fix `input-number` the problem that the negative sign is replaced when the negative sign is entered.
 - Fix `n-data-table`'s header will show scrollbar in some old browsers, closes [#6557](https://github.com/tusen-ai/naive-ui/issues/6557).
-- Fix browser warnings caused by `aria-hidden` attribute in `Modal`, closes [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)
+- Fix `n-modal` has log warnings of console when use `aria-hidden` attribute, closes [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)
 
 ### Features
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -9,6 +9,7 @@
 - Fix `n-time-picker`'s `use-12-hours` type error warning, closes [#4308](https://github.com/tusen-ai/naive-ui/issues/4308)
 - Fix `input-number` the problem that the negative sign is replaced when the negative sign is entered.
 - Fix `n-data-table`'s header will show scrollbar in some old browsers, closes [#6557](https://github.com/tusen-ai/naive-ui/issues/6557).
+- Fix browser warnings caused by `aria-hidden` attribute in `Modal`, closes [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -9,7 +9,7 @@
 - `n-time-picker` 的 `use-12-hours` 类型错误警告，关闭 [#4308](https://github.com/tusen-ai/naive-ui/issues/4308)
 - 修复 `input-number` 存在负号时被替换的问题
 - 修复 `n-data-table` 的 header 在部分浏览器中会出现滚动条，关闭 [#6557](https://github.com/tusen-ai/naive-ui/issues/6557)
-- 修复 `Modal` 中 `aria-hidden` 属性引发的浏览器警告，关闭 [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)
+- 修复 `n-modal` 中 `aria-hidden` 属性引发的控制台报警告，关闭 [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -9,6 +9,7 @@
 - `n-time-picker` 的 `use-12-hours` 类型错误警告，关闭 [#4308](https://github.com/tusen-ai/naive-ui/issues/4308)
 - 修复 `input-number` 存在负号时被替换的问题
 - 修复 `n-data-table` 的 header 在部分浏览器中会出现滚动条，关闭 [#6557](https://github.com/tusen-ai/naive-ui/issues/6557)
+- 修复 `Modal` 中 `aria-hidden` 属性引发的浏览器警告，关闭 [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)
 
 ### Features
 

--- a/src/modal/src/Modal.tsx
+++ b/src/modal/src/Modal.tsx
@@ -347,7 +347,6 @@ export default defineComponent({
                               default: () => {
                                 return this.show ? (
                                   <div
-                                    aria-hidden
                                     ref="containerRef"
                                     class={`${mergedClsPrefix}-modal-mask`}
                                     onClick={this.handleClickoutside}


### PR DESCRIPTION
Fixes [#6436](https://github.com/tusen-ai/naive-ui/issues/6436)

close https://github.com/tusen-ai/naive-ui/issues/6593

我注意到之前有人提交了一个 PR [#6463](https://github.com/tusen-ai/naive-ui/pull/6463)
他用 `inert` 替换 `aria-hidden`，这样做会让 div 中的 onClick 事件失效的。

> https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert
>
> The `inert` attribute can be added to sections of content that should not be interactive. When an element is inert, it along with all of the element's descendants, including normally interactive elements such as links, buttons, and form controls are disabled because they **cannot receive focus or be clicked.**



<br>

我建议是直接就删除  `aria-hidden`，antd 组件库也是这样做的：[#fix: Modal a11y warning issue](https://github.com/ant-design/ant-design/pull/50823)