### PR TITLE
fix(input): textarea height cannot respond to autosize option changes

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-input` when the type is `textarea` the height cannot respond to `autosize` option changes.
+
 ## 2.40.3
 
 `2024-12-02`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - 修复 `n-scrollbar`、`n-float-button`、`n-float-button-group`、`n-popover` 组件中的 `inset` 属性在部分浏览器中有兼容性问题，close [#6604](https://github.com/tusen-ai/naive-ui/issues/6604)，close [#6602](https://github.com/tusen-ai/naive-ui/issues/6602)
+- 修复 `n-input` 组件 `type` 为 `textarea`的时候，`autosize` 配置发生变化，高度却没有改变
 
 ## 2.40.3
 

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -367,6 +367,9 @@ export default defineComponent({
         }
       }
     }
+    const autoSizeOptionNeedWatch = typeof props.autosize !== 'boolean'
+    if (autoSizeOptionNeedWatch)
+      watch(toRef(props, 'autosize'), () => updateTextAreaStyle())
     // word count
     const maxlengthRef = computed(() => {
       const { maxlength } = props


### PR DESCRIPTION
close [#6652](https://github.com/tusen-ai/naive-ui/issues/6652).