### PR TITLE
fix(n-input-number): misalignment issue when used in `n-input-group` with `n-input-group-label`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `n-data-table` may have multiple expand trigger with tree data.
+- Fix `n-input-number` misalignment issue when used in `n-input-group` with `n-input-group-label`, closes [#6608](https://github.com/tusen-ai/naive-ui/issues/6608).
 
 ## 2.40.4
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - 修复 `n-data-table` 在使用树形数据的时候出现多个展开 icon
+- Fix `n-input-number` 在 `n-input-group` 中配合 `n-input-group-label` 使用时两者错位的问题，关闭 [#6608](https://github.com/tusen-ai/naive-ui/issues/6608)
 
 ## 2.40.4
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - 修复 `n-data-table` 在使用树形数据的时候出现多个展开 icon
-- Fix `n-input-number` 在 `n-input-group` 中配合 `n-input-group-label` 使用时两者错位的问题，关闭 [#6608](https://github.com/tusen-ai/naive-ui/issues/6608)
+- 修复 `n-input-number` 在 `n-input-group` 中配合 `n-input-group-label` 使用时两者错位的问题，关闭 [#6608](https://github.com/tusen-ai/naive-ui/issues/6608)
 
 ## 2.40.4
 

--- a/src/input-number/src/styles/input-number.cssr.ts
+++ b/src/input-number/src/styles/input-number.cssr.ts
@@ -1,6 +1,8 @@
-import { c, cB } from '../../../_utils/cssr'
+import { cB } from '../../../_utils/cssr'
 
-export default c([
+export default cB('input-number', `
+  display: inline-flex;
+  `, [
   cB('input-number-suffix', `
     display: inline-block;
     margin-right: 10px;


### PR DESCRIPTION
close #6608
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
