### PR TITLE
UMD 构建产物向下兼容

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`2024-12-30`
+
+### Fixes
+
+- 修复 UMD 构建产物浏览器兼容性问题，Chrome84测试通过，其他浏览器未进行测试
+
 ## 2.40.4
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`2024-12-30`
+
+### Fixes
+
+- 修复 UMD 构建产物浏览器兼容性问题，Chrome84测试通过，其他浏览器未进行测试
+
 ## 2.40.4
 
 ### Fixes

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,15 @@ const umdConfig = defineConfig({
     globals: {
       vue: 'Vue'
     }
-  }
+  },
+  plugins: [
+    esbuild({
+      target: 'es2015',
+      jsx: 'transform',
+      jsxFactory: 'h',
+      jsxFragment: 'Fragment'
+    }),
+  ]
 })
 
 const esmConfig = defineConfig({


### PR DESCRIPTION
修复 UMD 构建产物浏览器兼容性问题，Chrome84测试通过，其他浏览器未进行测试