### PR TITLE
chore: inject configProviderInjectionKey 时提供默认值 null，防止 vue warn

### DIFF
--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -195,7 +195,7 @@ export default defineComponent({
       doUncheck,
       renderCell
     } = inject(dataTableInjectionKey)!
-    const NConfigProvider = inject(configProviderInjectionKey)
+    const NConfigProvider = inject(configProviderInjectionKey, null)
     const scrollbarInstRef = ref<ScrollbarInst | null>(null)
     const virtualListRef = ref<VirtualListInst | null>(null)
     const emptyElRef = ref<HTMLElement | null>(null)

--- a/src/equation/src/Equation.tsx
+++ b/src/equation/src/Equation.tsx
@@ -16,7 +16,7 @@ export const Equation = defineComponent({
   name: 'Equation',
   props: equationProps,
   setup(props) {
-    const configProviderContext = inject(configProviderInjectionKey)
+    const configProviderContext = inject(configProviderInjectionKey, null)
     const extractedHtmlInfo = computed(() => {
       const outerHtml
         = (


### PR DESCRIPTION
全局查了一下 configProviderInjectionKey 关键字，只有这 2 个组件没提供默认值