### PR TITLE
fix(n-tab-pane): fix tab-pane slots type error

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-tab-pane` slots type error.
+
 ## 2.41.0
 
 ### Breaking Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-tab-pane` 插槽的类型错误问题
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/tabs/src/TabPane.tsx
+++ b/src/tabs/src/TabPane.tsx
@@ -41,8 +41,7 @@ export type TabPaneProps = ExtractPublicPropTypes<typeof tabPaneProps>
 
 export interface TabPaneSlots {
   default?: () => VNode[]
-  prefix?: () => VNode[]
-  suffix?: () => VNode[]
+  tab?: () => VNode[]
 }
 
 export default defineComponent({


### PR DESCRIPTION
修复 `n-tab-pane` 插槽的类型定义错误问题，缺少 `tab` 插槽及多余 `prefix` 和 `suffix` 插槽。