### PR TITLE
feat(data-table): summary总结栏支持滚动固定

### DIFF
--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Features
+
+- `n-data-table` 新增 `sticky-summary`、`summary-max-height` 属性，用于支持表格内容滚动时，总结栏固定不动，关闭 [#6585](https://github.com/tusen-ai/naive-ui/issues/6585)、[#6432](https://github.com/tusen-ai/naive-ui/issues/6432)、[#6170](https://github.com/tusen-ai/naive-ui/issues/6170)、[#2814](https://github.com/tusen-ai/naive-ui/issues/2814)
+
 ## 2.41.1
 
 ### Fixes

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -121,6 +121,8 @@ rtl-debug.vue
 | striped | `boolean` | `false` | 是否使用斑马线条纹 |  |
 | summary | `DataTableCreateSummary` | `undefined` | 表格总结栏的数据，类型见 <n-a href="#DataTableCreateSummary-Type">DataTableCreateSummary Type</n-a> |  |
 | summary-placement | `'top' \| 'bottom'` | `'bottom'` | 总结栏的位置 | 2.33.3 |
+| sticky-summary | `boolean` | `false` | 总结栏是否不随表格纵向滚动 | NEXT_VERSION |
+| summary-max-height | `number \| string` | `undefined` | 当 `sticky-summary` 为 `true` 时，总结栏最大高度，可以是 CSS 属性值 | NEXT_VERSION |
 | table-layout | `'auto' \| 'fixed'` | `'auto'` | 表格的 `table-layout` 样式属性，在设定 `ellipsis` 或 `max-height` 的情况下固定为 `'fixed'` |  |
 | virtual-scroll | `boolean` | `false` | 是否开启虚拟滚动，应对大规模数据，开启前请设定好 `max-height`。当 `virtual-scroll` 为 `true` 时，`rowSpan` 将不生效 |  |
 | virtual-scroll-header | `boolean` | `false` | 是否打开表头的虚拟滚动，如果横向列太多，可以考虑打开此属性，打开此属性会导致表头单元格跨行列的功能不可用，同时必须要配置 `header-height` | 2.40.0 |

--- a/src/data-table/demos/zhCN/summary-debug.demo.vue
+++ b/src/data-table/demos/zhCN/summary-debug.demo.vue
@@ -3,7 +3,15 @@
 </markdown>
 
 <script lang="ts">
+import type { DataTableColumns } from 'naive-ui'
 import { defineComponent, h } from 'vue'
+
+interface RowData {
+  key: number
+  name: string
+  age: number
+  address: string
+}
 
 function createColumns() {
   return [
@@ -28,27 +36,86 @@ function createColumns() {
   ] as any
 }
 
-function createData() {
+function createColumns2(): DataTableColumns<RowData> {
   return [
     {
-      key: 0,
-      name: 'John Brown',
-      age: 32,
-      address: 'New York No. 1 Lake Park'
+      type: 'selection',
+      fixed: 'left'
     },
     {
-      key: 1,
-      name: 'Jim Green',
-      age: 42,
-      address: 'London No. 1 Lake Park'
+      title: 'Name',
+      key: 'name',
+      width: 200,
+      fixed: 'left'
     },
     {
-      key: 2,
-      name: 'Joe Black',
-      age: 32,
-      address: 'Sidney No. 1 Lake Park'
+      title: 'Age',
+      key: 'age',
+      width: 100,
+      fixed: 'left'
+    },
+    {
+      title: 'Row',
+      key: 'row'
+    },
+    {
+      title: 'Row1',
+      key: 'row1'
+    },
+    {
+      title: 'Row2',
+      key: 'row2',
+      width: 100,
+      fixed: 'right'
+    },
+    {
+      title: 'Address',
+      key: 'address',
+      width: 200,
+      fixed: 'right'
     }
   ]
+}
+
+let scrollX = 0
+function createColumns3() {
+  scrollX = 0
+  const columns: DataTableColumns<RowData> = []
+  for (let i = 0; i < 1000; ++i) {
+    scrollX += 100
+    columns.push({
+      title: `Col ${i}`,
+      width: 100,
+      key: i,
+      fixed: i <= 1 ? 'left' : i > 997 ? 'right' : undefined,
+      render(_, rowIndex) {
+        return `${i}-${rowIndex}`
+      }
+    })
+  }
+  return columns
+}
+
+function createData2() {
+  const data: RowData[] = Array.from({ length: 1000 }).map((_, index) => ({
+    key: index,
+    name: `Edward King ${index}`,
+    age: 32,
+    address: `London, Park Lane no. ${index}`
+  }))
+  return data
+}
+
+function createData(length = 3) {
+  return Array.from({ length }).map((_, index) => ({
+    key: index,
+    name: `Edward King ${index}`,
+    age: 32,
+    address: `London, Park Lane no. ${index}`,
+    row: `row-${index}`,
+    row1: `row1-${index}`,
+    row2: `row2-${index}`
+  }))
 }
 
 function createSummary() {
@@ -66,17 +133,119 @@ function createSummary() {
   ]
 }
 
+function createSummary2(length = 2) {
+  return Array.from({ length }).map((_, index) => ({
+    name: {
+      value: h('span', { style: { color: 'red' } }, 7 + index)
+    },
+    age: {
+      value: h('span', null, 6 + index)
+    },
+    row: { value: `row-${index}` },
+    row1: { value: `row1-${index}` },
+    row2: { value: `row2-${index}` },
+    address: {
+      value: index
+    }
+  }))
+}
+
+function createSummary3(length = 100) {
+  return Array.from({ length }).map(() =>
+    Array.from({ length: 1000 }).reduce<Record<any, any>>((pre, cur, index) => {
+      pre[index] = { value: index }
+      return pre
+    }, {})
+  )
+}
+
 export default defineComponent({
   setup() {
     return {
-      summary: createSummary,
-      data: createData(),
-      columns: createColumns()
+      scrollX,
+      createData,
+      createData2,
+      createSummary,
+      createSummary2,
+      createSummary3,
+      createColumns,
+      createColumns2,
+      createColumns3
     }
   }
 })
 </script>
 
 <template>
-  <n-data-table :columns="columns" :data="data" :summary="summary" />
+  <n-space vertical :size="12">
+    <n-data-table
+      :columns="createColumns()"
+      :data="createData()"
+      :summary="createSummary"
+    />
+    <n-data-table
+      :columns="createColumns()"
+      :data="createData(10)"
+      max-height="200"
+      sticky-summary
+      :summary="createSummary"
+      summary-placement="top"
+    />
+    <n-data-table
+      :columns="createColumns()"
+      :data="createData(10)"
+      max-height="200"
+      sticky-summary
+      :summary="createSummary"
+      summary-placement="bottom"
+    />
+    <n-data-table
+      :columns="createColumns2()"
+      :data="createData(20)"
+      :pagination="{ pageSize: 10 }"
+      :scroll-x="1800"
+      :style="{ height: `300px` }"
+      flex-height
+      :summary="() => createSummary2(3)"
+      sticky-summary
+    />
+    <n-data-table
+      :columns="createColumns2()"
+      :data="createData(20)"
+      :pagination="{ pageSize: 10 }"
+      :scroll-x="1800"
+      :style="{ height: `300px` }"
+      flex-height
+      :summary="() => createSummary2(3)"
+      sticky-summary
+      summary-placement="top"
+    />
+    <n-data-table
+      :columns="createColumns2()"
+      :data="createData(20)"
+      :pagination="{ pageSize: 10 }"
+      :scroll-x="1800"
+      :style="{ height: `300px` }"
+      flex-height
+      :summary="() => createSummary2(3)"
+      sticky-summary
+      summary-max-height="70"
+      summary-placement="top"
+    />
+    <n-data-table
+      :columns="createColumns3()"
+      :data="createData2()"
+      :max-height="250"
+      virtual-scroll
+      virtual-scroll-x
+      :scroll-x="scrollX"
+      :min-row-height="48"
+      :height-for-row="() => 48"
+      virtual-scroll-header
+      :header-height="48"
+      :summary="() => createSummary3(1000)"
+      :summary-max-height="200"
+      sticky-summary
+    />
+  </n-space>
 </template>

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -278,6 +278,8 @@ export default defineComponent({
       mergedTableLayoutRef,
       maxHeightRef: toRef(props, 'maxHeight'),
       minHeightRef: toRef(props, 'minHeight'),
+      summaryMaxHeightRef: toRef(props, 'summaryMaxHeight'),
+      stickySummaryRef: toRef(props, 'stickySummary'),
       flexHeightRef: toRef(props, 'flexHeight'),
       headerCheckboxDisabledRef,
       paginationBehaviorOnFilterRef: toRef(props, 'paginationBehaviorOnFilter'),

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -186,6 +186,8 @@ export default defineComponent({
       indentRef,
       rowPropsRef,
       maxHeightRef,
+      summaryMaxHeightRef,
+      stickySummaryRef,
       stripedRef,
       loadingRef,
       onLoadRef,
@@ -206,6 +208,15 @@ export default defineComponent({
     const NConfigProvider = inject(configProviderInjectionKey)
     const scrollbarInstRef = ref<ScrollbarInst | null>(null)
     const virtualListRef = ref<VirtualListInst | null>(null)
+    const summaryScrollable = computed(() => {
+      const scrollable = summaryMaxHeightRef.value !== undefined
+      return (
+        scrollable || (!scrollable && mergedTableLayoutRef.value === 'auto')
+      )
+    })
+    const summaryScrollElRef = ref<HTMLDivElement | null>(null)
+    const summaryScrollbarInstRef = ref<ScrollbarInst | null>(null)
+    const summaryVirtualListRef = ref<VirtualListInst | null>(null)
     const emptyElRef = ref<HTMLElement | null>(null)
     const emptyRef = useMemo(() => paginatedDataRef.value.length === 0)
     // If header is not inside & empty is displayed, no table part would be
@@ -349,12 +360,60 @@ export default defineComponent({
     function handleVirtualListScroll(e: Event): void {
       handleTableBodyScroll(e)
       scrollbarInstRef.value?.sync()
+      setSummaryScrollLeft()
     }
     function handleVirtualListResize(e: ResizeObserverEntry): void {
       const { onResize } = props
       if (onResize)
         onResize(e)
       scrollbarInstRef.value?.sync()
+    }
+    function summaryVirtualListContainer(): HTMLElement | null {
+      const { value } = summaryVirtualListRef
+      return value?.listElRef || null
+    }
+    function summaryVirtualListContent(): HTMLElement | null {
+      const { value } = summaryVirtualListRef
+      return value?.itemsElRef || null
+    }
+    function handleSummaryVirtualListResize() {
+      summaryScrollbarInstRef.value?.sync()
+    }
+    function getSummaryScrollContainer() {
+      if (!virtualScrollRef.value) {
+        return summaryScrollable.value
+          ? summaryScrollbarInstRef.value?.containerRef
+          : summaryScrollElRef.value
+      }
+      else {
+        return summaryVirtualListRef.value?.listElRef
+      }
+    }
+    function setSummaryScrollLeft() {
+      const body = getScrollContainer()
+      if (!body) {
+        return
+      }
+      const summaryScrollContainer = getSummaryScrollContainer()
+      if (summaryScrollContainer) {
+        summaryScrollContainer.scrollLeft = body.scrollLeft
+      }
+    }
+    let lastSummaryScrollLeft = 0
+    function handleSummaryScroll(e: Event): void {
+      const body = getScrollContainer()
+      const scrollLeft = (e.target as HTMLElement).scrollLeft
+      if (lastSummaryScrollLeft !== scrollLeft) {
+        if (body) {
+          body.scrollLeft = scrollLeft
+        }
+        lastSummaryScrollLeft = scrollLeft
+      }
+      else {
+        if (virtualScrollRef.value) {
+          summaryScrollbarInstRef.value?.sync()
+        }
+      }
     }
     const exposedMethods: MainTableBodyRef = {
       getScrollContainer,
@@ -450,6 +509,9 @@ export default defineComponent({
       componentId,
       scrollbarInstRef,
       virtualListRef,
+      summaryScrollElRef,
+      summaryScrollbarInstRef,
+      summaryVirtualListRef,
       emptyElRef,
       summary: summaryRef,
       mergedClsPrefix: mergedClsPrefixRef,
@@ -509,6 +571,9 @@ export default defineComponent({
       indent: indentRef,
       rowProps: rowPropsRef,
       maxHeight: maxHeightRef,
+      summaryScrollable,
+      summaryMaxHeight: summaryMaxHeightRef,
+      stickySummary: stickySummaryRef,
       loadingKeySet: loadingKeySetRef,
       expandable: expandableRef,
       stickyExpandedRows: stickyExpandedRowsRef,
@@ -517,10 +582,17 @@ export default defineComponent({
       setHeaderScrollLeft,
       handleVirtualListScroll,
       handleVirtualListResize,
+      handleSummaryScroll,
       handleMouseleaveTable,
       virtualListContainer,
       virtualListContent,
-      handleTableBodyScroll,
+      summaryVirtualListContainer,
+      summaryVirtualListContent,
+      handleSummaryVirtualListResize,
+      handleTableBodyScroll(e: Event) {
+        handleTableBodyScroll(e)
+        setSummaryScrollLeft()
+      },
       handleCheckboxUpdateChecked,
       handleRadioUpdateChecked,
       handleUpdateExpanded,
@@ -530,11 +602,13 @@ export default defineComponent({
   },
   render() {
     const {
-      mergedTheme,
       scrollX,
       mergedClsPrefix,
       virtualScroll,
       maxHeight,
+      summaryScrollable,
+      summaryMaxHeight,
+      stickySummary,
       mergedTableLayout,
       flexHeight,
       loadingKeySet,
@@ -557,593 +631,751 @@ export default defineComponent({
     if (scrollX)
       contentStyle.width = '100%'
 
-    const tableNode = (
-      <NScrollbar
-        {...this.scrollbarProps}
-        ref="scrollbarInstRef"
-        scrollable={scrollable || isBasicAutoLayout}
-        class={`${mergedClsPrefix}-data-table-base-table-body`}
-        style={!this.empty ? this.bodyStyle : undefined}
-        theme={mergedTheme.peers.Scrollbar}
-        themeOverrides={mergedTheme.peerOverrides.Scrollbar}
-        contentStyle={contentStyle}
-        container={virtualScroll ? this.virtualListContainer : undefined}
-        content={virtualScroll ? this.virtualListContent : undefined}
-        horizontalRailStyle={{ zIndex: 3 }}
-        verticalRailStyle={{ zIndex: 3 }}
-        xScrollable={xScrollable}
-        onScroll={virtualScroll ? undefined : this.handleTableBodyScroll}
-        internalOnUpdateScrollLeft={setHeaderScrollLeft}
-        onResize={onResize}
-      >
-        {{
-          default: () => {
-            // coordinate to pass if there are cells that cross row & col
-            const cordToPass: Record<number, number[]> = {}
-            // coordinate to related hover keys
-            const cordKey: Record<number, Record<number, RowKey[]>> = {}
-            const {
-              cols,
-              paginatedDataAndInfo,
-              mergedTheme,
-              fixedColumnLeftMap,
-              fixedColumnRightMap,
-              currentPage,
-              rowClassName,
-              mergedSortState,
-              mergedExpandedRowKeySet,
-              stickyExpandedRows,
-              componentId,
-              childTriggerColIndex,
-              expandable,
-              rowProps,
-              handleMouseleaveTable,
-              renderExpand,
-              summary,
-              handleCheckboxUpdateChecked,
-              handleRadioUpdateChecked,
-              handleUpdateExpanded,
-              heightForRow,
-              minRowHeight,
-              virtualScrollX
-            } = this
-            const { length: colCount } = cols
+    const createTableNode = () => {
+      // coordinate to pass if there are cells that cross row & col
+      const cordToPass: Record<number, number[]> = {}
+      // coordinate to related hover keys
+      const cordKey: Record<number, Record<number, RowKey[]>> = {}
+      const {
+        cols,
+        paginatedDataAndInfo,
+        mergedTheme,
+        fixedColumnLeftMap,
+        fixedColumnRightMap,
+        currentPage,
+        rowClassName,
+        mergedSortState,
+        mergedExpandedRowKeySet,
+        stickyExpandedRows,
+        componentId,
+        childTriggerColIndex,
+        expandable,
+        rowProps,
+        handleMouseleaveTable,
+        renderExpand,
+        summary,
+        handleCheckboxUpdateChecked,
+        handleRadioUpdateChecked,
+        handleUpdateExpanded,
+        heightForRow,
+        minRowHeight,
+        virtualScrollX,
+        handleSummaryScroll
+      } = this
+      const { length: colCount } = cols
 
-            let mergedData: RowRenderInfo[]
+      let mergedData: RowRenderInfo[]
 
-            // if there is children in data, we should expand mergedData first
+      // if there is children in data, we should expand mergedData first
 
-            const { data: paginatedData, hasChildren } = paginatedDataAndInfo
+      const { data: paginatedData, hasChildren } = paginatedDataAndInfo
 
-            const mergedPaginationData = hasChildren
-              ? flatten(paginatedData, mergedExpandedRowKeySet)
-              : paginatedData
+      const mergedPaginationData = hasChildren
+        ? flatten(paginatedData, mergedExpandedRowKeySet)
+        : paginatedData
 
-            if (summary) {
-              const summaryRows = summary(this.rawPaginatedData)
-              if (Array.isArray(summaryRows)) {
-                const summaryRowData = summaryRows.map((row, i) => ({
-                  isSummaryRow: true as const,
-                  key: `__n_summary__${i}`,
-                  tmNode: {
-                    rawNode: row,
-                    disabled: true
-                  },
-                  index: -1
-                }))
-                mergedData
-                  = this.summaryPlacement === 'top'
-                    ? [...summaryRowData, ...mergedPaginationData]
-                    : [...mergedPaginationData, ...summaryRowData]
-              }
-              else {
-                const summaryRowData = {
-                  isSummaryRow: true as const,
-                  key: '__n_summary__',
-                  tmNode: {
-                    rawNode: summaryRows,
-                    disabled: true
-                  },
-                  index: -1
-                }
-                mergedData
-                  = this.summaryPlacement === 'top'
-                    ? [summaryRowData, ...mergedPaginationData]
-                    : [...mergedPaginationData, summaryRowData]
-              }
+      const summaryRows = summary ? summary(this.rawPaginatedData) : []
+      const summaryRowData = Array.isArray(summaryRows)
+        ? summaryRows.map((row, i) => ({
+            isSummaryRow: true as const,
+            key: `__n_summary__${i}`,
+            tmNode: {
+              rawNode: row,
+              disabled: true
+            },
+            index: -1
+          }))
+        : [
+            {
+              isSummaryRow: true as const,
+              key: '__n_summary__',
+              tmNode: {
+                rawNode: summaryRows,
+                disabled: true
+              },
+              index: -1
             }
-            else {
-              mergedData = mergedPaginationData
-            }
+          ]
 
-            const indentStyle = hasChildren
-              ? { width: pxfy(this.indent) }
-              : undefined
+      if ((!stickySummary || this.showHeader) && summaryRowData.length > 0) {
+        mergedData
+          = this.summaryPlacement === 'top'
+            ? [...summaryRowData, ...mergedPaginationData]
+            : [...mergedPaginationData, ...summaryRowData]
+      }
+      else {
+        mergedData = mergedPaginationData
+      }
 
-            // Tile the data of the expanded row
-            const displayedData: RowRenderInfo[] = []
-            mergedData.forEach((rowInfo) => {
-              if (
-                renderExpand
-                && mergedExpandedRowKeySet.has(rowInfo.key)
-                && (!expandable || expandable(rowInfo.tmNode.rawNode))
-              ) {
-                displayedData.push(rowInfo, {
-                  isExpandedRow: true,
-                  key: `${rowInfo.key}-expand`, // solve key repeat of the expanded row
-                  tmNode: rowInfo.tmNode as TmNode,
-                  index: rowInfo.index
-                })
-              }
-              else {
-                displayedData.push(rowInfo)
-              }
-            })
+      const indentStyle = hasChildren ? { width: pxfy(this.indent) } : undefined
 
-            const { length: rowCount } = displayedData
+      // Tile the data of the expanded row
+      const displayedData: RowRenderInfo[] = []
+      mergedData.forEach((rowInfo) => {
+        if (
+          renderExpand
+          && mergedExpandedRowKeySet.has(rowInfo.key)
+          && (!expandable || expandable(rowInfo.tmNode.rawNode))
+        ) {
+          displayedData.push(rowInfo, {
+            isExpandedRow: true,
+            key: `${rowInfo.key}-expand`, // solve key repeat of the expanded row
+            tmNode: rowInfo.tmNode as TmNode,
+            index: rowInfo.index
+          })
+        }
+        else {
+          displayedData.push(rowInfo)
+        }
+      })
 
-            const rowIndexToKey: Record<number, RowKey> = {}
-            paginatedData.forEach(({ tmNode }, rowIndex) => {
-              rowIndexToKey[rowIndex] = tmNode.key
-            })
+      const { length: rowCount } = displayedData
 
-            const bodyWidth = stickyExpandedRows ? this.bodyWidth : null
-            const bodyWidthPx
-              = bodyWidth === null ? undefined : `${bodyWidth}px`
+      const rowIndexToKey: Record<number, RowKey> = {}
+      paginatedData.forEach(({ tmNode }, rowIndex) => {
+        rowIndexToKey[rowIndex] = tmNode.key
+      })
 
-            const CellComponent = (this.virtualScrollX ? 'div' : 'td') as 'td'
-            let leftFixedColsCount = 0
-            let rightFixedColsCount = 0
-            if (virtualScrollX) {
-              cols.forEach((col) => {
-                if (col.column.fixed === 'left') {
-                  leftFixedColsCount++
-                }
-                else if (col.column.fixed === 'right') {
-                  rightFixedColsCount++
-                }
-              })
-            }
+      const bodyWidth = stickyExpandedRows ? this.bodyWidth : null
+      const bodyWidthPx = bodyWidth === null ? undefined : `${bodyWidth}px`
 
-            const renderRow = ({
-              // Normal
-              rowInfo,
-              displayedRowIndex,
-              isVirtual,
-              // Virtual X
-              isVirtualX,
-              startColIndex,
-              endColIndex,
-              getLeft
-            }: {
-              rowInfo: RowRenderInfo
-              displayedRowIndex: number
-              isVirtual: boolean
-              // for horizontal virtual list
-              isVirtualX: boolean
-              startColIndex: number
-              endColIndex: number
-              getLeft: (index: number) => number
-            }): VNode => {
-              const { index: actualRowIndex } = rowInfo
-              if ('isExpandedRow' in rowInfo) {
-                const {
-                  tmNode: { key, rawNode }
-                } = rowInfo
-                return (
-                  <tr
-                    class={`${mergedClsPrefix}-data-table-tr ${mergedClsPrefix}-data-table-tr--expanded`}
-                    key={`${key}__expand`}
+      const CellComponent = (this.virtualScrollX ? 'div' : 'td') as 'td'
+      let leftFixedColsCount = 0
+      let rightFixedColsCount = 0
+      if (virtualScrollX) {
+        cols.forEach((col) => {
+          if (col.column.fixed === 'left') {
+            leftFixedColsCount++
+          }
+          else if (col.column.fixed === 'right') {
+            rightFixedColsCount++
+          }
+        })
+      }
+
+      const renderRow = ({
+        // Normal
+        rowInfo,
+        displayedRowIndex,
+        isVirtual,
+        // Virtual X
+        isVirtualX,
+        startColIndex,
+        endColIndex,
+        rowCount,
+        getLeft
+      }: {
+        rowInfo: RowRenderInfo
+        displayedRowIndex: number
+        isVirtual: boolean
+        // for horizontal virtual list
+        isVirtualX: boolean
+        startColIndex: number
+        endColIndex: number
+        rowCount: number
+        getLeft: (index: number) => number
+      }): VNode => {
+        const { index: actualRowIndex } = rowInfo
+        if ('isExpandedRow' in rowInfo) {
+          const {
+            tmNode: { key, rawNode }
+          } = rowInfo
+          return (
+            <tr
+              class={`${mergedClsPrefix}-data-table-tr ${mergedClsPrefix}-data-table-tr--expanded`}
+              key={`${key}__expand`}
+            >
+              <td
+                class={[
+                  `${mergedClsPrefix}-data-table-td`,
+                  `${mergedClsPrefix}-data-table-td--last-col`,
+                  displayedRowIndex + 1 === rowCount
+                  && `${mergedClsPrefix}-data-table-td--last-row`
+                ]}
+                colspan={colCount}
+              >
+                {stickyExpandedRows ? (
+                  <div
+                    class={`${mergedClsPrefix}-data-table-expand`}
+                    style={{
+                      width: bodyWidthPx
+                    }}
                   >
-                    <td
-                      class={[
-                        `${mergedClsPrefix}-data-table-td`,
-                        `${mergedClsPrefix}-data-table-td--last-col`,
-                        displayedRowIndex + 1 === rowCount
-                        && `${mergedClsPrefix}-data-table-td--last-row`
-                      ]}
-                      colspan={colCount}
-                    >
-                      {stickyExpandedRows ? (
-                        <div
-                          class={`${mergedClsPrefix}-data-table-expand`}
-                          style={{
-                            width: bodyWidthPx
-                          }}
-                        >
-                          {renderExpand!(rawNode, actualRowIndex)}
-                        </div>
-                      ) : (
-                        renderExpand!(rawNode, actualRowIndex)
-                      )}
-                    </td>
-                  </tr>
-                )
+                    {renderExpand!(rawNode, actualRowIndex)}
+                  </div>
+                ) : (
+                  renderExpand!(rawNode, actualRowIndex)
+                )}
+              </td>
+            </tr>
+          )
+        }
+        const isSummary = 'isSummaryRow' in rowInfo
+        const striped = !isSummary && rowInfo.striped
+        const { tmNode, key: rowKey } = rowInfo
+        const { rawNode: rowData } = tmNode
+        const expanded = mergedExpandedRowKeySet.has(rowKey)
+        const props = rowProps ? rowProps(rowData, actualRowIndex) : undefined
+        const mergedRowClassName
+          = typeof rowClassName === 'string'
+            ? rowClassName
+            : createRowClassName(rowData, actualRowIndex, rowClassName)
+        const iteratedCols = isVirtualX
+          ? cols.filter((col, index) => {
+              if (startColIndex <= index && index <= endColIndex)
+                return true
+              if (col.column.fixed) {
+                return true
               }
-              const isSummary = 'isSummaryRow' in rowInfo
-              const striped = !isSummary && rowInfo.striped
-              const { tmNode, key: rowKey } = rowInfo
-              const { rawNode: rowData } = tmNode
-              const expanded = mergedExpandedRowKeySet.has(rowKey)
-              const props = rowProps
-                ? rowProps(rowData, actualRowIndex)
-                : undefined
-              const mergedRowClassName
-                = typeof rowClassName === 'string'
-                  ? rowClassName
-                  : createRowClassName(rowData, actualRowIndex, rowClassName)
-              const iteratedCols = isVirtualX
-                ? cols.filter((col, index) => {
-                    if (startColIndex <= index && index <= endColIndex)
-                      return true
-                    if (col.column.fixed) {
-                      return true
+              return false
+            })
+          : cols
+        const virtualXRowHeight = isVirtualX
+          ? pxfy(heightForRow?.(rowData, actualRowIndex) || minRowHeight)
+          : undefined
+        const cells = iteratedCols.map((col) => {
+          const colIndex = col.index
+          if (displayedRowIndex in cordToPass) {
+            const cordOfRowToPass = cordToPass[displayedRowIndex]
+            const indexInCordOfRowToPass = cordOfRowToPass.indexOf(colIndex)
+            if (~indexInCordOfRowToPass) {
+              cordOfRowToPass.splice(indexInCordOfRowToPass, 1)
+              return null
+            }
+          }
+          // TODO: Simplify row calculation
+          const { column } = col
+          const colKey = getColKey(col)
+          const { rowSpan, colSpan } = column
+          const mergedColSpan = isSummary
+            ? rowInfo.tmNode.rawNode[colKey]?.colSpan || 1 // optional for #1276
+            : colSpan
+              ? colSpan(rowData, actualRowIndex)
+              : 1
+          const mergedRowSpan = isSummary
+            ? rowInfo.tmNode.rawNode[colKey]?.rowSpan || 1 // optional for #1276
+            : rowSpan
+              ? rowSpan(rowData, actualRowIndex)
+              : 1
+          const isLastCol = colIndex + mergedColSpan === colCount
+          const isLastRow = displayedRowIndex + mergedRowSpan === rowCount
+          const isCrossRowTd = mergedRowSpan > 1
+          if (isCrossRowTd) {
+            cordKey[displayedRowIndex] = {
+              [colIndex]: []
+            }
+          }
+          if (mergedColSpan > 1 || isCrossRowTd) {
+            for (
+              let i = displayedRowIndex;
+              i < displayedRowIndex + mergedRowSpan;
+              ++i
+            ) {
+              if (isCrossRowTd) {
+                cordKey[displayedRowIndex][colIndex].push(rowIndexToKey[i])
+              }
+              for (let j = colIndex; j < colIndex + mergedColSpan; ++j) {
+                if (i === displayedRowIndex && j === colIndex) {
+                  continue
+                }
+                if (!(i in cordToPass)) {
+                  cordToPass[i] = [j]
+                }
+                else {
+                  cordToPass[i].push(j)
+                }
+              }
+            }
+          }
+          const hoverKey = isCrossRowTd ? this.hoverKey : null
+          const { cellProps } = column
+          const resolvedCellProps = cellProps?.(rowData, actualRowIndex)
+          const indentOffsetStyle = {
+            '--indent-offset': '' as string | number
+          }
+          const FinalCellComponent = column.fixed ? 'td' : CellComponent
+          return (
+            <FinalCellComponent
+              {...resolvedCellProps}
+              key={colKey}
+              style={[
+                {
+                  textAlign: column.align || undefined,
+                  width: pxfy(column.width)
+                },
+                isVirtualX && {
+                  height: virtualXRowHeight
+                },
+                isVirtualX && !column.fixed
+                  ? {
+                      position: 'absolute',
+                      left: pxfy(getLeft(colIndex)),
+                      top: 0,
+                      bottom: 0
                     }
-                    return false
-                  })
-                : cols
-              const virtualXRowHeight = isVirtualX
-                ? pxfy(heightForRow?.(rowData, actualRowIndex) || minRowHeight)
-                : undefined
-              const cells = iteratedCols.map((col) => {
-                const colIndex = col.index
-                if (displayedRowIndex in cordToPass) {
-                  const cordOfRowToPass = cordToPass[displayedRowIndex]
-                  const indexInCordOfRowToPass
-                    = cordOfRowToPass.indexOf(colIndex)
-                  if (~indexInCordOfRowToPass) {
-                    cordOfRowToPass.splice(indexInCordOfRowToPass, 1)
-                    return null
-                  }
-                }
-                // TODO: Simplify row calculation
-                const { column } = col
-                const colKey = getColKey(col)
-                const { rowSpan, colSpan } = column
-                const mergedColSpan = isSummary
-                  ? rowInfo.tmNode.rawNode[colKey]?.colSpan || 1 // optional for #1276
-                  : colSpan
-                    ? colSpan(rowData, actualRowIndex)
-                    : 1
-                const mergedRowSpan = isSummary
-                  ? rowInfo.tmNode.rawNode[colKey]?.rowSpan || 1 // optional for #1276
-                  : rowSpan
-                    ? rowSpan(rowData, actualRowIndex)
-                    : 1
-                const isLastCol = colIndex + mergedColSpan === colCount
-                const isLastRow = displayedRowIndex + mergedRowSpan === rowCount
-                const isCrossRowTd = mergedRowSpan > 1
-                if (isCrossRowTd) {
-                  cordKey[displayedRowIndex] = {
-                    [colIndex]: []
-                  }
-                }
-                if (mergedColSpan > 1 || isCrossRowTd) {
-                  for (
-                    let i = displayedRowIndex;
-                    i < displayedRowIndex + mergedRowSpan;
-                    ++i
-                  ) {
-                    if (isCrossRowTd) {
-                      cordKey[displayedRowIndex][colIndex].push(
-                        rowIndexToKey[i]
-                      )
-                    }
-                    for (let j = colIndex; j < colIndex + mergedColSpan; ++j) {
-                      if (i === displayedRowIndex && j === colIndex) {
-                        continue
-                      }
-                      if (!(i in cordToPass)) {
-                        cordToPass[i] = [j]
-                      }
-                      else {
-                        cordToPass[i].push(j)
-                      }
-                    }
-                  }
-                }
-                const hoverKey = isCrossRowTd ? this.hoverKey : null
-                const { cellProps } = column
-                const resolvedCellProps = cellProps?.(rowData, actualRowIndex)
-                const indentOffsetStyle = {
-                  '--indent-offset': '' as string | number
-                }
-                const FinalCellComponent = column.fixed ? 'td' : CellComponent
-                return (
-                  <FinalCellComponent
-                    {...resolvedCellProps}
-                    key={colKey}
-                    style={[
-                      {
-                        textAlign: column.align || undefined,
-                        width: pxfy(column.width)
-                      },
-                      isVirtualX && {
-                        height: virtualXRowHeight
-                      },
-                      isVirtualX && !column.fixed
-                        ? {
-                            position: 'absolute',
-                            left: pxfy(getLeft(colIndex)),
-                            top: 0,
-                            bottom: 0
-                          }
-                        : {
-                            left: pxfy(fixedColumnLeftMap[colKey]?.start),
-                            right: pxfy(fixedColumnRightMap[colKey]?.start)
-                          },
-                      indentOffsetStyle as CSSProperties,
-                      resolvedCellProps?.style || ''
-                    ]}
-                    colspan={mergedColSpan}
-                    rowspan={isVirtual ? undefined : mergedRowSpan}
-                    data-col-key={colKey}
-                    class={[
-                      `${mergedClsPrefix}-data-table-td`,
-                      column.className,
-                      resolvedCellProps?.class,
-                      isSummary && `${mergedClsPrefix}-data-table-td--summary`,
-                      hoverKey !== null
-                      && cordKey[displayedRowIndex][colIndex].includes(
-                        hoverKey
-                      )
-                      && `${mergedClsPrefix}-data-table-td--hover`,
-                      isColumnSorting(column, mergedSortState)
-                      && `${mergedClsPrefix}-data-table-td--sorting`,
-                      column.fixed
-                      && `${mergedClsPrefix}-data-table-td--fixed-${column.fixed}`,
-                      column.align
-                      && `${mergedClsPrefix}-data-table-td--${column.align}-align`,
-                      column.type === 'selection'
-                      && `${mergedClsPrefix}-data-table-td--selection`,
-                      column.type === 'expand'
-                      && `${mergedClsPrefix}-data-table-td--expand`,
-                      isLastCol && `${mergedClsPrefix}-data-table-td--last-col`,
-                      isLastRow && `${mergedClsPrefix}-data-table-td--last-row`
-                    ]}
-                  >
-                    {hasChildren && colIndex === childTriggerColIndex
-                      ? [
-                          repeat(
-                            (indentOffsetStyle['--indent-offset'] = isSummary
-                              ? 0
-                              : rowInfo.tmNode.level),
-                            <div
-                              class={`${mergedClsPrefix}-data-table-indent`}
-                              style={indentStyle}
-                            />
-                          ),
-                          isSummary || rowInfo.tmNode.isLeaf ? (
-                            <div
-                              class={`${mergedClsPrefix}-data-table-expand-placeholder`}
-                            />
-                          ) : (
-                            <ExpandTrigger
-                              class={`${mergedClsPrefix}-data-table-expand-trigger`}
-                              clsPrefix={mergedClsPrefix}
-                              expanded={expanded}
-                              rowData={rowData}
-                              renderExpandIcon={this.renderExpandIcon}
-                              loading={loadingKeySet.has(rowInfo.key)}
-                              onClick={() => {
-                                handleUpdateExpanded(rowKey, rowInfo.tmNode)
-                              }}
-                            />
-                          )
-                        ]
-                      : null}
-                    {column.type === 'selection' ? (
-                      !isSummary ? (
-                        column.multiple === false ? (
-                          <RenderSafeRadio
-                            key={currentPage}
-                            rowKey={rowKey}
-                            disabled={rowInfo.tmNode.disabled}
-                            onUpdateChecked={() => {
-                              handleRadioUpdateChecked(rowInfo.tmNode)
-                            }}
-                          />
-                        ) : (
-                          <RenderSafeCheckbox
-                            key={currentPage}
-                            rowKey={rowKey}
-                            disabled={rowInfo.tmNode.disabled}
-                            onUpdateChecked={(checked: boolean, e) => {
-                              handleCheckboxUpdateChecked(
-                                rowInfo.tmNode,
-                                checked,
-                                e.shiftKey
-                              )
-                            }}
-                          />
-                        )
-                      ) : null
-                    ) : column.type === 'expand' ? (
-                      !isSummary ? (
-                        !column.expandable || column.expandable?.(rowData) ? (
-                          <ExpandTrigger
-                            clsPrefix={mergedClsPrefix}
-                            rowData={rowData}
-                            expanded={expanded}
-                            renderExpandIcon={this.renderExpandIcon}
-                            onClick={() => {
-                              handleUpdateExpanded(rowKey, null)
-                            }}
-                          />
-                        ) : null
-                      ) : null
-                    ) : (
-                      <Cell
-                        clsPrefix={mergedClsPrefix}
-                        index={actualRowIndex}
-                        row={rowData}
-                        column={column}
-                        isSummary={isSummary}
-                        mergedTheme={mergedTheme}
-                        renderCell={this.renderCell}
+                  : {
+                      left: pxfy(fixedColumnLeftMap[colKey]?.start),
+                      right: pxfy(fixedColumnRightMap[colKey]?.start)
+                    },
+                indentOffsetStyle as CSSProperties,
+                resolvedCellProps?.style || ''
+              ]}
+              colspan={mergedColSpan}
+              rowspan={isVirtual ? undefined : mergedRowSpan}
+              data-col-key={colKey}
+              class={[
+                `${mergedClsPrefix}-data-table-td`,
+                column.className,
+                resolvedCellProps?.class,
+                isSummary && `${mergedClsPrefix}-data-table-td--summary`,
+                hoverKey !== null
+                && cordKey[displayedRowIndex][colIndex].includes(hoverKey)
+                && `${mergedClsPrefix}-data-table-td--hover`,
+                isColumnSorting(column, mergedSortState)
+                && `${mergedClsPrefix}-data-table-td--sorting`,
+                column.fixed
+                && `${mergedClsPrefix}-data-table-td--fixed-${column.fixed}`,
+                column.align
+                && `${mergedClsPrefix}-data-table-td--${column.align}-align`,
+                column.type === 'selection'
+                && `${mergedClsPrefix}-data-table-td--selection`,
+                column.type === 'expand'
+                && `${mergedClsPrefix}-data-table-td--expand`,
+                isLastCol && `${mergedClsPrefix}-data-table-td--last-col`,
+                isLastRow && `${mergedClsPrefix}-data-table-td--last-row`
+              ]}
+            >
+              {hasChildren && colIndex === childTriggerColIndex
+                ? [
+                    repeat(
+                      (indentOffsetStyle['--indent-offset'] = isSummary
+                        ? 0
+                        : rowInfo.tmNode.level),
+                      <div
+                        class={`${mergedClsPrefix}-data-table-indent`}
+                        style={indentStyle}
                       />
-                    )}
-                  </FinalCellComponent>
-                )
-              })
-
-              if (isVirtualX) {
-                if (leftFixedColsCount && rightFixedColsCount) {
-                  cells.splice(
-                    leftFixedColsCount,
-                    0,
-                    <td
-                      colspan={
-                        cols.length - leftFixedColsCount - rightFixedColsCount
-                      }
-                      style={{
-                        pointerEvents: 'none',
-                        visibility: 'hidden',
-                        height: 0
+                    ),
+                    isSummary || rowInfo.tmNode.isLeaf ? (
+                      <div
+                        class={`${mergedClsPrefix}-data-table-expand-placeholder`}
+                      />
+                    ) : (
+                      <ExpandTrigger
+                        class={`${mergedClsPrefix}-data-table-expand-trigger`}
+                        clsPrefix={mergedClsPrefix}
+                        expanded={expanded}
+                        rowData={rowData}
+                        renderExpandIcon={this.renderExpandIcon}
+                        loading={loadingKeySet.has(rowInfo.key)}
+                        onClick={() => {
+                          handleUpdateExpanded(rowKey, rowInfo.tmNode)
+                        }}
+                      />
+                    )
+                  ]
+                : null}
+              {column.type === 'selection' ? (
+                !isSummary ? (
+                  column.multiple === false ? (
+                    <RenderSafeRadio
+                      key={currentPage}
+                      rowKey={rowKey}
+                      disabled={rowInfo.tmNode.disabled}
+                      onUpdateChecked={() => {
+                        handleRadioUpdateChecked(rowInfo.tmNode)
+                      }}
+                    />
+                  ) : (
+                    <RenderSafeCheckbox
+                      key={currentPage}
+                      rowKey={rowKey}
+                      disabled={rowInfo.tmNode.disabled}
+                      onUpdateChecked={(checked: boolean, e) => {
+                        handleCheckboxUpdateChecked(
+                          rowInfo.tmNode,
+                          checked,
+                          e.shiftKey
+                        )
                       }}
                     />
                   )
+                ) : null
+              ) : column.type === 'expand' ? (
+                !isSummary ? (
+                  !column.expandable || column.expandable?.(rowData) ? (
+                    <ExpandTrigger
+                      clsPrefix={mergedClsPrefix}
+                      rowData={rowData}
+                      expanded={expanded}
+                      renderExpandIcon={this.renderExpandIcon}
+                      onClick={() => {
+                        handleUpdateExpanded(rowKey, null)
+                      }}
+                    />
+                  ) : null
+                ) : null
+              ) : (
+                <Cell
+                  clsPrefix={mergedClsPrefix}
+                  index={actualRowIndex}
+                  row={rowData}
+                  column={column}
+                  isSummary={isSummary}
+                  mergedTheme={mergedTheme}
+                  renderCell={this.renderCell}
+                />
+              )}
+            </FinalCellComponent>
+          )
+        })
+
+        if (isVirtualX) {
+          if (leftFixedColsCount && rightFixedColsCount) {
+            cells.splice(
+              leftFixedColsCount,
+              0,
+              <td
+                colspan={cols.length - leftFixedColsCount - rightFixedColsCount}
+                style={{
+                  pointerEvents: 'none',
+                  visibility: 'hidden',
+                  height: 0
+                }}
+              />
+            )
+          }
+        }
+
+        const row = (
+          <tr
+            {...props}
+            onMouseenter={(e) => {
+              this.hoverKey = rowKey
+              props?.onMouseenter?.(e)
+            }}
+            key={rowKey}
+            class={[
+              `${mergedClsPrefix}-data-table-tr`,
+              isSummary && `${mergedClsPrefix}-data-table-tr--summary`,
+              striped && `${mergedClsPrefix}-data-table-tr--striped`,
+              expanded && `${mergedClsPrefix}-data-table-tr--expanded`,
+              mergedRowClassName,
+              props?.class
+            ]}
+            style={[props?.style, isVirtualX && { height: virtualXRowHeight }]}
+          >
+            {cells}
+          </tr>
+        )
+        return row
+      }
+
+      const createSummaryNode = () => {
+        if (summaryRowData.length === 0) {
+          return null
+        }
+        const summaryRowCount
+          = this.summaryPlacement === 'top' ? -1 : summaryRowData.length
+        const summaryStyle = {
+          maxHeight: formatLength(summaryMaxHeight)
+        }
+
+        const summaryTableNode = (
+          <table
+            class={`${mergedClsPrefix}-data-table-table`}
+            onMouseleave={handleMouseleaveTable}
+            style={[
+              !summaryScrollable ? { minWidth: formatLength(scrollX) } : {},
+              { tableLayout: this.mergedTableLayout }
+            ]}
+          >
+            <colgroup>
+              {cols.map(col => (
+                <col key={col.key} style={col.style}></col>
+              ))}
+            </colgroup>
+            <tbody
+              data-n-id={componentId}
+              class={`${mergedClsPrefix}-data-table-tbody`}
+            >
+              {summaryRowData.map((rowInfo, displayedRowIndex) => {
+                return renderRow({
+                  rowInfo,
+                  displayedRowIndex,
+                  isVirtual: false,
+                  isVirtualX: false,
+                  startColIndex: -1,
+                  endColIndex: -1,
+                  rowCount: summaryRowCount,
+                  getLeft(_index) {
+                    return -1
+                  }
+                })
+              })}
+            </tbody>
+          </table>
+        )
+
+        if (!summaryScrollable && !virtualScroll) {
+          return (
+            <div
+              ref="summaryScrollElRef"
+              class={`${mergedClsPrefix}-data-table-base-table-summary`}
+              onScroll={handleSummaryScroll}
+            >
+              {summaryTableNode}
+            </div>
+          )
+        }
+
+        return (
+          <NScrollbar
+            {...this.scrollbarProps}
+            ref="summaryScrollbarInstRef"
+            scrollable={summaryScrollable}
+            class={`${mergedClsPrefix}-data-table-base-table-summary`}
+            style={summaryStyle}
+            theme={mergedTheme.peers.Scrollbar}
+            themeOverrides={mergedTheme.peerOverrides.Scrollbar}
+            contentStyle={contentStyle}
+            container={
+              virtualScroll ? this.summaryVirtualListContainer : undefined
+            }
+            content={virtualScroll ? this.summaryVirtualListContent : undefined}
+            horizontalRailStyle={{ zIndex: 3 }}
+            verticalRailStyle={{ zIndex: 3 }}
+            xScrollable={false}
+            onScroll={virtualScroll ? undefined : handleSummaryScroll}
+          >
+            {{
+              default: () => {
+                if (!virtualScroll) {
+                  return summaryTableNode
                 }
-              }
-
-              const row = (
-                <tr
-                  {...props}
-                  onMouseenter={(e) => {
-                    this.hoverKey = rowKey
-                    props?.onMouseenter?.(e)
-                  }}
-                  key={rowKey}
-                  class={[
-                    `${mergedClsPrefix}-data-table-tr`,
-                    isSummary && `${mergedClsPrefix}-data-table-tr--summary`,
-                    striped && `${mergedClsPrefix}-data-table-tr--striped`,
-                    expanded && `${mergedClsPrefix}-data-table-tr--expanded`,
-                    mergedRowClassName,
-                    props?.class
-                  ]}
-                  style={[
-                    props?.style,
-                    isVirtualX && { height: virtualXRowHeight }
-                  ]}
-                >
-                  {cells}
-                </tr>
-              )
-              return row
-            }
-
-            if (!virtualScroll) {
-              return (
-                <table
-                  class={`${mergedClsPrefix}-data-table-table`}
-                  onMouseleave={handleMouseleaveTable}
-                  style={{
-                    tableLayout: this.mergedTableLayout
-                  }}
-                >
-                  <colgroup>
-                    {cols.map(col => (
-                      <col key={col.key} style={col.style}></col>
-                    ))}
-                  </colgroup>
-                  {this.showHeader ? <TableHeader discrete={false} /> : null}
-                  {!this.empty ? (
-                    <tbody
-                      data-n-id={componentId}
-                      class={`${mergedClsPrefix}-data-table-tbody`}
+                else {
+                  return (
+                    <VirtualList
+                      ref="summaryVirtualListRef"
+                      items={summaryRowData}
+                      itemSize={this.minRowHeight}
+                      visibleItemsTag={VirtualListItemWrapper}
+                      visibleItemsProps={{
+                        clsPrefix: mergedClsPrefix,
+                        id: componentId,
+                        cols,
+                        onMouseleave: handleMouseleaveTable
+                      }}
+                      showScrollbar={false}
+                      onResize={this.handleSummaryVirtualListResize}
+                      onScroll={this.handleSummaryScroll}
+                      itemsStyle={contentStyle}
+                      itemResizable={!virtualScrollX}
+                      columns={cols}
+                      renderItemWithCols={
+                        virtualScrollX
+                          ? ({
+                              itemIndex,
+                              item,
+                              startColIndex,
+                              endColIndex,
+                              getLeft
+                            }) => {
+                              return renderRow({
+                                displayedRowIndex: itemIndex,
+                                isVirtual: true,
+                                isVirtualX: true,
+                                rowInfo: item as RowRenderInfo,
+                                startColIndex,
+                                endColIndex,
+                                rowCount: summaryRowCount,
+                                getLeft
+                              })
+                            }
+                          : undefined
+                      }
                     >
-                      {displayedData.map((rowInfo, displayedRowIndex) => {
-                        return renderRow({
-                          rowInfo,
-                          displayedRowIndex,
-                          isVirtual: false,
-                          isVirtualX: false,
-                          startColIndex: -1,
-                          endColIndex: -1,
-                          getLeft(_index) {
-                            return -1
-                          }
-                        })
-                      })}
-                    </tbody>
-                  ) : null}
-                </table>
-              )
-            }
-            else {
-              return (
-                <VirtualList
-                  ref="virtualListRef"
-                  items={displayedData}
-                  itemSize={this.minRowHeight}
-                  visibleItemsTag={VirtualListItemWrapper}
-                  visibleItemsProps={{
-                    clsPrefix: mergedClsPrefix,
-                    id: componentId,
-                    cols,
-                    onMouseleave: handleMouseleaveTable
-                  }}
-                  showScrollbar={false}
-                  onResize={this.handleVirtualListResize}
-                  onScroll={this.handleVirtualListScroll}
-                  itemsStyle={contentStyle}
-                  itemResizable={!virtualScrollX}
-                  columns={cols}
-                  renderItemWithCols={
-                    virtualScrollX
-                      ? ({
-                          itemIndex,
+                      {{
+                        default: ({
                           item,
-                          startColIndex,
-                          endColIndex,
-                          getLeft
+                          index,
+                          renderedItemWithCols
+                        }: {
+                          item: RowRenderInfo
+                          index: number
+                          renderedItemWithCols: VNodeChild
                         }) => {
+                          if (renderedItemWithCols)
+                            return renderedItemWithCols
                           return renderRow({
-                            displayedRowIndex: itemIndex,
+                            rowInfo: item,
+                            displayedRowIndex: index,
                             isVirtual: true,
-                            isVirtualX: true,
-                            rowInfo: item as RowRenderInfo,
-                            startColIndex,
-                            endColIndex,
-                            getLeft
+                            isVirtualX: false,
+                            startColIndex: 0,
+                            endColIndex: 0,
+                            rowCount: summaryRowCount,
+                            getLeft(_index) {
+                              return 0
+                            }
                           })
                         }
-                      : undefined
-                  }
-                >
-                  {{
-                    default: ({
-                      item,
-                      index,
-                      renderedItemWithCols
-                    }: {
-                      item: RowRenderInfo
-                      index: number
-                      renderedItemWithCols: VNodeChild
-                    }) => {
-                      if (renderedItemWithCols)
-                        return renderedItemWithCols
-                      return renderRow({
-                        rowInfo: item,
-                        displayedRowIndex: index,
-                        isVirtual: true,
-                        isVirtualX: false,
-                        startColIndex: 0,
-                        endColIndex: 0,
-                        getLeft(_index) {
-                          return 0
+                      }}
+                    </VirtualList>
+                  )
+                }
+              }
+            }}
+          </NScrollbar>
+        )
+      }
+
+      return (
+        <>
+          {stickySummary && !this.showHeader && this.summaryPlacement === 'top'
+            ? createSummaryNode()
+            : null}
+          <NScrollbar
+            {...this.scrollbarProps}
+            ref="scrollbarInstRef"
+            scrollable={scrollable || isBasicAutoLayout}
+            class={`${mergedClsPrefix}-data-table-base-table-body`}
+            style={!this.empty ? this.bodyStyle : undefined}
+            theme={mergedTheme.peers.Scrollbar}
+            themeOverrides={mergedTheme.peerOverrides.Scrollbar}
+            contentStyle={contentStyle}
+            container={virtualScroll ? this.virtualListContainer : undefined}
+            content={virtualScroll ? this.virtualListContent : undefined}
+            horizontalRailStyle={{ zIndex: 3 }}
+            verticalRailStyle={{ zIndex: 3 }}
+            xScrollable={xScrollable}
+            onScroll={virtualScroll ? undefined : this.handleTableBodyScroll}
+            internalOnUpdateScrollLeft={setHeaderScrollLeft}
+            onResize={onResize}
+          >
+            {{
+              default: () => {
+                if (!virtualScroll) {
+                  return (
+                    <table
+                      class={`${mergedClsPrefix}-data-table-table`}
+                      onMouseleave={handleMouseleaveTable}
+                      style={{
+                        tableLayout: this.mergedTableLayout
+                      }}
+                    >
+                      <colgroup>
+                        {cols.map(col => (
+                          <col key={col.key} style={col.style}></col>
+                        ))}
+                      </colgroup>
+                      {this.showHeader ? (
+                        <TableHeader discrete={false} />
+                      ) : null}
+                      {!this.empty ? (
+                        <tbody
+                          data-n-id={componentId}
+                          class={`${mergedClsPrefix}-data-table-tbody`}
+                        >
+                          {displayedData.map((rowInfo, displayedRowIndex) => {
+                            return renderRow({
+                              rowInfo,
+                              displayedRowIndex,
+                              isVirtual: false,
+                              isVirtualX: false,
+                              startColIndex: -1,
+                              endColIndex: -1,
+                              rowCount,
+                              getLeft(_index) {
+                                return -1
+                              }
+                            })
+                          })}
+                        </tbody>
+                      ) : null}
+                    </table>
+                  )
+                }
+                else {
+                  return (
+                    <VirtualList
+                      ref="virtualListRef"
+                      items={displayedData}
+                      itemSize={this.minRowHeight}
+                      visibleItemsTag={VirtualListItemWrapper}
+                      visibleItemsProps={{
+                        clsPrefix: mergedClsPrefix,
+                        id: componentId,
+                        cols,
+                        onMouseleave: handleMouseleaveTable
+                      }}
+                      showScrollbar={false}
+                      onResize={this.handleVirtualListResize}
+                      onScroll={this.handleVirtualListScroll}
+                      itemsStyle={contentStyle}
+                      itemResizable={!virtualScrollX}
+                      columns={cols}
+                      renderItemWithCols={
+                        virtualScrollX
+                          ? ({
+                              itemIndex,
+                              item,
+                              startColIndex,
+                              endColIndex,
+                              getLeft
+                            }) => {
+                              return renderRow({
+                                displayedRowIndex: itemIndex,
+                                isVirtual: true,
+                                isVirtualX: true,
+                                rowInfo: item as RowRenderInfo,
+                                startColIndex,
+                                endColIndex,
+                                rowCount,
+                                getLeft
+                              })
+                            }
+                          : undefined
+                      }
+                    >
+                      {{
+                        default: ({
+                          item,
+                          index,
+                          renderedItemWithCols
+                        }: {
+                          item: RowRenderInfo
+                          index: number
+                          renderedItemWithCols: VNodeChild
+                        }) => {
+                          if (renderedItemWithCols)
+                            return renderedItemWithCols
+                          return renderRow({
+                            rowInfo: item,
+                            displayedRowIndex: index,
+                            isVirtual: true,
+                            isVirtualX: false,
+                            startColIndex: 0,
+                            endColIndex: 0,
+                            rowCount,
+                            getLeft(_index) {
+                              return 0
+                            }
+                          })
                         }
-                      })
-                    }
-                  }}
-                </VirtualList>
-              )
-            }
-          }
-        }}
-      </NScrollbar>
-    )
+                      }}
+                    </VirtualList>
+                  )
+                }
+              }
+            }}
+          </NScrollbar>
+          {stickySummary && !this.showHeader && this.summaryPlacement !== 'top'
+            ? createSummaryNode()
+            : null}
+        </>
+      )
+    }
 
     if (this.empty) {
       const createEmptyNode = (): VNode => (
@@ -1166,7 +1398,7 @@ export default defineComponent({
       if (this.shouldDisplaySomeTablePart) {
         return (
           <>
-            {tableNode}
+            {createTableNode()}
             {createEmptyNode()}
           </>
         )
@@ -1179,6 +1411,6 @@ export default defineComponent({
         )
       }
     }
-    return tableNode
+    return createTableNode()
   }
 })

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -43,6 +43,8 @@ export const dataTableProps = {
   },
   minHeight: [Number, String] as PropType<string | number>,
   maxHeight: [Number, String] as PropType<string | number>,
+  summaryMaxHeight: [Number, String] as PropType<string | number>,
+  stickySummary: Boolean,
   // Use any type as row data to make prop data acceptable
   columns: {
     type: Array as PropType<TableColumns<any>>,
@@ -413,6 +415,8 @@ export interface DataTableInjection {
   mergedTableLayoutRef: Ref<'auto' | 'fixed'>
   maxHeightRef: Ref<string | number | undefined>
   minHeightRef: Ref<string | number | undefined>
+  summaryMaxHeightRef: Ref<string | number | undefined>
+  stickySummaryRef: Ref<boolean>
   rowPropsRef: Ref<CreateRowProps | undefined>
   flexHeightRef: Ref<boolean>
   headerCheckboxDisabledRef: Ref<boolean>

--- a/src/data-table/src/styles/index.cssr.ts
+++ b/src/data-table/src/styles/index.cssr.ts
@@ -87,7 +87,10 @@ export default c([
               flex-grow: 1;
             `, [
               c('>', [
-                cB('data-table-base-table-body', 'flex-basis: 0;', [
+                cB('data-table-base-table-body', `
+                  flex-basis: 0;
+                  flex-grow: 1;
+                `, [
                   // last-child means there is no empty icon
                   // body is a scrollbar, we need to override height 100%
                   c('&:last-child', 'flex-grow: 1;')
@@ -508,6 +511,19 @@ export default c([
     cB('data-table-base-table-header', `
       border-top-left-radius: calc(var(--n-border-radius) - 1px);
       border-top-right-radius: calc(var(--n-border-radius) - 1px);
+      z-index: 3;
+      overflow: scroll;
+      flex-shrink: 0;
+      transition: border-color .3s var(--n-bezier);
+      scrollbar-width: none;
+    `, [
+      c('&::-webkit-scrollbar, &::-webkit-scrollbar-track-piece, &::-webkit-scrollbar-thumb', `
+        display: none;
+        width: 0;
+        height: 0;
+      `)
+    ]),
+    cB('data-table-base-table-summary', `
       z-index: 3;
       overflow: scroll;
       flex-shrink: 0;


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
n-data-table 新增 `sticky-summary` 和 `summary-max-height` 属性，closes #6585，closes #6432，closes #6170，closes #2814