### PR TITLE
fix(dev-script): added npm run dev:win for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "start": "pnpm run dev",
     "dev": "pnpm run clean && pnpm run gen-version && pnpm run gen-volar-dts && NODE_ENV=development vite",
+    "dev:win": "pnpm run clean && pnpm run gen-version && pnpm run gen-volar-dts && set NODE_ENV=development&& vite",
     "build:package": "pnpm run gen-version && pnpm run clean && pnpm run gen-volar-dts && tsc -b --force tsconfig.esm.json && node scripts/pre-build/pre-cjs-build.js && tsc -b --force tsconfig.cjs.json && rollup -c && pnpm run test:umd && pnpm run test:esm && node scripts/post-build && rimraf {es,lib}/*.tsbuildinfo",
     "build:site": "bash ./scripts/pre-build-site/pre-build-site.sh && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 vite build && bash ./scripts/post-build-site/post-build-site.sh",
     "clean": "rimraf site lib es dist node_modules/naive-ui themes/tusimple/es themes/tusimple/lib",

--- a/volar.d.ts
+++ b/volar.d.ts
@@ -68,6 +68,7 @@ declare module 'vue' {
     NH4: (typeof import('naive-ui'))['NH4']
     NH5: (typeof import('naive-ui'))['NH5']
     NH6: (typeof import('naive-ui'))['NH6']
+    NHighlight: (typeof import('naive-ui'))['NHighlight']
     NHr: (typeof import('naive-ui'))['NHr']
     NIcon: (typeof import('naive-ui'))['NIcon']
     NIconWrapper: (typeof import('naive-ui'))['NIconWrapper']
@@ -89,6 +90,7 @@ declare module 'vue' {
     NListItem: (typeof import('naive-ui'))['NListItem']
     NLoadingBarProvider: (typeof import('naive-ui'))['NLoadingBarProvider']
     NLog: (typeof import('naive-ui'))['NLog']
+    NMarquee: (typeof import('naive-ui'))['NMarquee']
     NMention: (typeof import('naive-ui'))['NMention']
     NMenu: (typeof import('naive-ui'))['NMenu']
     NMessageProvider: (typeof import('naive-ui'))['NMessageProvider']
@@ -150,8 +152,6 @@ declare module 'vue' {
     NUploadTrigger: (typeof import('naive-ui'))['NUploadTrigger']
     NVirtualList: (typeof import('naive-ui'))['NVirtualList']
     NWatermark: (typeof import('naive-ui'))['NWatermark']
-    NHighlight: (typeof import('naive-ui'))['NHighlight']
-    NMarquee: (typeof import('naive-ui'))['NMarquee']
   }
 }
 export {}


### PR DESCRIPTION
This PR adds a new script `dev:win` specifically for Windows systems to address the issue where the `NODE_ENV=development` command does not work on non-Unix systems. The fix ensures the development environment variable is set correctly in Windows PowerShell.

### Changes:
- **Added** `dev:win` script to handle setting `NODE_ENV` on Windows.
- **Tested** the fix to work in Microsoft Windows PowerShell.

### Original Script:
```json
"dev": "pnpm run clean && pnpm run gen-version && pnpm run gen-volar-dts && NODE_ENV=development vite",
```

### Updated Scripts:
**For Unix-like systems:**
```json
"dev": "pnpm run clean && pnpm run gen-version && pnpm run gen-volar-dts && NODE_ENV=development vite",
```

**For Windows systems:**
```json
"dev:win": "pnpm run clean && pnpm run gen-version && pnpm run gen-volar-dts && set NODE_ENV=development&& vite",
```

### Changelog:
- Added `dev:win` script to handle Windows-specific environment variable setting.

### Testing:
- The fix has been tested and confirmed to work in Microsoft Windows PowerShell.