### PR TITLE
`n-modal` 新增 `max-height` 属性

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.41.1
+
+### Features
+
+- `n-modal` add `max-height` props.
+
 ## 2.41.0
 
 `2025-01-05`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.41.1
+
+### Features
+
+- `n-modal` 新增 `max-height` 属性
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/dialog/src/styles/index.cssr.ts
+++ b/src/dialog/src/styles/index.cssr.ts
@@ -37,6 +37,8 @@ export default c([
     color: var(--n-text-color);
     box-sizing: border-box;
     margin: auto;
+    display: flex;
+    flex-direction: column;
     border-radius: var(--n-border-radius);
     padding: var(--n-padding);
     transition: 

--- a/src/modal/demos/enUS/index.demo-entry.md
+++ b/src/modal/demos/enUS/index.demo-entry.md
@@ -67,6 +67,7 @@ Provided since `2.38.0`.
 | transform-origin | `'mouse' \| 'center'` | `'mouse'` | The transform origin of the modal's display animation. |  |
 | trap-focus | `boolean` | `true` | Whether to trap focus inside modal. | 2.24.2 |
 | z-index | `number` | `undefined` | Z index of the modal. | 2.24.0 |
+| max-height | `number \| string` | `undefined` | Maximum height of a modal window |  |
 | on-after-enter | `() => void` | `undefined` | Callback after modal is opened. |  |
 | on-after-leave | `() => void` | `undefined` | Callback after modal is closed. |  |
 | on-esc | `() => void` | `undefined` | Callback fired when the escape key is pressed and focus is within modal. | 2.24.2 |

--- a/src/modal/demos/zhCN/dark-1-debug.demo.vue
+++ b/src/modal/demos/zhCN/dark-1-debug.demo.vue
@@ -138,6 +138,7 @@ export default defineComponent({
     v-model:show="showModal"
     title="Dark Modal Debug"
     preset="card"
+    :max-height="300"
     :style="{ marginTop: '24px', marginBottom: '24px', width: '800px' }"
   >
     <n-radio-group

--- a/src/modal/demos/zhCN/dark-2-debug.demo.vue
+++ b/src/modal/demos/zhCN/dark-2-debug.demo.vue
@@ -22,6 +22,7 @@ export default defineComponent({
     v-model:show="modalActive"
     title="Dark Modal Debug"
     preset="card"
+    max-height="20%"
     :style="{ marginTop: '24px', marginBottom: '24px', width: '800px' }"
   >
     <n-table :bordered="false" :single-line="false">

--- a/src/modal/demos/zhCN/draggable.demo.vue
+++ b/src/modal/demos/zhCN/draggable.demo.vue
@@ -70,6 +70,7 @@ export default defineComponent({
     title="card 预设拖拽"
     preset="card"
     draggable
+    max-height="30%"
     :style="{ width: '800px' }"
   >
     <div>无意义的内容...</div>
@@ -88,6 +89,8 @@ export default defineComponent({
     title="dialog 预设拖拽"
     preset="dialog"
     draggable
+    height="30%"
+    max-height="200"
     :style="{ width: '800px' }"
   >
     <div>无意义的内容...</div>
@@ -105,10 +108,11 @@ export default defineComponent({
     v-model:show="showModal3"
     title="无预设拖拽"
     draggable
+    max-height="30%"
     :style="{ width: '800px' }"
   >
     <template #default="{ draggableClass }">
-      <n-card>
+      <n-card content-style="overflow: auto">
         <div :class="draggableClass">
           点我拖拽
         </div>

--- a/src/modal/demos/zhCN/index.demo-entry.md
+++ b/src/modal/demos/zhCN/index.demo-entry.md
@@ -82,6 +82,7 @@ mask-click-debug.vue
 | transform-origin | `'mouse' \| 'center'` | `'mouse'` | 模态框动画出现的位置 |  |
 | trap-focus | `boolean` | `true` | 是否将焦点锁定在 Modal 内部 | 2.24.2 |
 | z-index | `number` | `undefined` | Modal 的 z-index | 2.24.0 |
+| max-height | `number \| string` | `undefined` | modal 窗口的最大高度 |  |
 | on-after-enter | `() => void` | `undefined` | Modal 出现后的回调 |  |
 | on-after-leave | `() => void` | `undefined` | Modal 关闭后的回调 |  |
 | on-esc | `() => void` | `undefined` | 焦点在 Modal 内部时按下 Esc 键的回调 | 2.24.2 |

--- a/src/modal/src/Modal.tsx
+++ b/src/modal/src/Modal.tsx
@@ -27,6 +27,7 @@ import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import {
   call,
   eventEffectNotPerformed,
+  formatLength,
   keep,
   useIsComposing,
   warnOnce
@@ -101,7 +102,8 @@ export const modalProps = {
   overlayStyle: [String, Object] as PropType<string | CSSProperties>,
   onBeforeHide: Function as PropType<() => void>,
   onAfterHide: Function as PropType<() => void>,
-  onHide: Function as PropType<(value: false) => void>
+  onHide: Function as PropType<(value: false) => void>,
+  maxHeight: [Number, String] as PropType<string | number>
 }
 
 export type ModalProps = ExtractPublicPropTypes<typeof modalProps>
@@ -282,6 +284,7 @@ export default defineComponent({
     const themeClassHandle = inlineThemeDisabled
       ? useThemeClass('theme-class', undefined, cssVarsRef, props)
       : undefined
+
     return {
       mergedClsPrefix: mergedClsPrefixRef,
       namespace: namespaceRef,
@@ -306,7 +309,7 @@ export default defineComponent({
     }
   },
   render() {
-    const { mergedClsPrefix } = this
+    const { mergedClsPrefix, maxHeight } = this
     return (
       <VLazyTeleport to={this.to} show={this.show}>
         {{
@@ -335,6 +338,7 @@ export default defineComponent({
                   trapFocus={this.trapFocus}
                   draggable={this.draggable}
                   blockScroll={this.blockScroll}
+                  maxHeight={maxHeight}
                   {...this.presetProps}
                   onEsc={this.handleEsc}
                   onClose={this.handleCloseClick}


### PR DESCRIPTION
不传maxheight，按原来的外部滚动条逻辑
传了maxheight，替换滚动条成div
dialog增加flex布局

close https://github.com/tusen-ai/naive-ui/issues/4848