### PR TITLE
docs(enUS): correct spelling of 'compatible' in demo entry

### DIFF
--- a/src/space/demos/enUS/index.demo-entry.md
+++ b/src/space/demos/enUS/index.demo-entry.md
@@ -2,7 +2,7 @@
 
 A great invention (which is not invented by me).
 
-If you don't have compitable issue for `gap` CSS property, it's suggested to use [Flex](flex).
+If you don't have compatibility issues for `gap` CSS property, it's suggested to use [Flex](flex).
 
 ## Demos
 


### PR DESCRIPTION
Corrected 'compitable' to 'compatibility' and reworded the sentence slightly for better readability in the Space component documentation.

Sorry for the other PR, i hope this one is ok. Thank you for the library, its really good!