### PR TITLE
fix: prevent cursor position change when using `ArrowDown` and `ArrowUp` in `n-auto-complete`

### DIFF
--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -246,9 +246,11 @@ export default defineComponent({
           break
         case 'ArrowDown':
           menuInstRef.value?.next()
+          e.preventDefault()
           break
         case 'ArrowUp':
           menuInstRef.value?.prev()
+          e.preventDefault()
           break
       }
     }


### PR DESCRIPTION
close #6795 