### PR TITLE
fix(menu): 'group' type and children disabled state are not working

### DIFF
--- a/src/menu/src/MenuOptionGroup.tsx
+++ b/src/menu/src/MenuOptionGroup.tsx
@@ -38,16 +38,16 @@ export const NMenuOptionGroup = defineComponent({
   props: menuItemGroupProps,
   setup(props) {
     const MenuChild = useMenuChild(props)
-
-    const mergedDisabled = computed(() => {
-      return (
-        MenuChild.NSubmenu?.mergedDisabledRef.value || props.tmNode.disabled
-      )
+    const { NSubmenu } = MenuChild
+    const mergedDisabledRef = computed(() => {
+      const { disabled } = props.tmNode
+      if (NSubmenu?.mergedDisabledRef.value)
+        return true
+      return disabled
     })
-
     provide(submenuInjectionKey, {
-      mergedDisabledRef: mergedDisabled,
-      paddingLeftRef: MenuChild.paddingLeft
+      paddingLeftRef: MenuChild.paddingLeft,
+      mergedDisabledRef
     })
 
     provide(menuItemGroupInjectionKey, {
@@ -78,9 +78,7 @@ export const NMenuOptionGroup = defineComponent({
             ) : null}
           </div>
           <div>
-            {props.tmNodes.map((tmNode) => {
-              return itemRenderer(tmNode, menuProps)
-            })}
+            {props.tmNodes.map(tmNode => itemRenderer(tmNode, menuProps))}
           </div>
         </div>
       )

--- a/src/menu/src/MenuOptionGroup.tsx
+++ b/src/menu/src/MenuOptionGroup.tsx
@@ -1,5 +1,6 @@
 import type { TmNode } from './interface'
 import {
+  computed,
   defineComponent,
   Fragment,
   h,
@@ -36,8 +37,19 @@ export const NMenuOptionGroup = defineComponent({
   name: 'MenuOptionGroup',
   props: menuItemGroupProps,
   setup(props) {
-    provide(submenuInjectionKey, null)
     const MenuChild = useMenuChild(props)
+
+    const mergedDisabled = computed(() => {
+      return (
+        MenuChild.NSubmenu?.mergedDisabledRef.value || props.tmNode.disabled
+      )
+    })
+
+    provide(submenuInjectionKey, {
+      mergedDisabledRef: mergedDisabled,
+      paddingLeftRef: MenuChild.paddingLeft
+    })
+
     provide(menuItemGroupInjectionKey, {
       paddingLeftRef: MenuChild.paddingLeft
     })
@@ -66,7 +78,9 @@ export const NMenuOptionGroup = defineComponent({
             ) : null}
           </div>
           <div>
-            {props.tmNodes.map(tmNode => itemRenderer(tmNode, menuProps))}
+            {props.tmNodes.map((tmNode) => {
+              return itemRenderer(tmNode, menuProps)
+            })}
           </div>
         </div>
       )


### PR DESCRIPTION
`menu`  修复了父级菜单数据在设置了 `disabled` 属性后，子节点 type: "group" 的 children 的禁用样式不生效，关闭 [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)