### PR TITLE
feat: add indent prop for Tree in TreeSelect

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+- `n-tree-select` adds `indent` prop.
+
 ## 2.41.0
 
 `2025-01-05`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+- `n-tree-select` 新增 `indent` 属性
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/tree-select/src/TreeSelect.tsx
+++ b/src/tree-select/src/TreeSelect.tsx
@@ -1016,6 +1016,7 @@ export default defineComponent({
                                 themeOverrides={mergedTheme.peerOverrides.Tree}
                                 defaultExpandAll={this.defaultExpandAll}
                                 defaultExpandedKeys={this.defaultExpandedKeys}
+                                indent={this.indent}
                                 expandedKeys={this.mergedExpandedKeys}
                                 checkedKeys={this.treeCheckedKeys}
                                 selectedKeys={this.treeSelectedKeys}

--- a/src/tree/src/Tree.tsx
+++ b/src/tree/src/Tree.tsx
@@ -86,9 +86,9 @@ export function createTreeMateOptions<T>(
 ): TreeMateOptions<T, T, T> {
   const settledGetChildren: GetChildren
     = getChildren
-    || ((node: T) => {
-      return (node as any)[childrenField]
-    })
+      || ((node: T) => {
+        return (node as any)[childrenField]
+      })
   return {
     getIsGroup() {
       return false
@@ -195,6 +195,10 @@ export const treeSharedProps = {
     type: Array as PropType<Key[]>,
     default: () => []
   },
+  indent: {
+    type: Number,
+    default: 24
+  },
   indeterminateKeys: Array as PropType<Key[]>,
   renderSwitcherIcon: Function as PropType<RenderSwitcherIcon>,
   onUpdateIndeterminateKeys: [Function, Array] as PropType<
@@ -262,10 +266,6 @@ export const treeProps = {
     default: true
   },
   scrollbarProps: Object as PropType<ScrollbarProps>,
-  indent: {
-    type: Number,
-    default: 24
-  },
   allowDrop: {
     type: Function as PropType<AllowDrop>,
     default: defaultAllowDrop


### PR DESCRIPTION
Add the indent property of the `Tree` component for `TreeSelect` to support tree indentation.
Move the indent prop from `treeProps` to `treeSharedProps`.
为`TreeSelect`添加`Tree`的indent属性以实现树的缩进，indent属性从`treeProps`移动到了`treeSharedProps`