### PR TITLE
fix(data-table): 修复 `n-data-table` 可排序表格背景颜色变量丢失问题

### DIFF
--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-data-table` 可排序表格背景颜色变量丢失问题
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -410,12 +410,12 @@ export default defineComponent({
         '--n-td-color-striped': tdColorStriped,
         '--n-td-color-striped-modal': tdColorStripedModal,
         '--n-td-color-striped-popover': tdColorStripedPopover,
-        'n-td-color-sorting': tdColorSorting,
-        'n-td-color-sorting-modal': tdColorSortingModal,
-        'n-td-color-sorting-popover': tdColorSortingPopover,
-        'n-th-color-sorting': thColorSorting,
-        'n-th-color-sorting-modal': thColorSortingModal,
-        'n-th-color-sorting-popover': thColorSortingPopover
+        '--n-td-color-sorting': tdColorSorting,
+        '--n-td-color-sorting-modal': tdColorSortingModal,
+        '--n-td-color-sorting-popover': tdColorSortingPopover,
+        '--n-th-color-sorting': thColorSorting,
+        '--n-th-color-sorting-modal': thColorSortingModal,
+        '--n-th-color-sorting-popover': thColorSortingPopover
       }
     })
     const themeClassHandle = inlineThemeDisabled

--- a/src/data-table/src/styles/index.cssr.ts
+++ b/src/data-table/src/styles/index.cssr.ts
@@ -66,6 +66,7 @@ export default c([
     --n-merged-th-color: var(--n-th-color);
     --n-merged-td-color: var(--n-td-color);
     --n-merged-border-color: var(--n-border-color);
+    --n-merged-th-color-hover: var(--n-th-color-hover);
     --n-merged-th-color-sorting: var(--n-th-color-sorting);
     --n-merged-td-color-hover: var(--n-td-color-hover);
     --n-merged-td-color-sorting: var(--n-td-color-sorting);


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
close https://github.com/tusen-ai/naive-ui/issues/6521