### PR TITLE
`n-tabs` Fix the type exception of the tab slots in TabPane.

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.41.1
+
+### Fixes
+
+- `n-tabs` Fix the type exception of the tab slots in TabPane.
+
 ## 2.41.0
 
 `2025-01-05`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.41.1
+
+### Fixes
+
+- `n-tabs` 修复了TabPane中tab Slots的类型异常。
+
 ## 2.41.0
 
 `2025-01-05`

--- a/src/tabs/src/TabPane.tsx
+++ b/src/tabs/src/TabPane.tsx
@@ -41,6 +41,7 @@ export type TabPaneProps = ExtractPublicPropTypes<typeof tabPaneProps>
 
 export interface TabPaneSlots {
   default?: () => VNode[]
+  tab?: () => VNode[]
   prefix?: () => VNode[]
   suffix?: () => VNode[]
 }


### PR DESCRIPTION
修复了n-tabs组件中， tabpane 得tab Slotsts异常

![image](https://github.com/user-attachments/assets/1658e7da-5fbf-4461-93c8-f2aeca67171d)
![image](https://github.com/user-attachments/assets/48aad061-a811-415f-b26b-153c3b7d2380)

close #6874