### PR TITLE
新增 `n-cascader-panel` 组件

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -13,7 +13,7 @@
 - `n-upload` adds `uploadDownload` util method.
 - `n-tree-select` adds `indent` prop.
 - Adds `n-input-opt` component. closes [#1385](https://github.com/tusen-ai/naive-ui/issues/1385), [#5681](https://github.com/tusen-ai/naive-ui/issues/5681), [#6222](https://github.com/tusen-ai/naive-ui/issues/6222).
-- Adds `n-cascader-panel` component. closes [#5347](https://github.com/tusen-ai/naive-ui/issues/5347)
+- Adds `n-cascader-panel` component, closes [#5347](https://github.com/tusen-ai/naive-ui/issues/5347)
 
 ## 2.41.0
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -13,7 +13,7 @@
 - `n-upload` adds `uploadDownload` util method.
 - `n-tree-select` adds `indent` prop.
 - Adds `n-input-opt` component. closes [#1385](https://github.com/tusen-ai/naive-ui/issues/1385), [#5681](https://github.com/tusen-ai/naive-ui/issues/5681), [#6222](https://github.com/tusen-ai/naive-ui/issues/6222).
-- Adds `n-cascader-panel` component, closes [#5347](https://github.com/tusen-ai/naive-ui/issues/5347)
+- Adds `n-cascader-panel` component, closes [#5347](https://github.com/tusen-ai/naive-ui/issues/5347).
 
 ## 2.41.0
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -13,6 +13,7 @@
 - `n-upload` adds `uploadDownload` util method.
 - `n-tree-select` adds `indent` prop.
 - Adds `n-input-opt` component. closes [#1385](https://github.com/tusen-ai/naive-ui/issues/1385), [#5681](https://github.com/tusen-ai/naive-ui/issues/5681), [#6222](https://github.com/tusen-ai/naive-ui/issues/6222).
+- Adds `n-cascader-panel` component. closes [#5347](https://github.com/tusen-ai/naive-ui/issues/5347)
 
 ## 2.41.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -13,6 +13,7 @@
 - `n-upload` 新增 `uploadDownload` 工具方法
 - `n-tree-select` 新增 `indent` 属性
 - 新增 `n-input-opt` 组件，关闭 [#1385](https://github.com/tusen-ai/naive-ui/issues/1385)、[#5681](https://github.com/tusen-ai/naive-ui/issues/5681)、[#6222](https://github.com/tusen-ai/naive-ui/issues/6222)
+- 新增 `n-cascader-panel` 组件，关闭 [#5347](https://github.com/tusen-ai/naive-ui/issues/5347)
 
 ## 2.41.0
 

--- a/src/cascader/demos/enUS/cascaderPanel.demo.vue
+++ b/src/cascader/demos/enUS/cascaderPanel.demo.vue
@@ -1,0 +1,80 @@
+<markdown>
+# Cascader panel
+
+CascaderPanel is the core component of Cascader which has various of features such as single selection, multiple selection, dynamic loading and so on.
+
+Just like el-cascader, you can set alternative options by options, and enable other features by props, see the API form below for details.
+</markdown>
+
+<script lang="ts" setup>
+import type { CascaderOption } from 'naive-ui'
+import Flash16Regular from '@vicons/fluent/Flash16Regular'
+import { ref } from 'vue'
+
+function getOptions(depth = 2, iterator = 1, prefix = '') {
+  const length = 12
+  const options: CascaderOption[] = []
+  for (let i = 1; i <= length; ++i) {
+    if (iterator === 1) {
+      options.push({
+        value: `${i}`,
+        label: `${i}`,
+        disabled: i % 5 === 0,
+        children: getOptions(depth, iterator + 1, `${String(i)}`)
+      })
+    }
+    else if (iterator === depth) {
+      options.push({
+        value: `${prefix}-${i}`,
+        label: `${prefix}-${i}`,
+        disabled: i % 5 === 0
+      })
+    }
+    else {
+      options.push({
+        value: `${prefix}-${i}`,
+        label: `${prefix}-${i}`,
+        disabled: i % 5 === 0,
+        children: getOptions(depth, iterator + 1, `${prefix}-${i}`)
+      })
+    }
+  }
+  return options
+}
+
+const value = ref(null)
+
+const value2 = ref(null)
+const options = getOptions()
+</script>
+
+<template>
+  <n-space vertical>
+    <n-cascader-panel
+      v-model:value="value"
+      placeholder="Meaningless values"
+      :options="options"
+    >
+      <template #action>
+        Standing on a bridge that can divide the world
+      </template>
+      <template #arrow>
+        <Flash16Regular />
+      </template>
+    </n-cascader-panel>
+
+    <n-cascader-panel
+      v-model:value="value2"
+      placeholder="Meaningless values"
+      multiple
+      :options="options"
+    >
+      <template #action>
+        Standing on a bridge that can divide the world
+      </template>
+      <template #arrow>
+        <Flash16Regular />
+      </template>
+    </n-cascader-panel>
+  </n-space>
+</template>

--- a/src/cascader/demos/enUS/index.demo-entry.md
+++ b/src/cascader/demos/enUS/index.demo-entry.md
@@ -17,6 +17,7 @@ custom-field.vue
 custom-render.vue
 focus.vue
 status.vue
+cascaderPanel.vue
 ```
 
 ## API
@@ -66,6 +67,45 @@ status.vue
 | on-update:show | `(value: boolean) => void` | `undefined` | Callback executed when menu is opened & closed. |  |
 | on-update:value | `(value: string \| number \| Array<string \| number> \| null, option: CascaderOption \| Array<CascaderOption \| null> \| null, pathValues: Array<CascaderOption \| null> \| Array<CascaderOption[] \| null> \| null) => void` | `undefined` | Callback executed when the value changes. |  |
 
+### CascaderPanel Props
+
+| Name | Type | Default | Description | Version |
+| --- | --- | --- | --- | --- |
+| allow-checking-not-loaded | `boolean` | `false` | Whether to allow cascade checking on not loaded nodes. If you want to use this, you should know the `value` may be incomplete. Also, you should aware about the consistency bewteen naive's checking logic and your backend's checking logic, especially when there are disabled nodes. |  |
+| cascade | `boolean` | `true` | Whether to cascade the checkbox selection onto children. |  |
+| check-strategy | `string` | `'all'` | The way to show checked options. `all` means showing all checked node. `parent` means showing all checked parent node when all child node are checked (not working in single select mode). `child` means showing all child node. |  |
+| children-field | `string` | `'children'` | The children field in `CascaderOption`. |  |
+| clearable | `boolean` | `false` | Whether the cascader is clearable. |  |
+| clear-filter-after-select | `boolean` | `true` | When multiple and filter is true, whether to clear filter keyword after select an option. |  |
+| default-value | `string \| number \| Array<number \| string> \| null` | `null` | Data selected by default if no value is set. |  |
+| disabled | `boolean` | `false` | Whether to disable the cascader. |  |
+| disabled-field | `string` | `'disabled'` | The disabled field in `CascaderOption`. |  |
+| expand-trigger | `'click' \| 'hover'` | `'click'` | If `remote` is set, `'hover'` won't work. |  |
+| filterable | `boolean` | `false` | Note: If `remote` is set, this won't have any effect. |  |
+| filter | `(pattern: string, option: CascaderOption, path: CascaderOption[]) => boolean` | A string based filter algorithm. | Filter function of the cascader. |  |
+| filter-menu-props | `HTMLAttributes` | `undefined` | The filter menu's dom props. |  |
+| get-column-style | `(detail: { level: number }) => string \| object` | `undefined` | Function that resolves column style. `level` starts from `0`. |  |
+| value-field | `string` | `'value'` | The value field in `CascaderOption`. |  |
+| label-field | `string` | `'label'` | The label field in `CascaderOption`. |  |
+| menu-props | `HTMLAttributes` | `undefined` | The menu's dom props. |  |
+| multiple | `boolean` | `false` | Whether to allow multiple options being selected. |  |
+| options | `CascaderOption[]` | `[]` | Options of the cascader. |  |
+| placeholder | `string` | `'Please Select'` | Placeholder text. |  |
+| remote | `boolean` | `false` | Whether to obtain data remotely. |  |
+| render-prefix | `(info: { option: CascaderOption, node: VNode \| null, checked: boolean }) => VNodeChild` | `undefined` | Render function of all the options' prefix. |  |
+| render-label | `(option: CascaderOption, checked: boolean) => VNodeChild` | `undefined` | Render function for cascader menu option label. |  |
+| render-suffix | `(info: { option: CascaderOption, node: VNode \| null, checked: boolean }) => VNodeChild` | `undefined` | Render function of all the options' suffix. |  |
+| separator | `string` | `' / '` | Selected option path value separator (used with `show-path`). |  |
+| show-path | `boolean` | `true` | Whether to show the selected options as a path. |  |
+| size | `'small' \| 'medium' \| 'large'` | `'medium'` | Cascader size. |  |
+| status | `'success' \| 'warning' \| 'error'` | `undefined` | Validation status. |  |
+| value | `string \| number \| Array<number \| string> \| null` | `undefined` | Value of the cascader (if being set manually). |  |
+| virtual-scroll | `boolean` | `true` | Whether to enable virtual scrolling. |  |
+| on-blur | `() => void` | `undefined` | Callback on blurred. |  |
+| on-focus | `() => void` | `undefined` | Callback on focused. |  |
+| on-load | `(option: CascaderOption) => Promise<void>` | `undefined` | Callback when a node is loaded. Set `option.children` in the returned promise. Loading will stop after the promise is resolved or rejected. |  |
+| on-update:value | `(value: string \| number \| Array<string \| number> \| null, option: CascaderOption \| Array<CascaderOption \| null> \| null, pathValues: Array<CascaderOption \| null> \| Array<CascaderOption[] \| null> \| null) => void` | `undefined` | Callback executed when the value changes. |  |
+
 #### CascaderOption Properties
 
 | Name | Type | Description | Version |
@@ -84,6 +124,15 @@ status.vue
 | empty | `()` | Empty state slot for the options cascading menu. | 2.22.0 |
 | not-found | `()` | Data not found slot when searching. | 2.34.0 |
 
+### CascaderPanel Slots
+
+| Name | Parameters | Description | Version |
+| --- | --- | --- | --- |
+| action | `()` | Action content displayed in the cascading menu. |  |
+| arrow | `()` | Arrow content displayed in the cascading menu. |  |
+| empty | `()` | Empty state slot for the options cascading menu. |  |
+| not-found | `()` | Data not found slot when searching. |  |
+
 ### Cascader Methods
 
 | Name | Type | Description | Version |
@@ -92,3 +141,12 @@ status.vue
 | focus | `() => void` | Focus. | 2.24.2 |
 | getCheckedData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | Get checked data. | 2.34.0 |
 | getIndeterminateData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | Get indeterminate data. | 2.34.0 |
+
+### CascaderPanel Methods
+
+| Name | Type | Description | Version |
+| --- | --- | --- | --- |
+| blur | `() => void` | Blur. |  |
+| focus | `() => void` | Focus. |  |
+| getCheckedData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | Get checked data. |  |
+| getIndeterminateData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | Get indeterminate data. |  |

--- a/src/cascader/demos/zhCN/cascaderPanel.demo.vue
+++ b/src/cascader/demos/zhCN/cascaderPanel.demo.vue
@@ -1,0 +1,80 @@
+<markdown>
+# 级联面板
+
+级联面板是级联选择器的核心组件，与级联选择器一样，有单选、多选、动态加载等多种功能。
+
+和级联选择器一样，通过 options 来指定选项，也可通过 props 来设置多选、动态加载等功能，具体详情见下方API表格。
+</markdown>
+
+<script lang="ts" setup>
+import type { CascaderOption } from 'naive-ui'
+import Flash16Regular from '@vicons/fluent/Flash16Regular'
+import { ref } from 'vue'
+
+function getOptions(depth = 2, iterator = 1, prefix = '') {
+  const length = 12
+  const options: CascaderOption[] = []
+  for (let i = 1; i <= length; ++i) {
+    if (iterator === 1) {
+      options.push({
+        value: `${i}`,
+        label: `${i}`,
+        disabled: i % 5 === 0,
+        children: getOptions(depth, iterator + 1, `${String(i)}`)
+      })
+    }
+    else if (iterator === depth) {
+      options.push({
+        value: `${prefix}-${i}`,
+        label: `${prefix}-${i}`,
+        disabled: i % 5 === 0
+      })
+    }
+    else {
+      options.push({
+        value: `${prefix}-${i}`,
+        label: `${prefix}-${i}`,
+        disabled: i % 5 === 0,
+        children: getOptions(depth, iterator + 1, `${prefix}-${i}`)
+      })
+    }
+  }
+  return options
+}
+
+const value = ref(null)
+
+const value2 = ref(null)
+const options = getOptions()
+</script>
+
+<template>
+  <n-space vertical>
+    <n-cascader-panel
+      v-model:value="value"
+      placeholder="没啥用的值"
+      :options="options"
+    >
+      <template #action>
+        站在能分割世界的桥
+      </template>
+      <template #arrow>
+        <Flash16Regular />
+      </template>
+    </n-cascader-panel>
+
+    <n-cascader-panel
+      v-model:value="value2"
+      placeholder="没啥用的值"
+      multiple
+      :options="options"
+    >
+      <template #action>
+        站在能分割世界的桥
+      </template>
+      <template #arrow>
+        <Flash16Regular />
+      </template>
+    </n-cascader-panel>
+  </n-space>
+</template>

--- a/src/cascader/demos/zhCN/index.demo-entry.md
+++ b/src/cascader/demos/zhCN/index.demo-entry.md
@@ -18,6 +18,7 @@ custom-render.vue
 focus.vue
 status.vue
 default-value-debug.vue
+cascaderPanel.vue
 ```
 
 ## API
@@ -67,6 +68,45 @@ default-value-debug.vue
 | on-update:show | `(value: boolean) => void` | `undefined` | 菜单打开关闭的回调 |  |
 | on-update:value | `(value: string \| number \| Array<string \| number> \| null, option: CascaderOption \| Array<CascaderOption \| null> \| null, pathValues: Array<CascaderOption \| null> \| Array<CascaderOption[] \| null> \| null) => void` | `undefined` | 值改变时执行的回调 |  |
 
+### CascaderPanel Props
+
+| 名称 | 类型 | 默认值 | 说明 | 版本 |
+| --- | --- | --- | --- | --- |
+| allow-checking-not-loaded | `boolean` | `false` | 是否允许级联勾选还没有完全加载的节点。如果你要用这个属性，请记住 `value` 可能是不完整的，并且请注意勾选行为和后端计算逻辑的一致性，尤其是有禁用节点的情况下 |  |
+| cascade | `boolean` | `true` | 在多选时是否关联选项 |  |
+| check-strategy | `string` | `'all'` | 设置勾选策略来指定显示的勾选节点，`all` 表示显示全部选中节点；`parent` 表示只显示父节点（当父节点下所有子节点都选中时，对于单选无效）；`child` 表示只显示子节点 |  |
+| children-field | `string` | `'children'` | 替代 `CascaderOption` 中的 children 字段名 |  |
+| clearable | `boolean` | `false` | 值是否可清除 |  |
+| clear-filter-after-select | `boolean` | `true` | 是否在可过滤和多选的情况下选中一个选项后保留当前的搜索关键词 |  |
+| default-value | `string \| number \| Array<number \| string> \| null` | `null` | 级联菜单默认选中的数据 |  |
+| disabled | `boolean` | `false` | 是否禁用 |  |
+| disabled-field | `string` | `'disabled'` | 替代 `CascaderOption` 中的 disabled 字段名 |  |
+| expand-trigger | `'click' \| 'hover'` | `'click'` | 在 `remote` 被设定时 `'hover'` 不生效 |  |
+| filterable | `boolean` | `false` | `remote` 被设定时不生效 |  |
+| filter | `(pattern: string, option: CascaderOption, path: CascaderOption[]) => boolean` | 一个基于字符串的过滤算法 | 过滤选项的函数 |  |
+| filter-menu-props | `HTMLAttributes` | `undefined` | 可过滤菜单的 DOM 属性 |  |
+| get-column-style | `(detail: { level: number }) => string \| object` | `undefined` | 获取列样式的函数，`level` 从 `0` 开始 |  |
+| value-field | `string` | `'value'` | 替代 `CascaderOption` 中的 value 字段名 |  |
+| label-field | `string` | `'label'` | 替代 `CascaderOption` 中的 label 字段名 |  |
+| menu-props | `HTMLAttributes` | `undefined` | 菜单的 DOM 属性 |  |
+| multiple | `boolean` | `false` | 是否支持多选 |  |
+| options | `CascaderOption[]` | `[]` | 填充的 options 数据 |  |
+| placeholder | `string` | `'请选择'` | 提示信息 |  |
+| remote | `boolean` | `false` | 是否远程获取数据 |  |
+| render-prefix | `(info: { option: CascaderOption, node: VNode \| null, checked: boolean }) => VNodeChild` | `undefined` | 节点前缀的渲染函数 |  |
+| render-label | `(option: CascaderOption, checked: boolean) => VNodeChild` | `undefined` | Cascader 菜单选项标签渲染函数 |  |
+| render-suffix | `(info: { option: CascaderOption, checked: boolean }) => VNodeChild` | `undefined` | 节点后缀的渲染函数 |  |
+| separator | `string` | `' / '` | 数据分隔符 |  |
+| show-path | `boolean` | `true` | 是否在选择器中显示选项路径 |  |
+| size | `'small' \| 'medium' \| 'large'` | `'medium'` | 尺寸 |  |
+| status | `'success' \| 'warning' \| 'error'` | `undefined` | 验证状态 |  |
+| value | `string \| number \| Array<number \| string> \| null` | `undefined` | 级联选择的数据受控 |  |
+| virtual-scroll | `boolean` | `true` | 是否支持虚拟滚动 |  |
+| on-blur | `() => void` | `undefined` | 用户 blur 时执行的回调 |  |
+| on-focus | `() => void` | `undefined` | 用户 focus 时执行的回调 |  |
+| on-load | `(option: CascaderOption) => Promise<void>` | `undefined` | 在点击未加载完成节点时的回调，在返回的 promise 中设定 `option.children`，在返回的 promise resolve 或 reject 之后完成加载 |  |
+| on-update:value | `(value: string \| number \| Array<string \| number> \| null, option: CascaderOption \| Array<CascaderOption \| null> \| null, pathValues: Array<CascaderOption \| null> \| Array<CascaderOption[] \| null> \| null) => void` | `undefined` | 值改变时执行的回调 |  |
+
 #### CascaderOption Properties
 
 | 名称      | 类型               | 描述                     | 版本 |
@@ -85,6 +125,15 @@ default-value-debug.vue
 | empty     | `()` | 级联菜单无数据时的 slot          | 2.22.0 |
 | not-found | `()` | 搜索不到数据时候的 slot          | 2.34.0 |
 
+### CascaderPanel Slots
+
+| 名称      | 参数 | 描述                             | 版本 |
+| --------- | ---- | -------------------------------- | ---- |
+| action    | `()` | 级联菜单中显示的 action 填充内容 |      |
+| arrow     | `()` | 箭头的 slot                      |      |
+| empty     | `()` | 级联菜单无数据时的 slot          |      |
+| not-found | `()` | 搜索不到数据时候的 slot          |      |
+
 ### Cascader Methods
 
 | 名称 | 类型 | 说明 | 版本 |
@@ -93,3 +142,12 @@ default-value-debug.vue
 | focus | `() => void` | 聚焦 | 2.24.2 |
 | getCheckedData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | 获取选中的数据 | 2.34.0 |
 | getIndeterminateData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | 获取半选的数据 | 2.34.0 |
+
+### CascaderPanel Methods
+
+| 名称 | 类型 | 说明 | 版本 |
+| --- | --- | --- | --- |
+| blur | `() => void` | 失焦 |  |
+| focus | `() => void` | 聚焦 |  |
+| getCheckedData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | 获取选中的数据 |  |
+| getIndeterminateData | `() => { keys: Array<string \| number>, options: Array<TreeOption \| null> }` | 获取半选的数据 |  |

--- a/src/cascader/index.ts
+++ b/src/cascader/index.ts
@@ -1,3 +1,11 @@
 export { cascaderProps, default as NCascader } from './src/Cascader'
 export type { CascaderProps, CascaderSlots } from './src/Cascader'
+export {
+  cascaderPanelProps,
+  default as NCascaderPanel
+} from './src/CascaderPanel'
+export type {
+  CascaderPanelProps,
+  CascaderPanelSlots
+} from './src/CascaderPanel'
 export type { CascaderInst, CascaderOption } from './src/interface'

--- a/src/cascader/src/hooks/useCascader.ts
+++ b/src/cascader/src/hooks/useCascader.ts
@@ -1,0 +1,256 @@
+import type { CheckStrategy, Key } from 'treemate'
+import type { CascaderOption, Value } from '../interface'
+import { createTreeMate } from 'treemate'
+import { useMergedState } from 'vooks'
+import { computed, isReactive, ref, watch } from 'vue'
+import { getPathLabel } from '../utils'
+
+export interface cascaderProps {
+  defaultValue: Value | null
+  value: Value | null | undefined
+  leafOnly: boolean
+  checkStrategy: CheckStrategy
+  valueField: string
+  labelField: string
+  childrenField: string
+  disabledField: string
+  options: CascaderOption[]
+  cascade: boolean
+  multiple: boolean
+  allowCheckingNotLoaded: boolean
+  showPath: boolean
+  separator: string
+}
+
+export function useCascader(props: cascaderProps) {
+  const uncontrolledValueRef = ref(props.defaultValue)
+  const controlledValueRef = computed(() => props.value)
+
+  const mergedValueRef = useMergedState(
+    controlledValueRef,
+    uncontrolledValueRef
+  )
+  const mergedCheckStrategyRef = computed(() => {
+    return props.leafOnly ? 'child' : props.checkStrategy
+  })
+  const keyboardKeyRef = ref<Key | null>(null)
+  const hoverKeyRef = ref<Key | null>(null)
+  const loadingKeySetRef = ref<Set<Key>>(new Set())
+  const addLoadingKey = (key: Key): void => {
+    loadingKeySetRef.value.add(key)
+  }
+  const deleteLoadingKey = (key: Key): void => {
+    loadingKeySetRef.value.delete(key)
+  }
+  const treeMateRef = computed(() => {
+    const { valueField, childrenField, disabledField } = props
+    return createTreeMate(props.options, {
+      getDisabled(node) {
+        return (node as any)[disabledField]
+      },
+      getKey(node) {
+        return (node as any)[valueField]
+      },
+      getChildren(node) {
+        return (node as any)[childrenField]
+      }
+    })
+  })
+  const mergedKeysRef = computed(() => {
+    const { cascade, multiple, allowCheckingNotLoaded } = props
+    if (multiple && Array.isArray(mergedValueRef.value)) {
+      return treeMateRef.value.getCheckedKeys(mergedValueRef.value, {
+        cascade,
+        allowNotLoaded: allowCheckingNotLoaded
+      })
+    }
+    else {
+      return {
+        checkedKeys: [],
+        indeterminateKeys: []
+      }
+    }
+  })
+
+  const checkedKeysRef = computed(() => mergedKeysRef.value.checkedKeys)
+  const indeterminateKeysRef = computed(
+    () => mergedKeysRef.value.indeterminateKeys
+  )
+  const menuModelRef = computed(() => {
+    const { treeNodePath, treeNode } = treeMateRef.value.getPath(
+      hoverKeyRef.value
+    )
+    let ret
+    if (treeNode === null) {
+      ret = [treeMateRef.value.treeNodes]
+    }
+    else {
+      ret = treeNodePath.map(treeNode => treeNode.siblings)
+      if (
+        !treeNode.isLeaf
+        && !loadingKeySetRef.value.has(treeNode.key)
+        && treeNode.children
+      ) {
+        ret.push(treeNode.children)
+      }
+    }
+    return ret
+  })
+
+  const hoverKeyPathRef = computed(() => {
+    const { keyPath } = treeMateRef.value.getPath(hoverKeyRef.value)
+    return keyPath
+  })
+
+  if (isReactive(props.options)) {
+    watch(props.options, (value, oldValue) => {
+      if (!(value === oldValue)) {
+        hoverKeyRef.value = null
+        keyboardKeyRef.value = null
+      }
+    })
+  }
+
+  const selectedOptionsRef = computed(() => {
+    if (props.multiple) {
+      const {
+        showPath,
+        separator,
+        labelField,
+        cascade,
+        allowCheckingNotLoaded
+      } = props
+      const { getCheckedKeys, getNode } = treeMateRef.value
+      const value = getCheckedKeys(checkedKeysRef.value, {
+        cascade,
+        checkStrategy: mergedCheckStrategyRef.value,
+        allowNotLoaded: allowCheckingNotLoaded
+      }).checkedKeys
+      return value.map((key) => {
+        const node = getNode(key)
+        if (node === null) {
+          return {
+            label: String(key),
+            value: key
+          }
+        }
+        else {
+          return {
+            label: showPath
+              ? getPathLabel(node, separator, labelField)
+              : (node.rawNode as any)[labelField],
+            value: node.key
+          }
+        }
+      })
+    }
+    else {
+      return []
+    }
+  })
+
+  const selectedOptionRef = computed(() => {
+    const { multiple, showPath, separator, labelField } = props
+    const { value } = mergedValueRef
+    if (!multiple && !Array.isArray(value)) {
+      const { getNode } = treeMateRef.value
+      if (value === null) {
+        return null
+      }
+      const node = getNode(value)
+      if (node === null) {
+        return {
+          label: String(value),
+          value
+        }
+      }
+      else {
+        return {
+          label: showPath
+            ? getPathLabel(node, separator, labelField)
+            : (node.rawNode as any)[labelField],
+          value: node.key
+        }
+      }
+    }
+    else {
+      return null
+    }
+  })
+
+  function updateKeyboardKey(key: Key | null): void {
+    keyboardKeyRef.value = key
+  }
+
+  function updateHoverKey(key: Key | null): void {
+    hoverKeyRef.value = key
+  }
+
+  function getOptionsByKeys(keys: Key[]): Array<CascaderOption | null> {
+    const {
+      value: { getNode }
+    } = treeMateRef
+    return keys.map(keys => getNode(keys)?.rawNode || null)
+  }
+
+  const showCheckboxRef = computed(() => {
+    if (props.multiple && props.cascade)
+      return true
+    if (mergedCheckStrategyRef.value !== 'child')
+      return true
+    return false
+  })
+
+  function getCheckedData() {
+    if (showCheckboxRef.value) {
+      const checkedKeys = checkedKeysRef.value
+      return {
+        keys: checkedKeys,
+        options: getOptionsByKeys(checkedKeys)
+      }
+    }
+    return {
+      keys: [],
+      options: []
+    }
+  }
+
+  function getIndeterminateData() {
+    if (showCheckboxRef.value) {
+      const indeterminateKeys = indeterminateKeysRef.value
+      return {
+        keys: indeterminateKeys,
+        options: getOptionsByKeys(indeterminateKeys)
+      }
+    }
+    return {
+      keys: [],
+      options: []
+    }
+  }
+
+  return {
+    uncontrolledValueRef,
+    mergedValueRef,
+    mergedCheckStrategyRef,
+    keyboardKeyRef,
+    hoverKeyRef,
+    loadingKeySetRef,
+    addLoadingKey,
+    deleteLoadingKey,
+    treeMateRef,
+    mergedKeysRef,
+    checkedKeysRef,
+    indeterminateKeysRef,
+    menuModelRef,
+    hoverKeyPathRef,
+    selectedOptionsRef,
+    selectedOptionRef,
+    updateKeyboardKey,
+    updateHoverKey,
+    getOptionsByKeys,
+    showCheckboxRef,
+    getCheckedData,
+    getIndeterminateData
+  }
+}

--- a/volar.d.ts
+++ b/volar.d.ts
@@ -21,6 +21,7 @@ declare module 'vue' {
     NCarousel: (typeof import('naive-ui'))['NCarousel']
     NCarouselItem: (typeof import('naive-ui'))['NCarouselItem']
     NCascader: (typeof import('naive-ui'))['NCascader']
+    NCascaderPanel: (typeof import('naive-ui'))['NCascaderPanel']
     NCheckbox: (typeof import('naive-ui'))['NCheckbox']
     NCheckboxGroup: (typeof import('naive-ui'))['NCheckboxGroup']
     NCode: (typeof import('naive-ui'))['NCode']


### PR DESCRIPTION
新增 `n-cascader-panel` 组件

close https://github.com/tusen-ai/naive-ui/issues/5347

不明白这个东西的业务需求是什么，独立出来CascaderPanel组件，去掉Cascader中show和定位的相关逻辑。只保留CascaderSelectMenu。


![image](https://github.com/user-attachments/assets/0ea0130e-a448-4f89-b394-3da1f243b8b3)
