### PR TITLE
fix(anchor): correctly active link

### DIFF
--- a/src/anchor/src/BaseAnchor.tsx
+++ b/src/anchor/src/BaseAnchor.tsx
@@ -164,7 +164,7 @@ export default defineComponent({
       if (!transition) {
         disableTransitionOneTick()
       }
-      handleScroll()
+      // handleScroll()
     }
 
     function _handleScroll(transition = true): void {

--- a/src/anchor/src/BaseAnchor.tsx
+++ b/src/anchor/src/BaseAnchor.tsx
@@ -164,7 +164,6 @@ export default defineComponent({
       if (!transition) {
         disableTransitionOneTick()
       }
-      // handleScroll()
     }
 
     function _handleScroll(transition = true): void {


### PR DESCRIPTION
### 普通点击流程

click->setActiveHref->scrollIntoView->eventListener->handleScroll
再次调用 handleScroll()
handleScroll->_handleScroll->set activeHrefRef.value

### 边界情况
普通情况下上面的流程没什么问题

如果用户点击的是最后面几个 此时最后几个没有足够的内容高度 就无法正确 active 

表现如图
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/74ee8246-780a-4bdb-a3a9-290375cc8ac6" />


```ts
activeHrefRef.value = href
linkEl.scrollIntoView()
```
这两行代码会更新activeHref 和 触发 scroll
组件 mount 后会监听 scroll 事件
看起来 setActiveHref 里的 handleScroll 的这次调用是多余的
