### PR TITLE
feat(date-picker): add custom default time function support

### DIFF
--- a/src/date-picker/demos/enUS/default-time.demo.vue
+++ b/src/date-picker/demos/enUS/default-time.demo.vue
@@ -4,10 +4,60 @@
 You can set the default time of picked date.
 </markdown>
 
+<script setup lang="ts">
+import type {
+  IsRangeDefaultTime,
+  IsSingleDefaultTime
+} from '../../src/interface'
+import { format, isAfter, isToday } from 'date-fns'
+
+const getSingleDefaultTime: IsSingleDefaultTime = (
+  timestamp: number
+): string => {
+  const now = new Date()
+
+  if (isToday(timestamp)) {
+    return format(new Date(), 'HH:mm:ss')
+  }
+  if (isAfter(now, timestamp)) {
+    return '23:59:59'
+  }
+  else {
+    return '00:00:00'
+  }
+}
+
+const getRangeDefaultTime: IsRangeDefaultTime = (
+  timestamp: number,
+  position: 'start' | 'end'
+): string => {
+  const now = new Date()
+
+  if (position === 'start') {
+    return '00:00:00'
+  }
+
+  if (isToday(timestamp)) {
+    return format(new Date(), 'HH:mm:ss')
+  }
+  if (isAfter(now, timestamp)) {
+    return '23:59:59'
+  }
+  else {
+    return '00:00:00'
+  }
+}
+</script>
+
 <template>
   <n-space vertical>
     <n-date-picker type="datetime" clearable default-time="13:22:11" />
     <n-date-picker type="datetime" clearable default-time="16:00:00" />
+    <n-date-picker
+      type="datetime"
+      clearable
+      :default-time="getSingleDefaultTime"
+    />
     <n-date-picker type="datetimerange" clearable default-time="13:22:11" />
     <n-date-picker
       type="datetimerange"
@@ -18,6 +68,11 @@ You can set the default time of picked date.
       type="datetimerange"
       clearable
       :default-time="['13:22:11', '16:00:00']"
+    />
+    <n-date-picker
+      type="datetimerange"
+      clearable
+      :default-time="getRangeDefaultTime"
     />
   </n-space>
 </template>

--- a/src/date-picker/demos/enUS/index.demo-entry.md
+++ b/src/date-picker/demos/enUS/index.demo-entry.md
@@ -94,7 +94,7 @@ panel.vue
 | --- | --- | --- | --- | --- |
 | actions | `Array<'clear' \| 'now' \| 'confirm'> \| null` | `['clear', 'now', 'confirm']` | Operations supported for the `datetime` type date picker. |  |
 | default-calendar-start-time | `number` | `undefined` | Default panel calendar start month timestamp. | 2.38.1 |
-| default-time | `string` | `undefined` | Default time of the selected date. It's format is `HH:mm:ss`. | 2.22.0 |
+| default-time | `string \| (timestamp: number) => string` | `undefined` | Default time of the selected date. Can accept a function with a timestamp argument that returns a formatted string. It's format is `HH:mm:ss`. | 2.22.0 |
 | format | `string` | `'yyyy-MM-dd HH:mm:ss'` | Format of the input. For detail please see [format](https://date-fns.org/v2.23.0/docs/format). |  |
 | is-date-disabled | `(current: number, detail: { type: 'date', year: number, month: number, date: number } \| { type: 'month', year: number, month: number } \| { type: 'year', year: number } \| { type: 'quarter',  year: number, quarter: number } \| { type: 'input' }) => boolean` | `() => false` | Validator of the date. | `detail` 2.37.1 |
 | is-time-disabled | `(current: number) => { isHourDisabled?: () => boolean, isMinuteDisabled?: () => boolean, isSecondDisabled?: () => boolean }` | `undefined` | Validator of the time. |  |
@@ -131,7 +131,7 @@ panel.vue
 | bind-calendar-months | `boolean` | `false` | Whether months in panel calendar are consecutive. | 2.28.3 |
 | default-calendar-start-time | `number` | `undefined` | Default panel calendar start month timestamp. | 2.28.3 |
 | default-calendar-end-time | `number` | `undefined` | Default panel calendar end month timestamp. | 2.28.3 |
-| default-time | `string \| Array<string \| undefined>` | `undefined` | Default time of the selected date. It's format is `HH:mm:ss`. | 2.22.0 |
+| default-time | `string \| Array<string \| undefined> \| (timestamp: number, position: "start" \| "end", value: [number, number] \| null) => string` | `undefined` | Default time of the selected date. Can accept a function with a timestamp and position arguments that returns a formatted string. It's format is `HH:mm:ss`. | 2.22.0 |
 | end-placeholder | `string` | `'End Date and Time'` | Placeholder at end part of the input. |  |
 | format | `string` | `'yyyy-MM-dd HH:mm:ss'` | Format of the input. For detail please see [format](https://date-fns.org/v2.23.0/docs/format). |  |
 | is-date-disabled | `(current: number, phase: 'start' \| 'end', value: [number, number] \| null) => boolean` | `undefined` | Validator of the date. |  |

--- a/src/date-picker/demos/zhCN/default-time.demo.vue
+++ b/src/date-picker/demos/zhCN/default-time.demo.vue
@@ -4,10 +4,60 @@
 你可以设定选择某个日期后默认使用的时间。
 </markdown>
 
+<script setup lang="ts">
+import type {
+  IsRangeDefaultTime,
+  IsSingleDefaultTime
+} from '../../src/interface'
+import { format, isAfter, isToday } from 'date-fns'
+
+const getSingleDefaultTime: IsSingleDefaultTime = (
+  timestamp: number
+): string => {
+  const now = new Date()
+
+  if (isToday(timestamp)) {
+    return format(new Date(), 'HH:mm:ss')
+  }
+  if (isAfter(now, timestamp)) {
+    return '23:59:59'
+  }
+  else {
+    return '00:00:00'
+  }
+}
+
+const getRangeDefaultTime: IsRangeDefaultTime = (
+  timestamp: number,
+  position: 'start' | 'end'
+): string => {
+  const now = new Date()
+
+  if (position === 'start') {
+    return '00:00:00'
+  }
+
+  if (isToday(timestamp)) {
+    return format(new Date(), 'HH:mm:ss')
+  }
+  if (isAfter(now, timestamp)) {
+    return '23:59:59'
+  }
+  else {
+    return '00:00:00'
+  }
+}
+</script>
+
 <template>
   <n-space vertical>
     <n-date-picker type="datetime" clearable default-time="13:22:11" />
     <n-date-picker type="datetime" clearable default-time="16:00:00" />
+    <n-date-picker
+      type="datetime"
+      clearable
+      :default-time="getSingleDefaultTime"
+    />
     <n-date-picker type="datetimerange" clearable default-time="13:22:11" />
     <n-date-picker
       type="datetimerange"
@@ -18,6 +68,11 @@
       type="datetimerange"
       clearable
       :default-time="['13:22:11', '16:00:00']"
+    />
+    <n-date-picker
+      type="datetimerange"
+      clearable
+      :default-time="getRangeDefaultTime"
     />
   </n-space>
 </template>

--- a/src/date-picker/demos/zhCN/index.demo-entry.md
+++ b/src/date-picker/demos/zhCN/index.demo-entry.md
@@ -95,7 +95,7 @@ form-debug.vue
 | --- | --- | --- | --- | --- |
 | actions | `Array<'clear' \| 'now' \| 'confirm'> \| null` | `['clear', 'now', 'confirm']` | DateTime 类型的 Date Picker 中支持的操作 |  |
 | default-calendar-start-time | `number` | `undefined` | 面板日历默认开始的月份时间戳 | 2.38.1 |
-| default-time | `string` | `undefined` | 默认时间，格式为 `HH:mm:ss` | 2.22.0 |
+| default-time | `string \| (timestamp: number) => string` | `undefined` | 默认时间，格式为 `HH:mm:ss` | 2.22.0 |
 | format | `string` | `'yyyy-MM-dd HH:mm:ss'` | 时间格式化字符串，详情见 [format](https://date-fns.org/v2.23.0/docs/format) |  |
 | is-date-disabled | `(current: number, detail: { type: 'date', year: number, month: number, date: number } \| { type: 'month', year: number, month: number } \| { type: 'year', year: number } \| { type: 'quarter',  year: number, quarter: number } \| { type: 'input' }) => boolean` | `undefined` | 日期禁用的校验函数 | `detail` 2.37.1 |
 | is-time-disabled | `(current: number) => { isHourDisabled: boolean, isMinuteDisabled: boolean, isSecondDisabled: boolean }` | `undefined` | 时间禁用的校验函数 |  |
@@ -131,7 +131,7 @@ form-debug.vue
 | bind-calendar-months | `boolean` | `false` | 面板月份是否连续 | 2.28.3 |
 | default-calendar-start-time | `number` | `undefined` | 面板日历默认开始的月份时间戳 | 2.28.3 |
 | default-calendar-end-time | `number` | `undefined` | 面板日历默认结束的月份时间戳 | 2.28.3 |
-| default-time | `string \| Array<string \| undefined>` | `undefined` | 默认时间，格式为 `HH:mm:ss` | 2.22.0 |
+| default-time | `string \| Array<string \| undefined> \| (timestamp: number, position: "start" \| "end", value: [number, number] \| null) => string` | `undefined` | 默认时间，格式为 `HH:mm:ss` | 2.22.0 |
 | end-placeholder | `string` | `'结束日期时间'` | DateTimeRange 中 end 选框的提示信息 |  |
 | format | `string` | `'yyyy-MM-dd HH:mm:ss'` | 时间格式化字符串，详情见 [format](https://date-fns.org/v2.23.0/docs/format) |  |
 | is-date-disabled | `(current: number, phase: 'start' \| 'end', value: [number, number] \| null) => boolean` | `undefined` | 日期禁用的校验函数 |  |

--- a/src/date-picker/src/interface.ts
+++ b/src/date-picker/src/interface.ts
@@ -20,7 +20,11 @@ import { createInjectionKey } from '../../_utils'
 
 export type Value = number | [number, number]
 
-export type DefaultTime = string | [string | undefined, string | undefined]
+export type DefaultTime =
+  | string
+  | [string | undefined, string | undefined]
+  | IsSingleDefaultTime
+  | IsRangeDefaultTime
 
 export type FormattedValue = string | [string, string]
 
@@ -194,3 +198,10 @@ export type IsRangeTimeDisabled = (
   position: 'start' | 'end',
   value: [number, number] // date must exist to have time validation
 ) => TimeValidator
+
+export type IsSingleDefaultTime = (timestamp: number) => string
+export type IsRangeDefaultTime = (
+  timestamp: number,
+  position: 'start' | 'end',
+  value: [number, number] | null
+) => string

--- a/src/date-picker/src/panel/use-calendar.ts
+++ b/src/date-picker/src/panel/use-calendar.ts
@@ -4,6 +4,7 @@ import type {
   FirstDayOfWeek,
   IsSingleDateDisabled,
   IsSingleDateDisabledDetail,
+  IsSingleDefaultTime,
   PanelChildComponentRefs,
   Shortcuts
 } from '../interface'
@@ -41,6 +42,7 @@ import { MONTH_ITEM_HEIGHT } from '../config'
 import { datePickerInjectionKey } from '../interface'
 import {
   dateArray,
+  extractSingleDefaultTime,
   getDefaultTime,
   monthArray,
   quarterArray,
@@ -374,7 +376,18 @@ function useCalendar(
       && props.defaultTime !== null
       && !Array.isArray(props.defaultTime)
     ) {
-      const time = getDefaultTime(props.defaultTime)
+      let time: { hours: number, minutes: number, seconds: number } | undefined
+
+      if (typeof props.defaultTime === 'function') {
+        time = extractSingleDefaultTime(
+          dateItem.ts,
+          props.defaultTime as IsSingleDefaultTime
+        )
+      }
+      else {
+        time = getDefaultTime(props.defaultTime)
+      }
+
       if (time) {
         newValue = getTime(set(newValue, time)) // setDate getTime(addMilliseconds(startOfDay(newValue), time))
       }

--- a/src/date-picker/src/panel/use-dual-calendar.ts
+++ b/src/date-picker/src/panel/use-dual-calendar.ts
@@ -26,6 +26,7 @@ import {
 import {
   dateArray,
   type DateItem,
+  extractRangeDefaultTime,
   getDefaultTime,
   monthArray,
   type MonthItem,
@@ -534,12 +535,26 @@ function useDualCalendar(
         | undefined
       if (type === 'datetimerange') {
         const { defaultTime } = props
-        if (Array.isArray(defaultTime)) {
+        if (typeof defaultTime === 'function') {
+          startDefaultTime = extractRangeDefaultTime(
+            startTime,
+            defaultTime,
+            'start',
+            [startTime, endTime]
+          )
+          endDefaultTime = extractRangeDefaultTime(
+            endTime,
+            defaultTime,
+            'end',
+            [startTime, endTime]
+          )
+        }
+        else if (Array.isArray(defaultTime)) {
           startDefaultTime = getDefaultTime(defaultTime[0])
           endDefaultTime = getDefaultTime(defaultTime[1])
         }
         else {
-          startDefaultTime = getDefaultTime(defaultTime)
+          startDefaultTime = getDefaultTime(defaultTime as string)
           endDefaultTime = startDefaultTime
         }
       }

--- a/src/date-picker/src/panel/use-panel-common.ts
+++ b/src/date-picker/src/panel/use-panel-common.ts
@@ -39,7 +39,7 @@ const usePanelCommonProps = {
     default: null
   },
   shortcuts: Object as PropType<Shortcuts>,
-  defaultTime: [Number, String, Array] as PropType<DefaultTime>,
+  defaultTime: [Number, String, Array, Function] as PropType<DefaultTime>,
   inputReadonly: Boolean,
   onClear: Function,
   onConfirm: Function as PropType<(value: Value | null) => void>,

--- a/src/date-picker/src/props.ts
+++ b/src/date-picker/src/props.ts
@@ -43,7 +43,7 @@ export const datePickerProps = {
   },
   defaultValue: [Number, Array] as PropType<Value | null>,
   defaultFormattedValue: [String, Array] as PropType<FormattedValue | null>,
-  defaultTime: [Number, String, Array] as PropType<DefaultTime>,
+  defaultTime: [Number, String, Array, Function] as PropType<DefaultTime>,
   disabled: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined

--- a/src/date-picker/src/utils.ts
+++ b/src/date-picker/src/utils.ts
@@ -1,6 +1,11 @@
 import type { Ref } from 'vue'
 import type { NDateLocale } from '../../locales'
-import type { FirstDayOfWeek, Value } from './interface'
+import type {
+  FirstDayOfWeek,
+  IsRangeDefaultTime,
+  IsSingleDefaultTime,
+  Value
+} from './interface'
 import {
   addDays,
   addMonths,
@@ -488,6 +493,38 @@ function strictParse(
   else return new Date(Number.NaN)
 }
 
+function extractSingleDefaultTime(
+  timestamp: number,
+  defaultTimeExtractor: IsSingleDefaultTime
+):
+  | {
+    hours: number
+    minutes: number
+    seconds: number
+  }
+  | undefined {
+  const extractedTime = defaultTimeExtractor(timestamp)
+
+  return getDefaultTime(extractedTime as string)
+}
+
+function extractRangeDefaultTime(
+  timestamp: number,
+  defaultTimeExtractor: IsRangeDefaultTime,
+  position: 'start' | 'end',
+  value: [number, number] | null
+):
+  | {
+    hours: number
+    minutes: number
+    seconds: number
+  }
+  | undefined {
+  const extractedTime = defaultTimeExtractor(timestamp, position, value)
+
+  return getDefaultTime(extractedTime as string)
+}
+
 function getDefaultTime(timeValue: string | undefined):
   | {
     hours: number
@@ -518,6 +555,8 @@ function pluckValueFromRange(
 
 export {
   dateArray,
+  extractRangeDefaultTime,
+  extractSingleDefaultTime,
   getDefaultTime,
   getDerivedTimeFromKeyboardEvent,
   getMonthString,


### PR DESCRIPTION
Enhanced the `default-time` prop in DatePicker components to support custom functions for dynamic time calculation, in addition to the existing string and array formats. Fully backward compatible - existing string and array formats continue to work as before.

**Use Cases**

This enhancement enables more flexible time handling scenarios:
- Set current time for today, specific times for other dates
- Apply different default times based on date context
- Implement business logic for time selection (e.g., working hours) 