### PR TITLE
refactor: use `StyleValue` type

### DIFF
--- a/src/_internal/scrollbar/src/Scrollbar.tsx
+++ b/src/_internal/scrollbar/src/Scrollbar.tsx
@@ -1,4 +1,10 @@
-import type { CSSProperties, HTMLAttributes, PropType, VNode } from 'vue'
+import type {
+  CSSProperties,
+  HTMLAttributes,
+  PropType,
+  StyleValue,
+  VNode
+} from 'vue'
 import type { ThemeProps } from '../../../_mixins'
 import type {
   ExtractInternalPropTypes,
@@ -821,7 +827,7 @@ const Scrollbar = defineComponent({
     const triggerIsNone = this.trigger === 'none'
     const createYRail = (
       className: string | undefined,
-      style: CSSProperties | undefined
+      style?: StyleValue
     ): VNode => {
       return (
         <div
@@ -833,7 +839,7 @@ const Scrollbar = defineComponent({
             className
           ]}
           data-scrollbar-rail
-          style={[style || '', this.verticalRailStyle as CSSProperties]}
+          style={[style, this.verticalRailStyle]}
           aria-hidden
         >
           {h(

--- a/src/_internal/scrollbar/src/Scrollbar.tsx
+++ b/src/_internal/scrollbar/src/Scrollbar.tsx
@@ -1,10 +1,4 @@
-import type {
-  CSSProperties,
-  HTMLAttributes,
-  PropType,
-  StyleValue,
-  VNode
-} from 'vue'
+import type { HTMLAttributes, PropType, StyleValue, VNode } from 'vue'
 import type { ThemeProps } from '../../../_mixins'
 import type {
   ExtractInternalPropTypes,
@@ -100,11 +94,11 @@ const scrollbarProps = {
   container: Function as PropType<() => HTMLElement | null | undefined>,
   content: Function as PropType<() => HTMLElement | null | undefined>,
   containerClass: String,
-  containerStyle: [String, Object] as PropType<string | CSSProperties>,
+  containerStyle: Object as PropType<StyleValue>,
   contentClass: [String, Array] as PropType<string | Array<string | undefined>>,
-  contentStyle: [String, Object] as PropType<string | CSSProperties>,
-  horizontalRailStyle: [String, Object] as PropType<string | CSSProperties>,
-  verticalRailStyle: [String, Object] as PropType<string | CSSProperties>,
+  contentStyle: Object as PropType<StyleValue>,
+  horizontalRailStyle: Object as PropType<StyleValue>,
+  verticalRailStyle: Object as PropType<StyleValue>,
   onScroll: Function as PropType<(e: Event) => void>,
   onWheel: Function as PropType<(e: WheelEvent) => void>,
   onResize: Function as PropType<(e: ResizeObserverEntry) => void>,
@@ -903,14 +897,12 @@ const Scrollbar = defineComponent({
                     <div
                       ref="contentRef"
                       role="none"
-                      style={
-                        [
-                          {
-                            width: this.xScrollable ? 'fit-content' : null
-                          },
-                          this.contentStyle
-                        ] as any
-                      }
+                      style={[
+                        {
+                          width: this.xScrollable ? 'fit-content' : undefined
+                        },
+                        this.contentStyle
+                      ]}
                       class={[
                         `${mergedClsPrefix}-scrollbar-content`,
                         this.contentClass

--- a/src/_internal/select-menu/src/SelectMenu.tsx
+++ b/src/_internal/select-menu/src/SelectMenu.tsx
@@ -18,7 +18,6 @@ import { depx, getPadding, happensIn } from 'seemly'
 import { createIndexGetter, type TreeNode } from 'treemate'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   nextTick,
@@ -476,7 +475,7 @@ export default defineComponent({
           themeClass,
           this.multiple && `${clsPrefix}-base-select-menu--multiple`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onFocusin={this.handleFocusin}
         onFocusout={this.handleFocusout}
         onKeyup={this.handleKeyUp}

--- a/src/_internal/selection/src/Selection.tsx
+++ b/src/_internal/selection/src/Selection.tsx
@@ -11,7 +11,6 @@ import type { RenderTag } from './interface'
 import { getPadding } from 'seemly'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   h,
@@ -985,7 +984,7 @@ export default defineComponent({
             [`${clsPrefix}-base-selection--focus`]: this.focused
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onClick={this.onClick}
         onMouseenter={this.handleMouseEnter}
         onMouseleave={this.handleMouseLeave}

--- a/src/affix/src/Affix.tsx
+++ b/src/affix/src/Affix.tsx
@@ -3,13 +3,13 @@ import type { ScrollTarget } from './utils'
 import { beforeNextFrameOnce, unwrapElement } from 'seemly'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   onBeforeUnmount,
   onMounted,
   type PropType,
-  ref
+  ref,
+  type StyleValue
 } from 'vue'
 import { useConfig, useStyle } from '../../_mixins'
 import { keysOf, warn } from '../../_utils'
@@ -184,8 +184,8 @@ export default defineComponent({
       selfRef,
       affixed: affixedRef,
       mergedClsPrefix: mergedClsPrefixRef,
-      mergedstyle: computed<CSSProperties>(() => {
-        const style: CSSProperties = {}
+      mergedstyle: computed<StyleValue>(() => {
+        const style: StyleValue = {}
         if (
           stickToTopRef.value
           && mergedOffsetTopRef.value !== undefined

--- a/src/anchor/src/AnchorAdapter.tsx
+++ b/src/anchor/src/AnchorAdapter.tsx
@@ -2,7 +2,7 @@ import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { AnchorTheme } from '../styles'
 import type { BaseAnchorInst } from './BaseAnchor'
-import { computed, type CSSProperties, defineComponent, h, ref } from 'vue'
+import { computed, defineComponent, h, ref } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { keep } from '../../_utils'
 import { NAffix } from '../../affix'
@@ -82,11 +82,7 @@ export default defineComponent({
         return (
           <NBaseAnchor
             ref={anchorRef}
-            style={
-              inlineThemeDisabled
-                ? undefined
-                : (cssVarsRef.value as CSSProperties)
-            }
+            style={inlineThemeDisabled ? undefined : cssVarsRef.value}
             class={themeClassHandle?.themeClass.value}
             {...keep(props, baseAnchorPropKeys)}
             mergedClsPrefix={mergedClsPrefixRef.value}

--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -27,7 +27,6 @@ import { clickoutside } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type HTMLAttributes,
@@ -451,10 +450,7 @@ export default defineComponent({
                                 this.themeClass,
                                 menuProps?.class
                               ]}
-                              style={[
-                                menuProps?.style,
-                                this.cssVars as CSSProperties
-                              ]}
+                              style={[menuProps?.style, this.cssVars]}
                               treeMate={this.treeMate}
                               multiple={false}
                               renderLabel={this.renderLabel}

--- a/src/avatar-group/src/AvatarGroup.tsx
+++ b/src/avatar-group/src/AvatarGroup.tsx
@@ -9,12 +9,12 @@ import type {
 } from './public-types'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
   provide,
   type SlotsType,
+  type StyleValue,
   type VNode
 } from 'vue'
 import { useConfig, useTheme } from '../../_mixins'
@@ -31,7 +31,7 @@ export interface AvatarGroupInjection {
 export const avatarGroupProps = {
   ...(useTheme.props as ThemeProps<AvatarGroupTheme>),
   max: Number,
-  maxStyle: [Object, String] as PropType<CSSProperties | string>,
+  maxStyle: Object as PropType<StyleValue>,
   options: {
     type: Array as PropType<AvatarGroupOption[]>,
     default: () => []

--- a/src/avatar-group/src/generic-public-types.ts
+++ b/src/avatar-group/src/generic-public-types.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, VNode } from 'vue'
+import type { StyleValue, VNode } from 'vue'
 import type { Equal, Expect, ThemeRelatedProps } from '../../_utils'
 import type { Size } from '../../avatar/src/interface'
 import type { AvatarGroupProps } from './AvatarGroup'
@@ -16,7 +16,7 @@ interface ResolvableAvatarGroupProps<
   expandOnHover?: boolean
   size?: Size
   max?: number
-  maxStyle?: string | CSSProperties
+  maxStyle?: StyleValue
 }
 
 // eslint-disable-next-line ts/ban-ts-comment

--- a/src/badge/src/Badge.tsx
+++ b/src/badge/src/Badge.tsx
@@ -3,7 +3,6 @@ import type { ExtractPublicPropTypes } from '../../_utils'
 import type { BadgeTheme } from '../styles'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   onMounted,
@@ -162,7 +161,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-badge--as-is`]: !children
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {children}
         <Transition

--- a/src/breadcrumb/src/Breadcrumb.tsx
+++ b/src/breadcrumb/src/Breadcrumb.tsx
@@ -1,14 +1,6 @@
 import type { ThemeProps } from '../../_mixins'
 import type { BreadcrumbTheme } from '../styles'
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  provide,
-  type Ref,
-  toRef
-} from 'vue'
+import { computed, defineComponent, h, provide, type Ref, toRef } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { createInjectionKey, type ExtractPublicPropTypes } from '../../_utils'
 import { breadcrumbLight } from '../styles'
@@ -96,7 +88,7 @@ export default defineComponent({
     return (
       <nav
         class={[`${this.mergedClsPrefix}-breadcrumb`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         aria-label="Breadcrumb"
       >
         <ul>{this.$slots}</ul>

--- a/src/button/src/Button.tsx
+++ b/src/button/src/Button.tsx
@@ -8,7 +8,6 @@ import { useMemo } from 'vooks'
 import {
   type ButtonHTMLAttributes,
   computed,
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   h,
@@ -605,7 +604,7 @@ const Button = defineComponent({
         ]}
         tabindex={this.mergedFocusable ? 0 : -1}
         type={this.attrType}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         disabled={this.disabled}
         onClick={this.handleClick}
         onBlur={this.handleBlur}
@@ -661,14 +660,14 @@ const Button = defineComponent({
           <div
             aria-hidden
             class={`${mergedClsPrefix}-button__border`}
-            style={this.customColorCssVars as CSSProperties}
+            style={this.customColorCssVars}
           />
         ) : null}
         {this.showBorder ? (
           <div
             aria-hidden
             class={`${mergedClsPrefix}-button__state-border`}
-            style={this.customColorCssVars as CSSProperties}
+            style={this.customColorCssVars}
           />
         ) : null}
       </Component>

--- a/src/calendar/src/Calendar.tsx
+++ b/src/calendar/src/Calendar.tsx
@@ -227,7 +227,7 @@ export default defineComponent({
     return (
       <div
         class={[`${mergedClsPrefix}-calendar`, this.themeClass]}
-        style={cssVars as CSSProperties}
+        style={cssVars}
       >
         <div class={`${mergedClsPrefix}-calendar-header`}>
           <div class={`${mergedClsPrefix}-calendar-header__title`}>

--- a/src/calendar/src/Calendar.tsx
+++ b/src/calendar/src/Calendar.tsx
@@ -19,7 +19,6 @@ import {
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   h,

--- a/src/card/src/Card.tsx
+++ b/src/card/src/Card.tsx
@@ -233,7 +233,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-card--hoverable`]: hoverable
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         role={this.role}
       >
         {resolveWrappedSlot($slots.cover, (children) => {

--- a/src/carousel/src/Carousel.tsx
+++ b/src/carousel/src/Carousel.tsx
@@ -1010,7 +1010,7 @@ export default defineComponent({
           `${mergedClsPrefix}-carousel--${this.effect}`,
           userWantsControl && `${mergedClsPrefix}-carousel--usercontrol`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         {...slidesControlListeners}
         onMouseenter={this.handleMouseenter}
         onMouseleave={this.handleMouseleave}

--- a/src/carousel/src/Carousel.tsx
+++ b/src/carousel/src/Carousel.tsx
@@ -3,6 +3,7 @@ import type {
   PropType,
   Ref,
   SlotsType,
+  StyleValue,
   TransitionProps,
   VNode
 } from 'vue'
@@ -130,8 +131,8 @@ export const carouselProps = {
   },
   transitionProps: Object as PropType<TransitionProps>,
   draggable: Boolean,
-  prevSlideStyle: [Object, String] as PropType<CSSProperties | string>,
-  nextSlideStyle: [Object, String] as PropType<CSSProperties | string>,
+  prevSlideStyle: Object as PropType<StyleValue>,
+  nextSlideStyle: Object as PropType<StyleValue>,
   touchable: {
     type: Boolean,
     default: true
@@ -280,7 +281,7 @@ export default defineComponent({
       }
       const { effect, spaceBetween } = props
       const { value: spaceAxis } = spaceAxisRef
-      return slidesEls.reduce<CSSProperties[]>((styles, _, i) => {
+      return slidesEls.reduce<StyleValue[]>((styles, _, i) => {
         const style = {
           ...getSlideSize(i),
           [`margin-${spaceAxis}`]: `${spaceBetween}px`
@@ -438,7 +439,7 @@ export default defineComponent({
 
     // record the translate of each slide, so that it can be restored at touch
     let previousTranslate = 0
-    const translateStyleRef = ref({}) as Ref<CSSProperties>
+    const translateStyleRef = ref({}) as Ref<TransitionStyle>
     function updateTranslate(translate: number, speed = 0): void {
       translateStyleRef.value = Object.assign({}, transitionStyleRef.value, {
         transform: verticalRef.value
@@ -545,7 +546,7 @@ export default defineComponent({
     ): string | Record<string, string | number> | undefined {
       const index = getSlideIndex(slide)
       if (index !== -1) {
-        const styles: any[] = [slideStylesRef.value[index]]
+        const styles = [slideStylesRef.value[index]]
         const isPrev = carouselContext.isPrev(index)
         const isNext = carouselContext.isNext(index)
         if (isPrev) {

--- a/src/cascader/src/Cascader.tsx
+++ b/src/cascader/src/Cascader.tsx
@@ -1153,10 +1153,7 @@ export default defineComponent({
                         value={this.mergedValue}
                         show={this.mergedShow && !this.showSelectMenu}
                         menuModel={this.menuModel}
-                        style={[
-                          this.cssVars as CSSProperties,
-                          menuProps?.style
-                        ]}
+                        style={[this.cssVars, menuProps?.style]}
                         onFocus={this.handleMenuFocus}
                         onBlur={this.handleMenuBlur}
                         onKeydown={this.handleMenuKeydown}
@@ -1199,10 +1196,7 @@ export default defineComponent({
                         filter={this.filter}
                         labelField={this.labelField}
                         separator={this.separator}
-                        style={[
-                          this.cssVars as CSSProperties,
-                          filterMenuProps?.style
-                        ]}
+                        style={[this.cssVars, filterMenuProps?.style]}
                       />
                     )
                   }

--- a/src/cascader/src/Cascader.tsx
+++ b/src/cascader/src/Cascader.tsx
@@ -9,6 +9,7 @@ import type {
   CascaderInst,
   CascaderMenuInstance,
   CascaderOption,
+  ColumnStyleGetter,
   ExpandTrigger,
   Filter,
   Key,
@@ -27,7 +28,6 @@ import {
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type HTMLAttributes,
@@ -171,9 +171,7 @@ export const cascaderProps = {
   >,
   onBlur: Function as PropType<(e: FocusEvent) => void>,
   onFocus: Function as PropType<(e: FocusEvent) => void>,
-  getColumnStyle: Function as PropType<
-    (detail: { level: number }) => string | CSSProperties
-  >,
+  getColumnStyle: Function as PropType<ColumnStyleGetter>,
   renderPrefix: Function as PropType<
     (props: {
       option: CascaderOption

--- a/src/cascader/src/interface.ts
+++ b/src/cascader/src/interface.ts
@@ -1,5 +1,5 @@
 import type { CheckStrategy, TreeNode } from 'treemate'
-import type { CSSProperties, Ref, Slots, VNode, VNodeChild } from 'vue'
+import type { Ref, Slots, StyleValue, VNode, VNodeChild } from 'vue'
 import type { MergedTheme } from '../../_mixins'
 import type { NLocale } from '../../locales'
 import type { CascaderTheme } from '../styles'
@@ -56,6 +56,8 @@ export type OnUpdateValueImpl = (
 
 export type MenuModel = TmNode[][]
 
+export type ColumnStyleGetter = (detail: { level: number }) => StyleValue
+
 export interface CascaderInjection {
   slots: Slots
   mergedClsPrefixRef: Ref<string>
@@ -79,9 +81,7 @@ export interface CascaderInjection {
   optionHeightRef: Ref<string>
   labelFieldRef: Ref<string>
   showCheckboxRef: Ref<boolean>
-  getColumnStyleRef: Ref<
-    ((detail: { level: number }) => string | CSSProperties) | undefined
-  >
+  getColumnStyleRef: Ref<ColumnStyleGetter | undefined>
   renderPrefixRef: Ref<
     | ((info: {
       option: CascaderOption

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -10,7 +10,6 @@ import { createId } from 'seemly'
 import { useMemo, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -361,7 +360,7 @@ export default defineComponent({
         role="checkbox"
         aria-checked={indeterminate ? 'mixed' : renderedChecked}
         aria-labelledby={labelId}
-        style={cssVars as CSSProperties}
+        style={cssVars}
         onKeyup={handleKeyUp}
         onKeydown={handleKeyDown}
         onClick={handleClick}

--- a/src/collapse/src/Collapse.tsx
+++ b/src/collapse/src/Collapse.tsx
@@ -13,7 +13,6 @@ import type {
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   h,
@@ -259,7 +258,7 @@ export default defineComponent({
           this.rtlEnabled && `${this.mergedClsPrefix}-collapse--rtl`,
           this.themeClass
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </div>

--- a/src/color-picker/src/ColorPicker.tsx
+++ b/src/color-picker/src/ColorPicker.tsx
@@ -35,7 +35,6 @@ import { clickoutside } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   nextTick,
@@ -558,11 +557,7 @@ export default defineComponent({
           onDragstart={(e) => {
             e.preventDefault()
           }}
-          style={
-            inlineThemeDisabled
-              ? undefined
-              : (cssVarsRef.value as CSSProperties)
-          }
+          style={inlineThemeDisabled ? undefined : cssVarsRef.value}
         >
           <div class={`${mergedClsPrefix}-color-picker-control`}>
             <Pallete
@@ -715,7 +710,7 @@ export default defineComponent({
       <div
         class={[this.themeClass, `${mergedClsPrefix}-color-picker`]}
         ref="selfRef"
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <VBinder>
           {{

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -272,7 +272,7 @@ export default defineComponent({
           '--n-action-padding': actionPadding,
           '--n-action-button-margin': actionButtonMargin,
           '--n-action-divider-color': actionDividerColor
-        } satisfies CSSProperties
+        }
       }),
       onLoadRef: toRef(props, 'onLoad'),
       mergedTableLayoutRef,
@@ -476,7 +476,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-data-table--flex-height`]: this.flexHeight
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div class={`${mergedClsPrefix}-data-table-wrapper`}>
           <MainTable ref="mainTableInstRef" />

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -8,7 +8,6 @@ import type {
 import { createId } from 'seemly'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   provide,

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -872,7 +872,7 @@ export default defineComponent({
                             left: pxfy(fixedColumnLeftMap[colKey]?.start),
                             right: pxfy(fixedColumnRightMap[colKey]?.start)
                           },
-                      indentOffsetStyle as CSSProperties,
+                      indentOffsetStyle,
                       resolvedCellProps?.style || ''
                     ]}
                     colspan={mergedColSpan}

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -1,5 +1,5 @@
 import type { CNode } from 'css-render'
-import type { CSSProperties, PropType, VNode, VNodeChild } from 'vue'
+import type { PropType, StyleValue, VNode, VNodeChild } from 'vue'
 import type { VirtualListInst } from 'vueuc'
 import type { ColItem } from '../use-group-header'
 import { pxfy, repeat } from 'seemly'
@@ -151,7 +151,7 @@ export default defineComponent({
     onResize: Function as PropType<(e: ResizeObserverEntry) => void>,
     showHeader: Boolean,
     flexHeight: Boolean,
-    bodyStyle: Object as PropType<CSSProperties>
+    bodyStyle: Object as PropType<StyleValue>
   },
   setup(props) {
     const {
@@ -551,7 +551,7 @@ export default defineComponent({
     const isBasicAutoLayout = !scrollable && mergedTableLayout === 'auto'
     const xScrollable = scrollX !== undefined || isBasicAutoLayout
 
-    const contentStyle: CSSProperties = {
+    const contentStyle: StyleValue = {
       minWidth: formatLength(scrollX) || '100%'
     }
     if (scrollX)

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -1,10 +1,10 @@
 import type { TreeMate, TreeNode } from 'treemate'
 import type {
-  CSSProperties,
   ExtractPropTypes,
   HTMLAttributes,
   PropType,
   Ref,
+  StyleValue,
   VNode,
   VNodeChild
 } from 'vue'
@@ -398,7 +398,7 @@ export interface DataTableInjection {
   mergedCheckedRowKeySetRef: Ref<Set<RowKey>>
   mergedInderminateRowKeySetRef: Ref<Set<RowKey>>
   localeRef: Ref<NLocale['DataTable']>
-  filterMenuCssVarsRef: Ref<CSSProperties>
+  filterMenuCssVarsRef: Ref<StyleValue>
   mergedExpandedRowKeysRef: Ref<RowKey[]>
   rowKeyRef: Ref<CreateRowKey | undefined>
   renderExpandRef: Ref<undefined | RenderExpand>

--- a/src/data-table/src/use-group-header.ts
+++ b/src/data-table/src/use-group-header.ts
@@ -7,7 +7,7 @@ import type {
   TableExpandColumn,
   TableSelectionColumn
 } from './interface'
-import { computed, type ComputedRef, type CSSProperties } from 'vue'
+import { computed, type ComputedRef, type StyleValue } from 'vue'
 import { formatLength } from '../../_utils'
 import { createCustomWidthStyle, getColKey } from './utils'
 
@@ -20,7 +20,7 @@ export interface RowItem {
 }
 export interface ColItem {
   key: string | number
-  style: CSSProperties
+  style: StyleValue
   column: TableSelectionColumn | TableExpandColumn | TableBaseColumn
   index: number
   /**

--- a/src/data-table/src/utils.ts
+++ b/src/data-table/src/utils.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'vue'
+import type { StyleValue } from 'vue'
 import type {
   CreateRowClassName,
   InternalRowData,
@@ -95,7 +95,7 @@ export function clampValueFollowCSSRules(
 export function createCustomWidthStyle(
   column: TableBaseColumn | TableSelectionColumn | TableExpandColumn,
   resizedWidth?: string
-): CSSProperties {
+): StyleValue {
   if (resizedWidth !== undefined) {
     return {
       width: resizedWidth,

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -16,7 +16,6 @@ import { clickoutside } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   h,
@@ -24,6 +23,7 @@ import {
   type Ref,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   Transition,
   type VNode,
@@ -958,7 +958,7 @@ export default defineComponent({
     const { clearable, triggerOnRender, mergedClsPrefix, $slots } = this
     const commonPanelProps: UsePanelCommonProps & {
       ref: string
-      style: CSSProperties
+      style: StyleValue
     } = {
       onUpdateValue: this.handlePanelUpdateValue,
       onTabOut: this.handlePanelTabOut,
@@ -971,7 +971,7 @@ export default defineComponent({
       active: this.mergedShow,
       actions: this.actions,
       shortcuts: this.shortcuts,
-      style: this.cssVars as CSSProperties,
+      style: this.cssVars,
       defaultTime: this.defaultTime,
       themeClass: this.themeClass,
       panel: this.panel,
@@ -1060,7 +1060,7 @@ export default defineComponent({
           this.isRange && `${mergedClsPrefix}-date-picker--range`,
           this.triggerThemeClass
         ]}
-        style={this.triggerCssVars as CSSProperties}
+        style={this.triggerCssVars}
         onKeydown={this.handleKeydown}
       >
         <VBinder>

--- a/src/descriptions/src/Descriptions.tsx
+++ b/src/descriptions/src/Descriptions.tsx
@@ -5,11 +5,11 @@ import { repeat } from 'seemly'
 import { useCompitable } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
   type SlotsType,
+  type StyleValue,
   type VNode
 } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
@@ -50,9 +50,9 @@ export const descriptionsProps = {
   },
   bordered: Boolean,
   labelClass: String,
-  labelStyle: [Object, String] as PropType<string | CSSProperties>,
+  labelStyle: Object as PropType<StyleValue>,
   contentClass: String,
-  contentStyle: [Object, String] as PropType<string | CSSProperties>
+  contentStyle: Object as PropType<StyleValue>
 } as const
 
 export type DescriptionsProps = ExtractPublicPropTypes<typeof descriptionsProps>
@@ -318,7 +318,7 @@ export default defineComponent({
     ))
     return (
       <div
-        style={cssVars as any}
+        style={cssVars}
         class={[
           `${mergedClsPrefix}-descriptions`,
           this.themeClass,

--- a/src/descriptions/src/DescriptionsItem.ts
+++ b/src/descriptions/src/DescriptionsItem.ts
@@ -1,9 +1,9 @@
 import type { ExtractPublicPropTypes } from '../../_utils'
 import {
-  type CSSProperties,
   defineComponent,
   type PropType,
   type SlotsType,
+  type StyleValue,
   type VNode
 } from 'vue'
 import { DESCRIPTION_ITEM_FLAG } from './utils'
@@ -15,9 +15,9 @@ export const descriptionsItemProps = {
     default: 1
   },
   labelClass: String,
-  labelStyle: [Object, String] as PropType<string | CSSProperties>,
+  labelStyle: Object as PropType<StyleValue>,
   contentClass: String,
-  contentStyle: [Object, String] as PropType<string | CSSProperties>
+  contentStyle: Object as PropType<StyleValue>
 } as const
 
 export type DescriptionItemProps = ExtractPublicPropTypes<

--- a/src/dialog/src/Dialog.tsx
+++ b/src/dialog/src/Dialog.tsx
@@ -276,7 +276,7 @@ export const NDialog = defineComponent({
           bordered && `${mergedClsPrefix}-dialog--bordered`,
           this.rtlEnabled && `${mergedClsPrefix}-dialog--rtl`
         ]}
-        style={cssVars as CSSProperties}
+        style={cssVars}
         role="dialog"
       >
         {closable

--- a/src/dialog/src/Dialog.tsx
+++ b/src/dialog/src/Dialog.tsx
@@ -1,14 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { DialogTheme } from '../styles'
 import { getMargin } from 'seemly'
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  type SlotsType,
-  type VNode
-} from 'vue'
+import { computed, defineComponent, h, type SlotsType, type VNode } from 'vue'
 import { NBaseClose, NBaseIcon } from '../../_internal'
 import {
   ErrorIcon,

--- a/src/divider/src/Divider.tsx
+++ b/src/divider/src/Divider.tsx
@@ -1,14 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { DividerTheme } from '../styles'
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  Fragment,
-  h,
-  type PropType
-} from 'vue'
+import { computed, defineComponent, Fragment, h, type PropType } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { dividerLight } from '../styles'
 import style from './styles/index.cssr'
@@ -84,7 +77,7 @@ export default defineComponent({
               $slots.default && titlePlacement
           }
         ]}
-        style={cssVars as CSSProperties}
+        style={cssVars}
       >
         {!vertical ? (
           <div

--- a/src/drawer/src/Drawer.tsx
+++ b/src/drawer/src/Drawer.tsx
@@ -6,12 +6,12 @@ import { zindexable } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
   provide,
   ref,
+  type StyleValue,
   toRef,
   Transition,
   watchEffect,
@@ -61,7 +61,7 @@ export const drawerProps = {
   onMaskClick: Function as PropType<(e: MouseEvent) => void>,
   scrollbarProps: Object as PropType<ScrollbarProps>,
   contentClass: String,
-  contentStyle: [Object, String] as PropType<string | CSSProperties>,
+  contentStyle: Object as PropType<StyleValue>,
   trapFocus: {
     type: Boolean,
     default: true
@@ -113,7 +113,7 @@ export const drawerProps = {
   onAfterEnter: Function as PropType<() => void>,
   onAfterLeave: Function as PropType<() => void>,
   /** @deprecated */
-  drawerStyle: [String, Object] as PropType<string | CSSProperties>,
+  drawerStyle: Object as PropType<StyleValue>,
   drawerClass: String,
   target: null,
   onShow: Function as PropType<(value: boolean) => void>,
@@ -213,7 +213,7 @@ export default defineComponent({
       uncontrolledHeightRef.value = value
     }
 
-    const mergedBodyStyleRef = computed<Array<CSSProperties | string>>(() => {
+    const mergedBodyStyleRef = computed<StyleValue>(() => {
       return [
         {
           width: styleWidthRef.value,

--- a/src/drawer/src/Drawer.tsx
+++ b/src/drawer/src/Drawer.tsx
@@ -351,7 +351,7 @@ export default defineComponent({
                   this.namespace,
                   this.themeClass
                 ]}
-                style={this.cssVars as CSSProperties}
+                style={this.cssVars}
                 role="none"
               >
                 {this.showMask ? (

--- a/src/drawer/src/DrawerBodyWrapper.tsx
+++ b/src/drawer/src/DrawerBodyWrapper.tsx
@@ -1,15 +1,13 @@
+import type { DirectiveArguments, PropType, StyleValue } from 'vue'
 import type { ScrollbarProps } from '../../_internal'
 import { clickoutside } from 'vdirs'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
-  type DirectiveArguments,
   h,
   inject,
   mergeProps,
   onBeforeUnmount,
-  type PropType,
   provide,
   ref,
   Transition,
@@ -46,7 +44,7 @@ export default defineComponent({
       required: true
     },
     contentClass: String,
-    contentStyle: [Object, String] as PropType<string | CSSProperties>,
+    contentStyle: Object as PropType<StyleValue>,
     nativeScrollbar: {
       type: Boolean,
       required: true

--- a/src/drawer/src/DrawerContent.tsx
+++ b/src/drawer/src/DrawerContent.tsx
@@ -1,12 +1,12 @@
 import type { ScrollbarProps } from '../../_internal'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import {
-  type CSSProperties,
   defineComponent,
   h,
   inject,
   type PropType,
   type SlotsType,
+  type StyleValue,
   type VNode
 } from 'vue'
 import { NBaseClose, NScrollbar } from '../../_internal'
@@ -16,13 +16,13 @@ import { drawerInjectionKey } from './interface'
 export const drawerContentProps = {
   title: String,
   headerClass: String,
-  headerStyle: [Object, String] as PropType<string | CSSProperties>,
+  headerStyle: Object as PropType<StyleValue>,
   footerClass: String,
-  footerStyle: [Object, String] as PropType<string | CSSProperties>,
+  footerStyle: Object as PropType<StyleValue>,
   bodyClass: String,
-  bodyStyle: [Object, String] as PropType<string | CSSProperties>,
+  bodyStyle: Object as PropType<StyleValue>,
   bodyContentClass: String,
-  bodyContentStyle: [Object, String] as PropType<string | CSSProperties>,
+  bodyContentStyle: Object as PropType<StyleValue>,
   nativeScrollbar: { type: Boolean, default: true },
   scrollbarProps: Object as PropType<ScrollbarProps>,
   closable: Boolean

--- a/src/dropdown/src/DropdownMenu.tsx
+++ b/src/dropdown/src/DropdownMenu.tsx
@@ -7,14 +7,14 @@ import type {
 } from './interface'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
   type PropType,
   provide,
   type Ref,
-  ref
+  ref,
+  type StyleValue
 } from 'vue'
 import { NxScrollbar } from '../../_internal/scrollbar'
 import { drawerBodyInjectionKey } from '../../drawer/src/interface'
@@ -45,7 +45,7 @@ export default defineComponent({
   props: {
     scrollable: Boolean,
     showArrow: Boolean,
-    arrowStyle: [String, Object] as PropType<string | CSSProperties>,
+    arrowStyle: Object as PropType<StyleValue>,
     clsPrefix: {
       type: String,
       required: true

--- a/src/dynamic-input/src/DynamicInput.tsx
+++ b/src/dynamic-input/src/DynamicInput.tsx
@@ -11,7 +11,6 @@ import { createId } from 'seemly'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -19,6 +18,7 @@ import {
   type PropType,
   provide,
   ref,
+  type StyleValue,
   toRaw,
   toRef,
   type VNode,
@@ -69,7 +69,7 @@ export const dynamicInputProps = {
   },
   keyField: String,
   itemClass: String,
-  itemStyle: [String, Object] as PropType<string | CSSProperties>,
+  itemStyle: Object as PropType<StyleValue>,
   // for preset pair
   keyPlaceholder: {
     type: String,

--- a/src/dynamic-input/src/DynamicInput.tsx
+++ b/src/dynamic-input/src/DynamicInput.tsx
@@ -360,7 +360,7 @@ export default defineComponent({
           this.rtlEnabled && `${mergedClsPrefix}-dynamic-input--rtl`,
           this.themeClass
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {!Array.isArray(mergedValue) || mergedValue.length === 0 ? (
           <NButton

--- a/src/dynamic-tags/src/DynamicTags.tsx
+++ b/src/dynamic-tags/src/DynamicTags.tsx
@@ -13,13 +13,13 @@ import type {
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   nextTick,
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   type VNode,
   type VNodeChild,
@@ -60,11 +60,11 @@ export const dynamicTagsProps = {
   },
   value: Array as PropType<Array<string | DynamicTagsOption>>,
   inputClass: String,
-  inputStyle: [String, Object] as PropType<string | CSSProperties>,
+  inputStyle: Object as PropType<StyleValue>,
   inputProps: Object as PropType<InputProps>,
   max: Number as PropType<number>,
   tagClass: String,
-  tagStyle: [String, Object] as PropType<string | CSSProperties>,
+  tagStyle: Object as PropType<StyleValue>,
   renderTag: Function as PropType<
     | ((tag: string, index: number) => VNodeChild)
     | ((tag: DynamicTagsOption, index: number) => VNodeChild)

--- a/src/float-button-group/src/FloatButtonGroup.tsx
+++ b/src/float-button-group/src/FloatButtonGroup.tsx
@@ -1,6 +1,5 @@
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -106,7 +105,7 @@ export default defineComponent({
           `${mergedClsPrefix}-float-button-group`,
           `${mergedClsPrefix}-float-button-group--${shape}-shape`
         ]}
-        style={cssVars as CSSProperties}
+        style={cssVars}
         role="group"
       >
         {this.$slots}

--- a/src/float-button/src/FloatButton.tsx
+++ b/src/float-button/src/FloatButton.tsx
@@ -2,7 +2,6 @@ import { off, on } from 'evtd'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -11,6 +10,7 @@ import {
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   type VNode
 } from 'vue'
@@ -143,7 +143,7 @@ export default defineComponent({
         '--n-border-radius-square': borderRadiusSquare
       }
     })
-    const inlineStyle = computed<CSSProperties>(() => {
+    const inlineStyle = computed<StyleValue>(() => {
       const { width, height } = props
       return {
         position: floatButtonGroupInjection ? undefined : props.position,

--- a/src/float-button/src/FloatButton.tsx
+++ b/src/float-button/src/FloatButton.tsx
@@ -246,7 +246,7 @@ export default defineComponent({
           mergedShowMenu && `${mergedClsPrefix}-float-button--show-menu`,
           themeClass
         ]}
-        style={[cssVars as CSSProperties, inlineStyle]}
+        style={[cssVars, inlineStyle]}
         onMouseenter={this.Mouseenter}
         onMouseleave={this.handleMouseleave}
         onClick={this.handleClick}

--- a/src/form/demos/enUS/index.demo-entry.md
+++ b/src/form/demos/enUS/index.demo-entry.md
@@ -84,7 +84,7 @@ feedback-style.vue
 | label-align | `'left' \| 'right'` | `undefined` | Text alignment inside the label. If not set, it will inherit the parent form's `label-align`. |  |
 | label-placement | `'left' \| 'top'` | `undefined` | If not set, it will inherit the parent form's `label-placement`. |  |
 | label-props | `LabelHTMLAttributes` | `undefined` | HTML attributes of the label element inside form item. | 2.24.0 |
-| label-style | `CSSProperties \| string` | `undefined` | Label style. |  |
+| label-style | `StyleValue` | Label style. |  |
 | label-width | `number \| string \| 'auto'` | `undefined` | If not set, it will inherit the parent form's `label-width`,`'auto'` means label width will be auto adjusted. |  |
 | path | `string` | `undefined` | The path to use in the parent form's model object. |  |
 | required | `boolean` | `false` | Whether to show the "required" symbol. Note: a required rule has higher priority than this prop & this prop **won't** have any effect on validation. Validation still depends on rules. |  |

--- a/src/form/demos/zhCN/index.demo-entry.md
+++ b/src/form/demos/zhCN/index.demo-entry.md
@@ -77,7 +77,7 @@ feedback-style.vue
 | label | `string` | `undefined` | 标签信息 |  |
 | label-align | `'left' \| 'right'` | `undefined` | 标签的文本对齐方式。如果没有被设定，使用外层表单的 `label-align` |  |
 | label-placement | `'left' \| 'top'` | `undefined` | 如果没有被设定，使用外层表单的 `label-placement` |  |
-| label-style | `CSSProperties \| string` | `undefined` | 标签的样式 |  |
+| label-style | `StyleValue` | 标签的样式 |  |
 | label-props | `LabelHTMLAttributes` | `undefined` | 标签元素的属性 | 2.24.0 |
 | label-width | `number \| string \| 'auto'` | `undefined` | 如果没有被设定，使用外层表单的 `label-width`，`'auto'` 意味着 label width 会被自动调整 |  |
 | path | `string` | `undefined` | 将值收集到外层表单 `model` 对象的路径 |  |

--- a/src/form/src/FormItem.tsx
+++ b/src/form/src/FormItem.tsx
@@ -19,7 +19,6 @@ import { get } from 'lodash-es'
 import { createId } from 'seemly'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   h,
@@ -30,6 +29,7 @@ import {
   provide,
   ref,
   type Slot,
+  type StyleValue,
   toRef,
   Transition,
   type VNodeChild,
@@ -58,7 +58,7 @@ export const formItemProps = {
   ...(useTheme.props as ThemeProps<FormTheme>),
   label: String,
   labelWidth: [Number, String] as PropType<string | number>,
-  labelStyle: [String, Object] as PropType<CSSProperties | string>,
+  labelStyle: Object as PropType<StyleValue>,
   labelAlign: String as PropType<LabelAlign>,
   labelPlacement: String as PropType<LabelPlacement>,
   path: String,
@@ -80,7 +80,7 @@ export const formItemProps = {
   validationStatus: String as PropType<'error' | 'warning' | 'success'>,
   feedback: String,
   feedbackClass: String,
-  feedbackStyle: [String, Object] as PropType<string | CSSProperties>,
+  feedbackStyle: Object as PropType<StyleValue>,
   showLabel: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined

--- a/src/form/src/FormItem.tsx
+++ b/src/form/src/FormItem.tsx
@@ -604,7 +604,7 @@ export default defineComponent({
           && `${mergedClsPrefix}-form-item--auto-label-width`,
           !mergedShowLabel && `${mergedClsPrefix}-form-item--no-label`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {mergedShowLabel && renderLabel()}
         <div

--- a/src/grid/src/Grid.tsx
+++ b/src/grid/src/Grid.tsx
@@ -3,7 +3,6 @@ import { useBreakpoints, useMemo } from 'vooks'
 import {
   cloneVNode,
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   mergeProps,
@@ -12,6 +11,7 @@ import {
   provide,
   type Ref,
   ref,
+  type StyleValue,
   toRef,
   type VNode,
   vShow
@@ -49,7 +49,7 @@ export const gridProps = {
     type: Number,
     default: 1
   },
-  itemStyle: [Object, String] as PropType<CSSProperties | string>,
+  itemStyle: Object as PropType<StyleValue>,
   xGap: {
     type: [Number, String] as PropType<number | string>,
     default: 0
@@ -62,7 +62,7 @@ export const gridProps = {
 
 export interface NGridInjection {
   isSsrRef: Ref<boolean>
-  itemStyleRef: Ref<CSSProperties | string | undefined>
+  itemStyleRef: Ref<StyleValue>
   xGapRef: Ref<string | undefined>
   overflowRef: Ref<boolean>
   layoutShiftDisabledRef: Ref<boolean>
@@ -154,7 +154,7 @@ export default defineComponent({
       isSsr: !isBrowser,
       contentEl: contentElRef,
       mergedClsPrefix: mergedClsPrefixRef,
-      style: computed<CSSProperties>(() => {
+      style: computed<StyleValue>(() => {
         if (props.layoutShiftDisabled) {
           return {
             width: '100%',

--- a/src/highlight/src/Highlight.tsx
+++ b/src/highlight/src/Highlight.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, PropType, VNode, VNodeChild } from 'vue'
+import type { PropType, StyleValue, VNode, VNodeChild } from 'vue'
 import { computed, defineComponent, h } from 'vue'
 import { useConfig } from '../../_mixins'
 import { splitAndMarkByRegex } from './utils'
@@ -19,7 +19,7 @@ export const highlightProps = {
     default: () => []
   },
   highlightClass: String,
-  highlightStyle: [Object, String] as PropType<CSSProperties | string>
+  highlightStyle: Object as PropType<StyleValue>
 } as const
 
 export default defineComponent({

--- a/src/image/src/ImagePreview.tsx
+++ b/src/image/src/ImagePreview.tsx
@@ -7,7 +7,6 @@ import { zindexable } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   h,
@@ -643,7 +642,7 @@ export default defineComponent({
                     `${clsPrefix}-image-preview-container`,
                     this.themeClass
                   ]}
-                  style={this.cssVars as CSSProperties}
+                  style={this.cssVars}
                   onWheel={this.handleWheel}
                 >
                   <Transition name="fade-in-transition" appear={this.appear}>

--- a/src/input-otp/src/InputOtp.tsx
+++ b/src/input-otp/src/InputOtp.tsx
@@ -1,5 +1,5 @@
 import type { InputInst } from 'naive-ui'
-import type { CSSProperties, PropType, SlotsType } from 'vue'
+import type { PropType, SlotsType } from 'vue'
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes, MaybeArray } from '../../_utils'
 import type { FormValidationStatus } from '../../form/src/public-types'
@@ -348,7 +348,7 @@ export default defineComponent({
     onRender?.()
     return (
       <div
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         class={[
           `${mergedClsPrefix}-input-otp`,
           themeClass,

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -12,7 +12,6 @@ import { getPadding } from 'seemly'
 import { useMemo, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   getCurrentInstance,
@@ -1126,7 +1125,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-input--stateful`]: this.stateful
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         tabindex={
           !this.mergedDisabled && this.passivelyActivated && !this.activated
             ? 0
@@ -1338,7 +1337,7 @@ export default defineComponent({
                           loading={this.loading}
                           showArrow={false}
                           showClear={false}
-                          style={this.cssVars as CSSProperties}
+                          style={this.cssVars}
                         />
                       ) : null,
                       this.internalLoadingBeforeSuffix ? children : null,

--- a/src/layout/src/Layout.tsx
+++ b/src/layout/src/Layout.tsx
@@ -5,13 +5,13 @@ import type { LayoutTheme } from '../styles'
 import type { LayoutInst } from './interface'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   h,
   type PropType,
   provide,
-  ref
+  ref,
+  type StyleValue
 } from 'vue'
 import { NScrollbar } from '../../_internal'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
@@ -31,7 +31,7 @@ export const layoutProps = {
   onScroll: Function as PropType<(e: Event) => void>,
   contentClass: String,
   contentStyle: {
-    type: [String, Object] as PropType<string | CSSProperties>,
+    type: Object as PropType<StyleValue>,
     default: ''
   },
   hasSider: Boolean,
@@ -104,7 +104,7 @@ export function createLayoutComponent(isContent: boolean) {
           }
         }
       })
-      const hasSiderStyle: CSSProperties = {
+      const hasSiderStyle: StyleValue = {
         display: 'flex',
         flexWrap: 'nowrap',
         width: '100%',

--- a/src/layout/src/Layout.tsx
+++ b/src/layout/src/Layout.tsx
@@ -158,7 +158,7 @@ export function createLayoutComponent(isContent: boolean) {
         `${mergedClsPrefix}-layout--${this.position}-positioned`
       ]
       return (
-        <div class={layoutClass} style={this.cssVars as CSSProperties}>
+        <div class={layoutClass} style={this.cssVars}>
           {this.nativeScrollbar ? (
             <div
               ref="scrollableElRef"

--- a/src/layout/src/LayoutSider.tsx
+++ b/src/layout/src/LayoutSider.tsx
@@ -5,13 +5,13 @@ import type { LayoutTheme } from '../styles'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
   type PropType,
   provide,
   ref,
+  type StyleValue,
   toRef
 } from 'vue'
 import { NScrollbar } from '../../_internal'
@@ -41,7 +41,7 @@ export const layoutSiderProps = {
   },
   contentClass: String,
   contentStyle: {
-    type: [String, Object] as PropType<string | CSSProperties>,
+    type: Object as PropType<StyleValue>,
     default: ''
   },
   collapseMode: {
@@ -67,12 +67,12 @@ export const layoutSiderProps = {
   },
   inverted: Boolean,
   scrollbarProps: Object as PropType<
-    Partial<ScrollbarProps> & { style: CSSProperties }
+    Partial<ScrollbarProps> & { style: StyleValue }
   >,
   triggerClass: String,
-  triggerStyle: [String, Object] as PropType<string | CSSProperties>,
+  triggerStyle: Object as PropType<StyleValue>,
   collapsedTriggerClass: String,
-  collapsedTriggerStyle: [String, Object] as PropType<string | CSSProperties>,
+  collapsedTriggerStyle: Object as PropType<StyleValue>,
   'onUpdate:collapsed': [Function, Array] as PropType<
     MaybeArray<(value: boolean) => void>
   >,
@@ -125,7 +125,7 @@ export default defineComponent({
         mergedCollapsedRef.value ? props.collapsedWidth : props.width
       )
     })
-    const scrollContainerStyleRef = computed<CSSProperties>(() => {
+    const scrollContainerStyleRef = computed<StyleValue>(() => {
       if (props.collapseMode !== 'transform')
         return {}
       return {

--- a/src/legacy-transfer/src/Transfer.tsx
+++ b/src/legacy-transfer/src/Transfer.tsx
@@ -4,7 +4,6 @@ import { depx } from 'seemly'
 import { useIsMounted } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -315,7 +314,7 @@ export default defineComponent({
           this.mergedDisabled && `${mergedClsPrefix}-legacy-transfer--disabled`,
           this.filterable && `${mergedClsPrefix}-legacy-transfer--filterable`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div class={`${mergedClsPrefix}-legacy-transfer-list`}>
           <NTransferHeader

--- a/src/list/src/List.tsx
+++ b/src/list/src/List.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, PropType, Ref, SlotsType, VNode } from 'vue'
+import type { PropType, Ref, SlotsType, VNode } from 'vue'
 import type { ThemeProps } from '../../_mixins'
 import type { ListTheme } from '../styles'
 import { computed, defineComponent, h, provide, toRef } from 'vue'
@@ -117,7 +117,7 @@ export default defineComponent({
           this.clickable && `${mergedClsPrefix}-list--clickable`,
           this.themeClass
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {$slots.header ? (
           <div class={`${mergedClsPrefix}-list__header`}>{$slots.header()}</div>

--- a/src/loading-bar/src/LoadingBar.tsx
+++ b/src/loading-bar/src/LoadingBar.tsx
@@ -1,12 +1,12 @@
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
   nextTick,
   type PropType,
   ref,
+  type StyleValue,
   Transition,
   vShow,
   withDirectives
@@ -27,7 +27,7 @@ export default defineComponent({
   name: 'LoadingBar',
   props: {
     containerClass: String,
-    containerStyle: [String, Object] as PropType<string | CSSProperties>
+    containerStyle: Object as PropType<StyleValue>
   },
   setup() {
     const { inlineThemeDisabled } = useConfig()
@@ -199,10 +199,7 @@ export default defineComponent({
                 <div
                   ref="loadingBarRef"
                   class={[`${mergedClsPrefix}-loading-bar`]}
-                  style={[
-                    this.cssVars as any,
-                    this.mergedLoadingBarStyle as any
-                  ]}
+                  style={[this.cssVars, this.mergedLoadingBarStyle]}
                 />
               </div>,
               [[vShow, this.loading || (!this.loading && this.entering)]]

--- a/src/loading-bar/src/LoadingBarProvider.tsx
+++ b/src/loading-bar/src/LoadingBarProvider.tsx
@@ -3,7 +3,6 @@ import type { ExtractPublicPropTypes } from '../../_utils'
 import type { LoadingBarTheme } from '../styles'
 import { useIsMounted } from 'vooks'
 import {
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   Fragment,
@@ -12,6 +11,7 @@ import {
   type PropType,
   provide,
   ref,
+  type StyleValue,
   Teleport
 } from 'vue'
 import { useConfig, useTheme } from '../../_mixins'
@@ -37,11 +37,11 @@ export const loadingBarProviderProps = {
     default: undefined
   },
   containerClass: String,
-  containerStyle: [String, Object] as PropType<string | CSSProperties>,
+  containerStyle: Object as PropType<StyleValue>,
   loadingBarStyle: {
     type: Object as PropType<{
-      loading?: string | CSSProperties
-      error?: string | CSSProperties
+      loading?: StyleValue
+      error?: StyleValue
     }>
   }
 }

--- a/src/mention/src/Mention.tsx
+++ b/src/mention/src/Mention.tsx
@@ -16,13 +16,13 @@ import { createTreeMate, type TreeNode } from 'treemate'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   nextTick,
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   Transition,
   type VNode
@@ -476,7 +476,7 @@ export default defineComponent({
               <VTarget>
                 {{
                   default: () => {
-                    const style: CSSProperties = {
+                    const style: StyleValue = {
                       position: 'absolute',
                       width: 0
                     }
@@ -522,7 +522,7 @@ export default defineComponent({
                               loading={this.loading}
                               treeMate={this.treeMate}
                               virtualScroll={false}
-                              style={this.cssVars as any}
+                              style={this.cssVars}
                               onToggle={this.handleSelect}
                               renderLabel={this.renderLabel}
                             >

--- a/src/message/demos/enUS/index.demo-entry.md
+++ b/src/message/demos/enUS/index.demo-entry.md
@@ -60,7 +60,7 @@ no-icon.vue
 | --- | --- | --- | --- | --- |
 | closable | `boolean` | `false` | Whether to show close icon on all messages. |  |
 | container-class | `string` | `undefined` | Message container class. | 2.36.0 |
-| container-style | `string \| CSSProperties` | `undefined` | Message container style. |  |
+| container-style | `StyleValue` | Message container style. |  |
 | duration | `number` | `3000` | Default duration of on all messages. |  |
 | keep-alive-on-hover | `boolean` | `false` | Whether to destroy while hovering on all messages. |  |
 | max | `number` | `undefined` | Limit the number of messages to display. |  |

--- a/src/message/demos/zhCN/index.demo-entry.md
+++ b/src/message/demos/zhCN/index.demo-entry.md
@@ -61,7 +61,7 @@ rtl-debug.vue
 | --- | --- | --- | --- | --- |
 | closable | `boolean` | `false` | 所有 Message 是否显示 close 图标 |  |
 | container-class | `string` | `undefined` | Message 容器的类名 | 2.36.0 |
-| container-style | `string \| CSSProperties` | `undefined` | Message 容器的样式 |  |
+| container-style | `StyleValue` | Message 容器的样式 |  |
 | duration | `number` | `3000` | 所有 Message 默认的持续时长 |  |
 | keep-alive-on-hover | `boolean` | `false` | 所有 Message 在悬浮信息上时是否不销毁 |  |
 | max | `number` | `undefined` | 限制提示信息显示的个数 |  |

--- a/src/message/src/Message.tsx
+++ b/src/message/src/Message.tsx
@@ -2,7 +2,6 @@ import type { MessageRenderMessage, MessageType } from './types'
 /* eslint-disable no-cond-assign */
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -165,7 +164,7 @@ export default defineComponent({
               ? 'flex-start'
               : 'flex-end'
           },
-          cssVars as CSSProperties
+          cssVars
         ]}
       >
         {renderMessage ? (

--- a/src/message/src/MessageProvider.tsx
+++ b/src/message/src/MessageProvider.tsx
@@ -4,7 +4,6 @@ import type { MessageTheme } from '../styles'
 import type { MessageOptions, MessageType } from './types'
 import { createId } from 'seemly'
 import {
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   Fragment,
@@ -13,6 +12,7 @@ import {
   provide,
   reactive,
   ref,
+  type StyleValue,
   Teleport,
   type VNodeChild
 } from 'vue'
@@ -78,7 +78,7 @@ export const messageProviderProps = {
   },
   closable: Boolean,
   containerClass: String,
-  containerStyle: [String, Object] as PropType<string | CSSProperties>
+  containerStyle: Object as PropType<StyleValue>
 }
 
 export type MessageProviderProps = ExtractPublicPropTypes<

--- a/src/modal/src/Modal.tsx
+++ b/src/modal/src/Modal.tsx
@@ -322,7 +322,7 @@ export default defineComponent({
                   this.themeClass,
                   this.namespace
                 ]}
-                style={this.cssVars as CSSProperties}
+                style={this.cssVars}
               >
                 <NModalBodyWrapper
                   style={this.overlayStyle}

--- a/src/notification/src/Notification.tsx
+++ b/src/notification/src/Notification.tsx
@@ -1,7 +1,6 @@
 import { getPadding } from 'seemly'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -167,7 +166,7 @@ export const Notification = defineComponent({
         class={[`${mergedClsPrefix}-notification-wrapper`, this.themeClass]}
         onMouseenter={this.onMouseenter}
         onMouseleave={this.onMouseleave}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div
           class={[
@@ -179,7 +178,7 @@ export const Notification = defineComponent({
               [`${mergedClsPrefix}-notification--show-avatar`]: this.showAvatar
             }
           ]}
-          style={this.cssVars as CSSProperties}
+          style={this.cssVars}
         >
           {this.showAvatar ? (
             <div class={`${mergedClsPrefix}-notification__avatar`}>

--- a/src/notification/src/NotificationProvider.tsx
+++ b/src/notification/src/NotificationProvider.tsx
@@ -2,7 +2,6 @@ import type { MergedTheme, ThemeProps } from '../../_mixins'
 import type { NotificationOptions } from './NotificationEnvironment'
 import { createId } from 'seemly'
 import {
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   Fragment,
@@ -12,6 +11,7 @@ import {
   reactive,
   type Ref,
   ref,
+  type StyleValue,
   Teleport
 } from 'vue'
 import { useConfig, useTheme } from '../../_mixins'
@@ -81,7 +81,7 @@ interface NotificationRef {
 export const notificationProviderProps = {
   ...(useTheme.props as ThemeProps<NotificationTheme>),
   containerClass: String,
-  containerStyle: [String, Object] as PropType<string | CSSProperties>,
+  containerStyle: Object as PropType<StyleValue>,
   to: [String, Object] as PropType<string | HTMLElement>,
   scrollable: {
     type: Boolean,

--- a/src/pagination/src/Pagination.tsx
+++ b/src/pagination/src/Pagination.tsx
@@ -20,7 +20,6 @@ import type { PageItem } from './utils'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   h,
@@ -616,7 +615,7 @@ export default defineComponent({
           disabled && `${mergedClsPrefix}-pagination--disabled`,
           simple && `${mergedClsPrefix}-pagination--simple`
         ]}
-        style={cssVars as CSSProperties}
+        style={cssVars}
       >
         {renderPrefix ? (
           <div class={`${mergedClsPrefix}-pagination-prefix`}>

--- a/src/popconfirm/src/PopconfirmPanel.tsx
+++ b/src/popconfirm/src/PopconfirmPanel.tsx
@@ -1,12 +1,4 @@
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  inject,
-  type PropType,
-  toRef
-} from 'vue'
+import { computed, defineComponent, h, inject, type PropType, toRef } from 'vue'
 import { NBaseIcon } from '../../_internal'
 import { WarningIcon } from '../../_internal/icons'
 import { useConfig, useLocale, useThemeClass } from '../../_mixins'
@@ -116,7 +108,7 @@ export default defineComponent({
     return (
       <div
         class={[`${mergedClsPrefix}-popconfirm__panel`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {resolveWrappedSlot($slots.default, children =>
           showIcon || children ? (

--- a/src/popover/src/Popover.tsx
+++ b/src/popover/src/Popover.tsx
@@ -16,7 +16,6 @@ import {
   cloneVNode,
   computed,
   type ComputedRef,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -24,6 +23,7 @@ import {
   type Ref,
   ref,
   type SlotsType,
+  type StyleValue,
   Text,
   toRef,
   type VNode,
@@ -149,9 +149,9 @@ export const popoverBaseProps = {
     default: 'if'
   },
   arrowClass: String,
-  arrowStyle: [String, Object] as PropType<string | CSSProperties>,
+  arrowStyle: Object as PropType<StyleValue>,
   arrowWrapperClass: String,
-  arrowWrapperStyle: [String, Object] as PropType<string | CSSProperties>,
+  arrowWrapperStyle: Object as PropType<StyleValue>,
   flip: {
     type: Boolean,
     default: true
@@ -173,11 +173,11 @@ export const popoverBaseProps = {
   to: useAdjustedTo.propTo,
   scrollable: Boolean,
   contentClass: String,
-  contentStyle: [Object, String] as PropType<CSSProperties | string>,
+  contentStyle: Object as PropType<StyleValue>,
   headerClass: String,
-  headerStyle: [Object, String] as PropType<CSSProperties | string>,
+  headerStyle: Object as PropType<StyleValue>,
   footerClass: String,
-  footerStyle: [Object, String] as PropType<CSSProperties | string>,
+  footerStyle: Object as PropType<StyleValue>,
   // events
   onClickoutside: Function as PropType<(e: MouseEvent) => void>,
   'onUpdate:show': [Function, Array] as PropType<

--- a/src/popover/src/PopoverBody.tsx
+++ b/src/popover/src/PopoverBody.tsx
@@ -6,7 +6,6 @@ import { getPreciseEventTarget } from 'seemly'
 import { clickoutside, mousemoveoutside } from 'vdirs'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   type DirectiveArguments,
   Fragment,
@@ -17,6 +16,7 @@ import {
   type PropType,
   provide,
   ref,
+  type StyleValue,
   toRef,
   Transition,
   type VNode,
@@ -58,9 +58,9 @@ export const popoverBodyProps = {
   raw: Boolean,
   arrowPointToCenter: Boolean,
   arrowClass: String,
-  arrowStyle: [String, Object] as PropType<string | CSSProperties>,
+  arrowStyle: Object as PropType<StyleValue>,
   arrowWrapperClass: String,
-  arrowWrapperStyle: [String, Object] as PropType<string | CSSProperties>,
+  arrowWrapperStyle: Object as PropType<StyleValue>,
   displayDirective: String as PropType<'if' | 'show'>,
   x: Number,
   y: Number,
@@ -71,11 +71,11 @@ export const popoverBodyProps = {
   keepAliveOnHover: Boolean,
   scrollable: Boolean,
   contentClass: String,
-  contentStyle: [Object, String] as PropType<CSSProperties | string>,
+  contentStyle: Object as PropType<StyleValue>,
   headerClass: String,
-  headerStyle: [Object, String] as PropType<CSSProperties | string>,
+  headerStyle: Object as PropType<StyleValue>,
   footerClass: String,
-  footerStyle: [Object, String] as PropType<CSSProperties | string>,
+  footerStyle: Object as PropType<StyleValue>,
   // private
   internalDeactivateImmediately: Boolean,
   animated: Boolean,
@@ -89,9 +89,9 @@ export const popoverBodyProps = {
 
 interface RenderArrowProps {
   arrowClass: string | undefined
-  arrowStyle: string | CSSProperties | undefined
+  arrowStyle: StyleValue
   arrowWrapperClass: string | undefined
-  arrowWrapperStyle: string | CSSProperties | undefined
+  arrowWrapperStyle: StyleValue
   clsPrefix: string
 }
 
@@ -225,7 +225,7 @@ export default defineComponent({
     const styleRef = computed(() => {
       const width
         = props.width === 'trigger' ? undefined : formatLength(props.width)
-      const style: CSSProperties[] = []
+      const style: StyleValue = []
       if (width) {
         style.push({ width })
       }

--- a/src/popover/src/interface.ts
+++ b/src/popover/src/interface.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, Ref, VNode } from 'vue'
+import type { Ref, StyleValue, VNode } from 'vue'
 import { createInjectionKey } from '../../_utils/vue/create-injection-key'
 
 export type PopoverTrigger = 'click' | 'hover' | 'focus' | 'manual'
@@ -20,7 +20,7 @@ export const popoverBodyInjectionKey
 export type InternalRenderBody = (
   className: any,
   ref: Ref<HTMLElement | null>,
-  style: CSSProperties[],
+  style: StyleValue[],
   onMouseenter: (e: MouseEvent) => void,
   onMouseleave: (e: MouseEvent) => void
 ) => VNode

--- a/src/progress/src/Circle.tsx
+++ b/src/progress/src/Circle.tsx
@@ -1,5 +1,5 @@
 import type { ProgressGradient, ProgressStatus } from './public-types'
-import { type CSSProperties, defineComponent, h, type PropType } from 'vue'
+import { defineComponent, h, type PropType, type StyleValue } from 'vue'
 import { NBaseIcon } from '../../_internal'
 import {
   ErrorIcon,
@@ -32,7 +32,7 @@ export default defineComponent({
     },
     fillColor: [String, Object] as PropType<string | ProgressGradient>,
     railColor: String,
-    railStyle: [String, Object] as PropType<string | CSSProperties>,
+    railStyle: Object as PropType<StyleValue>,
     percentage: {
       type: Number,
       default: 0
@@ -66,7 +66,7 @@ export default defineComponent({
       offsetDegree: number,
       strokeColor?: string | ProgressGradient,
       type?: 'rail' | 'fill'
-    ): { pathString: string, pathStyle: CSSProperties } {
+    ): { pathString: string, pathStyle: StyleValue } {
       const { gapDegree, viewBoxWidth, strokeWidth } = props
       const radius = 50
       const beginPositionX = 0
@@ -78,7 +78,7 @@ export default defineComponent({
       a ${radius},${radius} 0 1 1 ${endPositionX},${-endPositionY}
       a ${radius},${radius} 0 1 1 ${-endPositionX},${endPositionY}`
       const len = Math.PI * 2 * radius
-      const pathStyle: CSSProperties = {
+      const pathStyle: StyleValue = {
         stroke:
           type === 'rail'
             ? (strokeColor as string)

--- a/src/progress/src/Line.tsx
+++ b/src/progress/src/Line.tsx
@@ -1,10 +1,10 @@
 import type { ProgressGradient, ProgressStatus } from './public-types'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
-  type PropType
+  type PropType,
+  type StyleValue
 } from 'vue'
 import { NBaseIcon } from '../../_internal'
 import {
@@ -34,7 +34,7 @@ export default defineComponent({
       default: 0
     },
     railColor: String,
-    railStyle: [String, Object] as PropType<string | CSSProperties>,
+    railStyle: Object as PropType<StyleValue>,
     fillColor: [String, Object] as PropType<string | ProgressGradient>,
     status: {
       type: String as PropType<ProgressStatus>,
@@ -111,23 +111,20 @@ export default defineComponent({
               class={[
                 `${clsPrefix}-progress-graph-line`,
                 {
-                  [`${clsPrefix}-progress-graph-line--indicator-${indicatorPlacement}`]:
-                    true
+                  [`${clsPrefix}-progress-graph-line--indicator-${indicatorPlacement}`]: true
                 }
               ]}
             >
               <div
                 class={`${clsPrefix}-progress-graph-line-rail`}
-                style={
-                  [
-                    {
-                      backgroundColor: railColor,
-                      height: styleHeightRef.value,
-                      borderRadius: styleRailBorderRadiusRef.value
-                    },
-                    railStyle
-                  ] as any
-                }
+                style={[
+                  {
+                    backgroundColor: railColor,
+                    height: styleHeightRef.value,
+                    borderRadius: styleRailBorderRadiusRef.value
+                  },
+                  railStyle
+                ]}
               >
                 <div
                   class={[

--- a/src/progress/src/MultipleCircle.tsx
+++ b/src/progress/src/MultipleCircle.tsx
@@ -1,10 +1,10 @@
 import type { ProgressGradient } from './public-types'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
-  type PropType
+  type PropType,
+  type StyleValue
 } from 'vue'
 
 function circlePath(r: number, sw: number, vw: number = 100): string {
@@ -49,7 +49,7 @@ export default defineComponent({
       default: () => []
     },
     railStyle: {
-      type: Array as PropType<Array<string | CSSProperties>>,
+      type: Array as PropType<StyleValue[]>,
       default: () => []
     }
   },
@@ -128,15 +128,13 @@ export default defineComponent({
                         stroke-width={strokeWidth}
                         stroke-linecap="round"
                         fill="none"
-                        style={
-                          [
-                            {
-                              strokeDashoffset: 0,
-                              stroke: railColor[index]
-                            },
-                            railStyle[index]
-                          ] as any
-                        }
+                        style={[
+                          {
+                            strokeDashoffset: 0,
+                            stroke: railColor[index]
+                          },
+                          railStyle[index]
+                        ]}
                       />
                       <path
                         class={[

--- a/src/progress/src/Progress.tsx
+++ b/src/progress/src/Progress.tsx
@@ -192,7 +192,7 @@ export default defineComponent({
           `${mergedClsPrefix}-progress--${type}`,
           `${mergedClsPrefix}-progress--${status}`
         ]}
-        style={cssVars as CSSProperties}
+        style={cssVars}
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={percentage as number}

--- a/src/progress/src/Progress.tsx
+++ b/src/progress/src/Progress.tsx
@@ -3,10 +3,10 @@ import type { ProgressTheme } from '../styles'
 import type { ProgressGradient, ProgressStatus } from './public-types'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
-  type PropType
+  type PropType,
+  type StyleValue
 } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { createKey, type ExtractPublicPropTypes } from '../../_utils'
@@ -32,9 +32,7 @@ export const progressProps = {
     default: 'default'
   },
   railColor: [String, Array] as PropType<string | string[]>,
-  railStyle: [String, Array] as PropType<
-    string | CSSProperties | Array<string | CSSProperties>
-  >,
+  railStyle: Array as PropType<StyleValue[]>,
   color: [String, Array, Object] as PropType<
     string | string[] | ProgressGradient | ProgressGradient[]
   >,
@@ -210,7 +208,7 @@ export default defineComponent({
             indicatorTextColor={indicatorTextColor}
             railColor={railColor as any}
             fillColor={color as any}
-            railStyle={railStyle as any}
+            railStyle={railStyle}
             offsetDegree={this.offsetDegree}
             percentage={percentage as number}
             viewBoxWidth={viewBoxWidth}
@@ -231,7 +229,7 @@ export default defineComponent({
             indicatorTextColor={indicatorTextColor}
             railColor={railColor as any}
             fillColor={color as any}
-            railStyle={railStyle as any}
+            railStyle={railStyle}
             percentage={percentage as number}
             processing={processing}
             indicatorPlacement={mergedIndicatorPlacement}
@@ -248,7 +246,7 @@ export default defineComponent({
             strokeWidth={strokeWidth}
             railColor={railColor as any}
             fillColor={color as any}
-            railStyle={railStyle as any}
+            railStyle={railStyle}
             viewBoxWidth={viewBoxWidth}
             percentage={percentage as number[]}
             showIndicator={showIndicator}

--- a/src/radio/src/Radio.tsx
+++ b/src/radio/src/Radio.tsx
@@ -1,6 +1,6 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
-import { computed, type CSSProperties, defineComponent, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { useRtl } from '../../_mixins/use-rtl'
 import { createKey, resolveWrappedSlot } from '../../_utils'
@@ -106,7 +106,7 @@ export default defineComponent({
           this.renderSafeChecked && `${mergedClsPrefix}-radio--checked`,
           this.focus && `${mergedClsPrefix}-radio--focus`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div class={`${mergedClsPrefix}-radio__dot-wrapper`}>
           &nbsp;

--- a/src/radio/src/RadioGroup.tsx
+++ b/src/radio/src/RadioGroup.tsx
@@ -6,7 +6,6 @@ import type { RadioBaseProps } from './use-radio'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -265,7 +264,7 @@ export default defineComponent({
           this.themeClass,
           isButtonGroup && `${mergedClsPrefix}-radio-group--button-group`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {children}
       </div>

--- a/src/rate/src/Rate.tsx
+++ b/src/rate/src/Rate.tsx
@@ -5,7 +5,6 @@ import type { RateOnUpdateValue, RateOnUpdateValueImpl } from './interface'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -196,7 +195,7 @@ export default defineComponent({
           },
           this.themeClass
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onMouseleave={this.handleMouseLeave}
       >
         {renderList(this.count, (_, index) => {

--- a/src/result/src/Result.tsx
+++ b/src/result/src/Result.tsx
@@ -3,7 +3,6 @@ import type { ExtractPublicPropTypes } from '../../_utils'
 import type { ResultTheme } from '../styles'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -134,7 +133,7 @@ export default defineComponent({
     return (
       <div
         class={[`${mergedClsPrefix}-result`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div class={`${mergedClsPrefix}-result-icon`}>
           {$slots.icon?.() || (

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -709,7 +709,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-slider--reverse`]: this.reverse
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onKeydown={this.handleRailKeyDown}
         onMousedown={this.handleRailMouseDown}
         onTouchstart={this.handleRailMouseDown}
@@ -825,10 +825,7 @@ export default defineComponent({
                                             this.indicatorThemeClass,
                                             `${mergedClsPrefix}-slider-handle-indicator--${this.mergedPlacement}`
                                           ]}
-                                          style={
-                                            this
-                                              .indicatorCssVars as CSSProperties
-                                          }
+                                          style={this.indicatorCssVars}
                                         >
                                           {typeof formatTooltip === 'function'
                                             ? formatTooltip(value)

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -4,7 +4,6 @@ import { useIsMounted, useMergedState } from 'vooks'
 import {
   type ComponentPublicInstance,
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   nextTick,
@@ -12,6 +11,7 @@ import {
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   Transition,
   type VNode,
@@ -216,7 +216,7 @@ export default defineComponent({
         active: boolean
         label: string | (() => VNodeChild)
         key: number
-        style: CSSProperties
+        style: StyleValue
       }> = []
       const { marks } = props
       if (marks) {
@@ -247,7 +247,7 @@ export default defineComponent({
       return mergedMarks
     })
 
-    function getHandleStyle(value: number, index: number): Record<string, any> {
+    function getHandleStyle(value: number, index: number): StyleValue {
       const percentage = valueToPercentage(value)
       const { value: styleDirection } = styleDirectionRef
       return {

--- a/src/space/src/Space.tsx
+++ b/src/space/src/Space.tsx
@@ -5,10 +5,10 @@ import { depx, getGap } from 'seemly'
 import {
   Comment,
   computed,
-  type CSSProperties,
   defineComponent,
   h,
-  type PropType
+  type PropType,
+  type StyleValue
 } from 'vue'
 import { useConfig, useTheme } from '../../_mixins'
 import { useRtl } from '../../_mixins/use-rtl'
@@ -54,7 +54,7 @@ export const spaceProps = {
     default: true
   },
   itemClass: String,
-  itemStyle: [String, Object] as PropType<string | CSSProperties>,
+  itemStyle: Object as PropType<StyleValue>,
   wrap: {
     type: Boolean,
     default: true
@@ -175,7 +175,7 @@ export default defineComponent({
                   role="none"
                   class={itemClass}
                   style={[
-                    itemStyle as any,
+                    itemStyle,
                     {
                       maxWidth: '100%'
                     },

--- a/src/spin/src/Spin.tsx
+++ b/src/spin/src/Spin.tsx
@@ -168,7 +168,7 @@ export default defineComponent({
             `${mergedClsPrefix}-spin`,
             rotate && `${mergedClsPrefix}-spin--rotate`
           ]}
-          style={$slots.default ? '' : (this.cssVars as CSSProperties)}
+          style={$slots.default ? '' : this.cssVars}
         >
           {$slots.icon()}
         </div>
@@ -178,7 +178,7 @@ export default defineComponent({
       <div class={[`${mergedClsPrefix}-spin-body`, this.themeClass]}>
         <NBaseLoading
           clsPrefix={mergedClsPrefix}
-          style={$slots.default ? '' : (this.cssVars as CSSProperties)}
+          style={$slots.default ? '' : this.cssVars}
           stroke={this.stroke}
           stroke-width={this.mergedStrokeWidth}
           class={`${mergedClsPrefix}-spin`}
@@ -190,7 +190,7 @@ export default defineComponent({
     return $slots.default ? (
       <div
         class={[`${mergedClsPrefix}-spin-container`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div
           class={[

--- a/src/spin/src/Spin.tsx
+++ b/src/spin/src/Spin.tsx
@@ -4,12 +4,12 @@ import { pxfy } from 'seemly'
 import { useCompitable } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   Transition,
   type VNode,
   watchEffect
@@ -29,7 +29,7 @@ const STROKE_WIDTH = {
 export const spinProps = {
   ...(useTheme.props as ThemeProps<SpinTheme>),
   contentClass: String,
-  contentStyle: [Object, String] as PropType<CSSProperties | string>,
+  contentStyle: Object as PropType<StyleValue>,
   description: String,
   stroke: String,
   size: {

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -4,12 +4,12 @@ import { depx } from 'seemly'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   type VNode,
   watchEffect
@@ -51,9 +51,9 @@ export const splitProps = {
     default: 1
   },
   pane1Class: String,
-  pane1Style: [Object, String] as PropType<CSSProperties | string>,
+  pane1Style: Object as PropType<StyleValue>,
   pane2Class: String,
-  pane2Style: [Object, String] as PropType<CSSProperties | string>,
+  pane2Style: Object as PropType<StyleValue>,
   onDragStart: Function as PropType<(e: Event) => void>,
   onDragMove: Function as PropType<(e: Event) => void>,
   onDragEnd: Function as PropType<(e: Event) => void>,

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -256,7 +256,7 @@ export default defineComponent({
           `${this.mergedClsPrefix}-split--${this.direction}`,
           this.themeClass
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div
           class={[`${this.mergedClsPrefix}-split-pane-1`, this.pane1Class]}

--- a/src/steps/src/Step.tsx
+++ b/src/steps/src/Step.tsx
@@ -1,7 +1,6 @@
 import type { ExtractPublicPropTypes } from '../../_utils'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -191,7 +190,7 @@ export default defineComponent({
           descriptionNode && `${mergedClsPrefix}-step--show-description`,
           `${mergedClsPrefix}-step--${this.mergedStatus}-status`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onClick={handleStepClick}
       >
         <div class={`${mergedClsPrefix}-step-indicator`}>

--- a/src/switch/demos/enUS/color.demo.vue
+++ b/src/switch/demos/enUS/color.demo.vue
@@ -3,7 +3,7 @@
 </markdown>
 
 <script lang="ts" setup>
-import type { CSSProperties } from 'vue'
+import type { StyleValue } from 'vue'
 
 function railStyle({
   focused,
@@ -12,7 +12,7 @@ function railStyle({
   focused: boolean
   checked: boolean
 }) {
-  const style: CSSProperties = {}
+  const style: StyleValue = {}
   if (checked) {
     style.background = '#d03050'
     if (focused) {

--- a/src/switch/demos/enUS/index.demo-entry.md
+++ b/src/switch/demos/enUS/index.demo-entry.md
@@ -26,7 +26,7 @@ icon.vue
 | default-value | `boolean` | `false` | Default value. |  |
 | disabled | `boolean` | `false` | Whether to disable the switch. |  |
 | loading | `boolean` | `false` | Whether to show loading state. |  |
-| rail-style | `(info: { focused: boolean, checked: boolean }) => (CSSProperties \| string)` | `undefined` | Rail style generator. |  |
+| rail-style | `(info: { focused: boolean, checked: boolean }) => StyleValue` | Rail style generator. |  |
 | round | `boolean` | `true` | Whether the switch has rounded corners. |  |
 | rubber-band | `boolean` | `true` | Whether the switch button has rubber band effect. | 2.28.3 |
 | size | `'small' \| 'medium' \| 'large'` | `'medium'` | The size of the switch. |  |

--- a/src/switch/demos/zhCN/color.demo.vue
+++ b/src/switch/demos/zhCN/color.demo.vue
@@ -3,7 +3,7 @@
 </markdown>
 
 <script lang="ts" setup>
-import type { CSSProperties } from 'vue'
+import type { StyleValue } from 'vue'
 
 function railStyle({
   focused,
@@ -12,7 +12,7 @@ function railStyle({
   focused: boolean
   checked: boolean
 }) {
-  const style: CSSProperties = {}
+  const style: StyleValue = {}
   if (checked) {
     style.background = '#d03050'
     if (focused) {

--- a/src/switch/demos/zhCN/index.demo-entry.md
+++ b/src/switch/demos/zhCN/index.demo-entry.md
@@ -26,7 +26,7 @@ icon.vue
 | default-value | `boolean` | `false` | 非受控模式下的默认值 |  |
 | disabled | `boolean` | `false` | 是否禁用 |  |
 | loading | `boolean` | `false` | 是否加载 |  |
-| rail-style | `(info: { focused: boolean, checked: boolean }) => (CSSProperties \| string)` | `undefined` | 创建轨道样式的函数 |  |
+| rail-style | `(info: { focused: boolean, checked: boolean }) => StyleValue` | 创建轨道样式的函数 |  |
 | round | `boolean` | `true` | 是否为圆形按钮 |  |
 | rubber-band | `boolean` | `true` | 按钮是否有橡皮筋效果 | 2.28.3 |
 | size | `'small' \| 'medium' \| 'large'` | `'medium'` | 开关大小 |  |

--- a/src/switch/src/Switch.tsx
+++ b/src/switch/src/Switch.tsx
@@ -6,12 +6,12 @@ import { depx, pxfy } from 'seemly'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   type VNode,
   watchEffect
@@ -64,7 +64,7 @@ export const switchProps = {
     default: false
   },
   railStyle: Function as PropType<
-    (params: { focused: boolean, checked: boolean }) => string | CSSProperties
+    (params: { focused: boolean, checked: boolean }) => StyleValue
   >,
   rubberBand: {
     type: Boolean,

--- a/src/switch/src/Switch.tsx
+++ b/src/switch/src/Switch.tsx
@@ -338,7 +338,7 @@ export default defineComponent({
           this.rubberBand && `${mergedClsPrefix}-switch--rubber-band`
         ]}
         tabindex={!this.mergedDisabled ? 0 : undefined}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onClick={this.handleClick}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}

--- a/src/switch/tests/Switch.spec.tsx
+++ b/src/switch/tests/Switch.spec.tsx
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { type CSSProperties, Fragment, h } from 'vue'
+import { Fragment, h, type StyleValue } from 'vue'
 import { NSwitch } from '../index'
 
 describe('n-switch', () => {
@@ -100,8 +100,8 @@ describe('n-switch', () => {
     }: {
       focused: boolean
       checked: boolean
-    }): CSSProperties | string => {
-      const style: any = {}
+    }): StyleValue => {
+      const style: StyleValue = {}
       if (!checked) {
         style.background = color
         if (focused) {

--- a/src/table/src/Table.tsx
+++ b/src/table/src/Table.tsx
@@ -1,13 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TableTheme } from '../styles'
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  type PropType
-} from 'vue'
+import { computed, defineComponent, h, type PropType } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { useRtl } from '../../_mixins/use-rtl'
 import { createKey } from '../../_utils'
@@ -139,7 +133,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-table--striped`]: this.striped
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </table>

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -19,7 +19,6 @@ import {
   cloneVNode,
   type ComponentPublicInstance,
   computed,
-  type CSSProperties,
   defineComponent,
   type ExtractPropTypes,
   h,
@@ -29,6 +28,7 @@ import {
   provide,
   ref,
   type SlotsType,
+  type StyleValue,
   toRef,
   TransitionGroup,
   type VNode,
@@ -85,15 +85,15 @@ export const tabsProps = {
     type: String as PropType<'top' | 'left' | 'right' | 'bottom'>,
     default: 'top'
   },
-  tabStyle: [String, Object] as PropType<string | CSSProperties>,
+  tabStyle: Object as PropType<StyleValue>,
   tabClass: String,
-  addTabStyle: [String, Object] as PropType<string | CSSProperties>,
+  addTabStyle: Object as PropType<StyleValue>,
   addTabClass: String,
   barWidth: Number,
   paneClass: String,
-  paneStyle: [String, Object] as PropType<string | CSSProperties>,
+  paneStyle: Object as PropType<StyleValue>,
   paneWrapperClass: String,
-  paneWrapperStyle: [String, Object] as PropType<string | CSSProperties>,
+  paneWrapperStyle: Object as PropType<StyleValue>,
   addable: [Boolean, Object] as PropType<Addable>,
   tabsPadding: {
     type: Number,
@@ -386,12 +386,15 @@ export default defineComponent({
           tabsPaneWrapperEl.style.cssText = paneWrapperStyle
         }
         else if (paneWrapperStyle) {
-          const { maxHeight, height } = paneWrapperStyle
+          const { maxHeight, height } = paneWrapperStyle as {
+            maxHeight?: string
+            height?: string
+          }
           if (maxHeight !== undefined) {
-            tabsPaneWrapperEl.style.maxHeight = maxHeight as string
+            tabsPaneWrapperEl.style.maxHeight = maxHeight
           }
           if (height !== undefined) {
-            tabsPaneWrapperEl.style.height = height as string
+            tabsPaneWrapperEl.style.height = height
           }
         }
       }

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -929,7 +929,7 @@ export default defineComponent({
           mergedJustifyContent && `${mergedClsPrefix}-tabs--flex`,
           `${mergedClsPrefix}-tabs--${resolvedPlacement}`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div
           class={[

--- a/src/tabs/src/interface.ts
+++ b/src/tabs/src/interface.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, Ref } from 'vue'
+import type { Ref, StyleValue } from 'vue'
 import { createInjectionKey } from '../../_utils'
 
 export type TabsType = 'line' | 'card' | 'bar' | 'segment'
@@ -23,12 +23,12 @@ export interface TabsInjection {
   valueRef: Ref<string | number | null>
   typeRef: Ref<TabsType>
   closableRef: Ref<boolean>
-  tabStyleRef: Ref<string | CSSProperties | undefined>
+  tabStyleRef: Ref<StyleValue>
   tabClassRef: Ref<string | undefined>
   addTabClassRef: Ref<string | undefined>
-  addTabStyleRef: Ref<string | CSSProperties | undefined>
+  addTabStyleRef: Ref<StyleValue>
   paneClassRef: Ref<string | undefined>
-  paneStyleRef: Ref<string | CSSProperties | undefined>
+  paneStyleRef: Ref<StyleValue>
   tabChangeIdRef: { id: number }
   onBeforeLeaveRef: Ref<OnBeforeLeave | undefined>
   triggerRef: Ref<'click' | 'hover'>

--- a/src/tag/src/Tag.tsx
+++ b/src/tag/src/Tag.tsx
@@ -4,7 +4,6 @@ import type { TagTheme } from '../styles'
 import { getMargin } from 'seemly'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -302,7 +301,7 @@ export default defineComponent({
             [`${mergedClsPrefix}-tag--closable`]: closable
           }
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
         onClick={this.handleClick}
         onMouseenter={this.onMouseenter}
         onMouseleave={this.onMouseleave}

--- a/src/thing/src/Thing.tsx
+++ b/src/thing/src/Thing.tsx
@@ -84,11 +84,7 @@ export default defineComponent({
             themeClassHandle?.themeClass,
             rtlEnabled && `${mergedClsPrefix}-thing--rtl`
           ]}
-          style={
-            inlineThemeDisabled
-              ? undefined
-              : (cssVarsRef.value as CSSProperties)
-          }
+          style={inlineThemeDisabled ? undefined : cssVarsRef.value}
         >
           {slots.avatar && props.contentIndented ? (
             <div class={`${mergedClsPrefix}-thing-avatar`}>

--- a/src/thing/src/Thing.tsx
+++ b/src/thing/src/Thing.tsx
@@ -3,12 +3,12 @@ import type { ExtractPublicPropTypes } from '../../_utils'
 import type { ThingTheme } from '../styles'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   h,
   type PropType,
   type SlotsType,
+  type StyleValue,
   type VNode
 } from 'vue'
 import { useConfig, useRtl, useTheme, useThemeClass } from '../../_mixins'
@@ -21,10 +21,10 @@ export const thingProps = {
   titleExtra: String,
   description: String,
   descriptionClass: String,
-  descriptionStyle: [String, Object] as PropType<string | CSSProperties>,
+  descriptionStyle: Object as PropType<StyleValue>,
   content: String,
   contentClass: String,
-  contentStyle: [String, Object] as PropType<string | CSSProperties>,
+  contentStyle: Object as PropType<StyleValue>,
   contentIndented: Boolean
 }
 

--- a/src/time-picker/src/TimePicker.tsx
+++ b/src/time-picker/src/TimePicker.tsx
@@ -38,7 +38,6 @@ import { clickoutside } from 'vdirs'
 import { useIsMounted, useKeyboard, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   nextTick,

--- a/src/time-picker/src/TimePicker.tsx
+++ b/src/time-picker/src/TimePicker.tsx
@@ -925,7 +925,7 @@ export default defineComponent({
     return (
       <div
         class={[`${mergedClsPrefix}-time-picker`, this.triggerThemeClass]}
-        style={this.triggerCssVars as CSSProperties}
+        style={this.triggerCssVars}
       >
         <VBinder>
           {{
@@ -1005,7 +1005,7 @@ export default defineComponent({
                                 ref="panelInstRef"
                                 actions={this.actions}
                                 class={this.themeClass}
-                                style={this.cssVars as CSSProperties}
+                                style={this.cssVars}
                                 seconds={this.seconds}
                                 minutes={this.minutes}
                                 hours={this.hours}

--- a/src/timeline/src/TimelineItem.tsx
+++ b/src/timeline/src/TimelineItem.tsx
@@ -1,7 +1,6 @@
 import type { ExtractPublicPropTypes } from '../../_utils'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -129,7 +128,7 @@ export default defineComponent({
           `${mergedClsPrefix}-timeline-item--${this.type}-type`,
           `${mergedClsPrefix}-timeline-item--${this.lineType}-line-type`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div class={`${mergedClsPrefix}-timeline-item-timeline`}>
           <div class={`${mergedClsPrefix}-timeline-item-timeline__line`} />

--- a/src/transfer/src/Transfer.tsx
+++ b/src/transfer/src/Transfer.tsx
@@ -4,7 +4,6 @@ import { depx } from 'seemly'
 import { useIsMounted } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type PropType,
@@ -305,7 +304,7 @@ export default defineComponent({
           `${mergedClsPrefix}-transfer`,
           this.mergedDisabled && `${mergedClsPrefix}-transfer--disabled`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         <div
           class={`${mergedClsPrefix}-transfer-list ${mergedClsPrefix}-transfer-list--source`}

--- a/src/tree-select/src/TreeSelect.tsx
+++ b/src/tree-select/src/TreeSelect.tsx
@@ -29,7 +29,6 @@ import { clickoutside } from 'vdirs'
 import { useIsMounted, useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   type HTMLAttributes,
@@ -975,10 +974,7 @@ export default defineComponent({
                                 this.themeClass
                               ]}
                               ref="menuElRef"
-                              style={[
-                                menuProps?.style || '',
-                                this.cssVars as CSSProperties
-                              ]}
+                              style={[menuProps?.style || '', this.cssVars]}
                               tabindex={0}
                               onMousedown={this.handleMenuMousedown}
                               onKeydown={this.handleKeydown}

--- a/src/tree/src/Tree.tsx
+++ b/src/tree/src/Tree.tsx
@@ -38,7 +38,6 @@ import {
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   h,
   inject,
@@ -1822,7 +1821,7 @@ export default defineComponent({
                   paddingBottom={padding.bottom}
                   class={this.themeClass}
                   style={[
-                    this.cssVars as CSSProperties,
+                    this.cssVars,
                     {
                       paddingLeft: padding.left,
                       paddingRight: padding.right
@@ -1855,7 +1854,7 @@ export default defineComponent({
           tabindex={tabindex}
           onKeydown={mergedFocusable ? handleKeydown : undefined}
           onFocusout={mergedFocusable ? handleFocusout : undefined}
-          style={this.cssVars as CSSProperties}
+          style={this.cssVars}
           contentStyle={{ padding: this.internalScrollablePadding }}
         >
           {{
@@ -1877,7 +1876,7 @@ export default defineComponent({
           class={treeClass}
           tabindex={tabindex}
           ref="selfElRef"
-          style={this.cssVars as CSSProperties}
+          style={this.cssVars}
           onKeydown={mergedFocusable ? handleKeydown : undefined}
           onFocusout={mergedFocusable ? handleFocusout : undefined}
           onDragleave={draggable ? this.handleDragLeaveTree : undefined}

--- a/src/tree/src/dnd.tsx
+++ b/src/tree/src/dnd.tsx
@@ -1,5 +1,5 @@
 import type { DropPosition, TreeOption } from './interface'
-import { type CSSProperties, h, type VNode } from 'vue'
+import { h, type StyleValue, type VNode } from 'vue'
 
 export function renderDropMark({
   position,
@@ -12,7 +12,7 @@ export function renderDropMark({
   indent: number
   el: HTMLElement
 }): VNode {
-  const style: CSSProperties = {
+  const style: StyleValue = {
     position: 'absolute',
     boxSizing: 'border-box',
     right: 0

--- a/src/typography/src/a.tsx
+++ b/src/typography/src/a.tsx
@@ -50,7 +50,7 @@ export default defineComponent({
     return (
       <a
         class={[`${this.mergedClsPrefix}-a`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </a>

--- a/src/typography/src/a.tsx
+++ b/src/typography/src/a.tsx
@@ -1,7 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TypographyTheme } from '../styles'
-import { computed, type CSSProperties, defineComponent, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { typographyLight } from '../styles'
 import style from './styles/a.cssr'

--- a/src/typography/src/blockquote.tsx
+++ b/src/typography/src/blockquote.tsx
@@ -1,7 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TypographyTheme } from '../styles'
-import { computed, type CSSProperties, defineComponent, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { typographyLight } from '../styles'
 import style from './styles/blockquote.cssr'
@@ -64,7 +64,7 @@ export default defineComponent({
           this.themeClass,
           this.alignText && `${mergedClsPrefix}-blockquote--align-text`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </blockquote>

--- a/src/typography/src/hr.tsx
+++ b/src/typography/src/hr.tsx
@@ -1,6 +1,6 @@
 import type { ThemeProps } from '../../_mixins'
 import type { TypographyTheme } from '../styles'
-import { computed, type CSSProperties, defineComponent, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { typographyLight } from '../styles'
 import style from './styles/hr.cssr'
@@ -45,7 +45,7 @@ export default defineComponent({
     return (
       <hr
         class={[`${this.mergedClsPrefix}-hr`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       />
     )
   }

--- a/src/typography/src/ol.tsx
+++ b/src/typography/src/ol.tsx
@@ -1,7 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TypographyTheme } from '../styles'
-import { computed, type CSSProperties, defineComponent, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { typographyLight } from '../styles'
 import style from './styles/list.cssr'
@@ -68,7 +68,7 @@ export default defineComponent({
           this.themeClass,
           this.alignText && `${mergedClsPrefix}-ol--align-text`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </ol>

--- a/src/typography/src/p.tsx
+++ b/src/typography/src/p.tsx
@@ -1,13 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TypographyTheme } from '../styles'
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  type PropType
-} from 'vue'
+import { computed, defineComponent, h, type PropType } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { typographyLight } from '../styles'
 import style from './styles/p.cssr'
@@ -73,7 +67,7 @@ export default defineComponent({
     return (
       <p
         class={[`${this.mergedClsPrefix}-p`, this.themeClass]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </p>

--- a/src/typography/src/text.tsx
+++ b/src/typography/src/text.tsx
@@ -2,13 +2,7 @@ import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TypographyTheme } from '../styles'
 import { useCompitable } from 'vooks'
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  type PropType
-} from 'vue'
+import { computed, defineComponent, h, type PropType } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { createKey, warn } from '../../_utils'
 import { typographyLight } from '../styles'
@@ -116,11 +110,11 @@ export default defineComponent({
     ]
     const children = this.$slots.default?.()
     return this.code ? (
-      <code class={textClass} style={this.cssVars as CSSProperties}>
+      <code class={textClass} style={this.cssVars}>
         {this.delete ? <del>{children}</del> : children}
       </code>
     ) : this.delete ? (
-      <del class={textClass} style={this.cssVars as CSSProperties}>
+      <del class={textClass} style={this.cssVars}>
         {children}
       </del>
     ) : (

--- a/src/typography/src/ul.tsx
+++ b/src/typography/src/ul.tsx
@@ -1,7 +1,7 @@
 import type { ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { TypographyTheme } from '../styles'
-import { computed, type CSSProperties, defineComponent, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import { typographyLight } from '../styles'
 import style from './styles/list.cssr'
@@ -68,7 +68,7 @@ export default defineComponent({
           this.themeClass,
           this.alignText && `${mergedClsPrefix}-ul--align-text`
         ]}
-        style={this.cssVars as CSSProperties}
+        style={this.cssVars}
       >
         {this.$slots}
       </ul>

--- a/src/upload/src/Upload.tsx
+++ b/src/upload/src/Upload.tsx
@@ -31,7 +31,6 @@ import { createId } from 'seemly'
 import { useMergedState } from 'vooks'
 import {
   computed,
-  type CSSProperties,
   defineComponent,
   Fragment,
   h,
@@ -40,6 +39,7 @@ import {
   type PropType,
   provide,
   ref,
+  type StyleValue,
   Teleport,
   toRef
 } from 'vue'
@@ -349,7 +349,7 @@ export const uploadProps = {
   >,
   onUpdateFileList: [Function, Array] as PropType<MaybeArray<OnUpdateFileList>>,
   fileListClass: String,
-  fileListStyle: [String, Object] as PropType<string | CSSProperties>,
+  fileListStyle: Object as PropType<StyleValue>,
   defaultFileList: {
     type: Array as PropType<UploadFileInfo[]>,
     default: () => []
@@ -394,7 +394,7 @@ export const uploadProps = {
   imageGroupProps: Object as PropType<ImageGroupProps>,
   inputProps: Object as PropType<InputHTMLAttributes>,
   triggerClass: String,
-  triggerStyle: [String, Object] as PropType<CSSProperties | string>,
+  triggerStyle: Object as PropType<StyleValue>,
   renderIcon: Function as PropType<RenderIcon>
 } as const
 

--- a/src/upload/src/UploadFileList.tsx
+++ b/src/upload/src/UploadFileList.tsx
@@ -1,11 +1,4 @@
-import {
-  computed,
-  type CSSProperties,
-  defineComponent,
-  h,
-  inject,
-  type VNode
-} from 'vue'
+import { computed, defineComponent, h, inject, type VNode } from 'vue'
 import { NFadeInExpandTransition } from '../../_internal'
 import { throwError } from '../../_utils'
 import { NImageGroup } from '../../image'
@@ -80,7 +73,7 @@ export default defineComponent({
           ]}
           style={[
             abstract && cssVarsRef ? cssVarsRef.value : '',
-            fileListStyleRef.value as CSSProperties
+            fileListStyleRef.value
           ]}
         >
           {renderUploadFileList()}

--- a/src/upload/src/interface.ts
+++ b/src/upload/src/interface.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, Ref, VNodeChild } from 'vue'
+import type { Ref, StyleValue, VNodeChild } from 'vue'
 import type { MergedTheme } from '../../_mixins'
 import type { ImageGroupProps } from '../../image'
 import type { UploadTheme } from '../styles'
@@ -59,17 +59,17 @@ export interface UploadInjection {
   dragOverRef: Ref<boolean>
   draggerInsideRef: { value: boolean }
   fileListClassRef: Ref<string | undefined>
-  fileListStyleRef: Ref<string | CSSProperties | undefined>
+  fileListStyleRef: Ref<StyleValue>
   mergedDisabledRef: Ref<boolean>
   maxReachedRef: Ref<boolean>
   abstractRef: Ref<boolean>
   imageGroupPropsRef: Ref<ImageGroupProps | undefined>
-  cssVarsRef: undefined | Ref<CSSProperties>
+  cssVarsRef: undefined | Ref<StyleValue>
   themeClassRef: undefined | Ref<string>
   mergedDirectoryDndRef: Ref<boolean>
   acceptRef: Ref<string | undefined>
   triggerClassRef: Ref<string | undefined>
-  triggerStyleRef: Ref<CSSProperties | string | undefined>
+  triggerStyleRef: Ref<StyleValue>
   doChange: DoChange
   onRender: undefined | (() => void)
   submit: (fileId?: string) => void

--- a/src/virtual-list/demos/enUS/index.demo-entry.md
+++ b/src/virtual-list/demos/enUS/index.demo-entry.md
@@ -27,7 +27,7 @@ keep-alive.vue
 | items | `Array<object>` | `[]` | Data to display. | 2.36.0 |
 | item-resizable | `number` | `false` | Whether dynamic sizing is enabled, you don't have to care about the size of the item, it will be calculated automatically. | 2.36.0 |
 | item-size | `number` | required | Displays the minimum height of the item in pixels to calculate scroll size and position. | 2.36.0 |
-| items-style | `string \| CSSProperties` | `undefined` | Items container style. | 2.36.0 |
+| items-style | `StyleValue` | Items container style. | 2.36.0 |
 | key-field | `string` | `'key'` | Field name of option key. | 2.36.0 |
 | padding-top | `string \| number` | `undefined` | Distance from the top. | 2.36.0 |
 | padding-bottom | `string \| number` | `undefined` | Distance from the bottom. | 2.36.0 |

--- a/src/virtual-list/demos/zhCN/index.demo-entry.md
+++ b/src/virtual-list/demos/zhCN/index.demo-entry.md
@@ -27,7 +27,7 @@ keep-alive.vue
 | items | `Array<object>` | `[]` | 需要展示的数据 | 2.36.0 |
 | item-resizable | `number` | `false` | 是否启用动态尺寸，你不必关心项目大小，它会自动计算 | 2.36.0 |
 | item-size | `number` | required | 以像素为单位显示项目的最小高度，用于计算滚动大小和位置 | 2.36.0 |
-| items-style | `string \| CSSProperties` | `undefined` | 全部内容的容器样式 | 2.36.0 |
+| items-style | `StyleValue` | 全部内容的容器样式 | 2.36.0 |
 | key-field | `string` | `'key'` | 选项 key 的字段名 | 2.36.0 |
 | padding-top | `string \| number` | `undefined` | 距离上部的距离 | 2.36.0 |
 | padding-bottom | `string \| number` | `undefined` | 距离底部的距离 | 2.36.0 |

--- a/src/virtual-list/src/VirtualList.tsx
+++ b/src/virtual-list/src/VirtualList.tsx
@@ -1,6 +1,6 @@
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { ScrollbarProps } from '../../scrollbar/src/Scrollbar'
-import { type CSSProperties, defineComponent, h, type PropType, ref } from 'vue'
+import { defineComponent, h, type PropType, ref, type StyleValue } from 'vue'
 import {
   type VirtualListInst,
   type VirtualListItemData,
@@ -22,7 +22,7 @@ export const virtualListProps = {
     required: true
   },
   itemResizable: Boolean,
-  itemsStyle: [String, Object] as PropType<string | CSSProperties>,
+  itemsStyle: Object as PropType<StyleValue>,
   visibleItemsTag: {
     type: [String, Object] as PropType<string | object>,
     default: 'div'
@@ -125,7 +125,8 @@ export default defineComponent({
                 items={this.items}
                 itemSize={this.itemSize}
                 itemResizable={this.itemResizable}
-                itemsStyle={this.itemsStyle}
+                // FIXME: after vueuc itemsStyle type upgrade, we can remove this
+                itemsStyle={this.itemsStyle as any}
                 visibleItemsTag={this.visibleItemsTag}
                 visibleItemsProps={this.visibleItemsProps}
                 ignoreItemResize={this.ignoreItemResize}


### PR DESCRIPTION
- 前置PR https://github.com/tusen-ai/naive-ui/pull/7098（需要先合入）
- 使用 `StyleValue` type 来简化类型定义

### 特别说明
对于 `Card` `Modal` `Dailog` `Select` 这几个具有特别复杂类型的组件仍然保留使用 `CSSProperties` type

因为他们本身的类型复杂度就已经容易让 TS 的类型爆掉 

`StyleValue` 是一个递归类型 加上 Vue 的 `Ref` `Reactive` 会导致有类型深度太深的问题

