### PR TITLE
fix(input-number): resolve issue when input-number is readonly

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - Fix `n-menu`'s disabled style not working when parent node is set to `disabled` and child node has `type: "group"`, closes [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - Fix `n-input-group-label` not injecting `formItemInjectionKey`, causing the `size` property to fail, and close [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - Fix the issue of style confusion in `n-carousel` when there is only one image, close [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- Fix `n-input-number` in readonly mode, the value still could be modified by keyboard arrow up & down, close [#7112](https://github.com/tusen-ai/naive-ui/issues/7112)
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - 修复 `n-menu` 在父节点设置 `disabled`，子节点为 `type: "group"` 的禁用样式失效，关闭 [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - 修复 `n-input-group-label` 没有注入 `formItemInjectionKey`，导致 `size` 属性失效的问题，关闭 [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - 修复 `n-carousel` 只有一张图的情況下样式错乱的问题，关闭 [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- 修复 `n-input-number` readonly时仍然可以通过键盘的上下箭头修改值 关闭[#7112](https://github.com/tusen-ai/naive-ui/issues/7112)
 
 ### Features
 

--- a/src/input-number/src/InputNumber.tsx
+++ b/src/input-number/src/InputNumber.tsx
@@ -529,6 +529,9 @@ export default defineComponent({
       doMinus()
     }
     function handleKeyDown(e: KeyboardEvent): void {
+      if (props.readonly) {
+        return
+      }
       if (e.key === 'Enter') {
         if (e.target === inputInstRef.value?.wrapperElRef) {
           // hit input wrapper


### PR DESCRIPTION
when the input-number is in readonly mode, the keyboard arrow up and down still could be used. close #7112 