### PR TITLE
fix(select): When using the "dynamic option creation" feature of the Select component, selecting another option from the search results lead to the issue of search text remaining in the selection area.

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - Fix `n-menu`'s disabled style not working when parent node is set to `disabled` and child node has `type: "group"`, closes [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - Fix `n-input-group-label` not injecting `formItemInjectionKey`, causing the `size` property to fail, and close [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - Fix the issue of style confusion in `n-carousel` when there is only one image, close [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- Fix `n-select` residual search text issue when using dynamic option creation and selecting options after searching.
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - 修复 `n-menu` 在父节点设置 `disabled`，子节点为 `type: "group"` 的禁用样式失效，关闭 [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - 修复 `n-input-group-label` 没有注入 `formItemInjectionKey`，导致 `size` 属性失效的问题，关闭 [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - 修复 `n-carousel` 只有一张图的情況下样式错乱的问题，关闭 [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- 修复 `n-select` 在使用动态创建选项功能时，搜索后选择选项导致搜索文本残留的问题
 
 ### Features
 

--- a/src/select/src/Select.tsx
+++ b/src/select/src/Select.tsx
@@ -624,12 +624,14 @@ export default defineComponent({
         const { value: beingCreatedOptions } = beingCreatedOptionsRef
         const beingCreatedOption = beingCreatedOptions[0] || null
         if (beingCreatedOption) {
-          const createdOptions = createdOptionsRef.value
-          if (!createdOptions.length) {
-            createdOptionsRef.value = [beingCreatedOption]
-          }
-          else {
-            createdOptions.push(beingCreatedOption)
+          if (beingCreatedOption[valueField] === option[valueField]) {
+            const createdOptions = createdOptionsRef.value
+            if (!createdOptions.length) {
+              createdOptionsRef.value = [beingCreatedOption]
+            }
+            else {
+              createdOptions.push(beingCreatedOption)
+            }
           }
           beingCreatedOptionsRef.value = emptyArray
         }


### PR DESCRIPTION
**Purpose:** Ensures that an option being created is only added to the list of created options when its value matches the value of the selected option.

 The selected options below were all added through filterable
**Before modification:**  
When selecting other options retrieved through the search, the search values remain in the options and accumulate more and more...
<img width="643" height="416" alt="image" src="https://github.com/user-attachments/assets/42734392-8540-4a46-ada8-9da5f5136b9b" />

**After modification:**  
Only newly created options that are successful will exist.
<img width="675" height="423" alt="image" src="https://github.com/user-attachments/assets/27ebe371-419f-474d-9cfd-3eedead7d7f1" />
