### PR TITLE
refactor(divider): replace to grid grid-inline layout, supporting vertical titles and title offsets

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - Fix `n-menu`'s disabled style not working when parent node is set to `disabled` and child node has `type: "group"`, closes [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - Fix `n-input-group-label` not injecting `formItemInjectionKey`, causing the `size` property to fail, and close [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - Fix the issue of style confusion in `n-carousel` when there is only one image, close [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- Fix `n-divider`'s uneven thickness in dividing lines.
 
 ### Features
 
@@ -34,6 +35,8 @@
 - - `n-image` adds showPreview methods, closes [#6695](https://github.com/tusen-ai/naive-ui/issues/6695).
 - `n-image-preview` `n-image-group` support being used independently.
 - `n-input-otp` adds `focusOnChar` util method, closes [#7073](https://github.com/tusen-ai/naive-ui/issues/7073).
+- `n-divider` adds `type`, `offset`, `title-class`, `title-style` props, the original ~~`dashed`~~ prop is replaced with `type="dashed"`, `title-placement` type is changed to `'before' | 'center' | 'after'`, supports using title in `vertical` layout.
+- `n-divider` adds `borderWidth`, `fontSize`, `margin`, `verticalMargin` theme variables. closes [#5348](https://github.com/tusen-ai/naive-ui/issues/5348)
 
 ## 2.42.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - 修复 `n-menu` 在父节点设置 `disabled`，子节点为 `type: "group"` 的禁用样式失效，关闭 [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - 修复 `n-input-group-label` 没有注入 `formItemInjectionKey`，导致 `size` 属性失效的问题，关闭 [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - 修复 `n-carousel` 只有一张图的情況下样式错乱的问题，关闭 [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- 修复 `n-divider` 的分割线条显示粗细不均的问题
 
 ### Features
 
@@ -34,6 +35,8 @@
 - `n-image` 增加 showPreview 方法，关闭 [#6695](https://github.com/tusen-ai/naive-ui/issues/6695)
 - `n-image-preview`，`n-image-group` 支持单独使用
 - `n-input-otp` 增加 `focusOnChar` 方法，关闭 [#7073](https://github.com/tusen-ai/naive-ui/issues/7073)
+- `n-divider` 增加 `type`、`offset`、`title-class`、`title-style` 属性，原 ~~`dashed`~~ 属性替换为 `type="dashed"`，`title-placement` 类型改为 `'before' | 'center' | 'after'`，支持 `vertical` 排版使用标题
+- `n-divider` 增加 `borderWidth`、`fontSize`、`margin`、`verticalMargin` 主题变量，关闭 [#5348](https://github.com/tusen-ai/naive-ui/issues/5348)
 
 ## 2.42.0
 

--- a/src/divider/demos/enUS/basic.demo.vue
+++ b/src/divider/demos/enUS/basic.demo.vue
@@ -3,7 +3,10 @@
 </markdown>
 
 <template>
-  Oops
+  Solid
   <n-divider />
-  Oops
+  Dashed
+  <n-divider type="dashed" />
+  Dotted
+  <n-divider type="dotted" />
 </template>

--- a/src/divider/demos/enUS/content.demo.vue
+++ b/src/divider/demos/enUS/content.demo.vue
@@ -4,16 +4,14 @@
 
 <template>
   Oops
-  <n-divider title-placement="left">
-    Left
+  <n-divider title-placement="before">
+    Before
   </n-divider>
   Oops
-  <n-divider title-placement="right">
-    Right
+  <n-divider title-placement="after">
+    After
   </n-divider>
   Oops
-  <n-divider dashed>
-    Dashed
-  </n-divider>
+  <n-divider> Center </n-divider>
   Oops
 </template>

--- a/src/divider/demos/enUS/content.offset.demo.vue
+++ b/src/divider/demos/enUS/content.offset.demo.vue
@@ -1,0 +1,23 @@
+<markdown>
+# Title Offset
+
+When `title-placement` is set to `before` or `after`, the `offset` property can be used to adjust the spacing between the title and divider line.
+</markdown>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const beforeOffset = ref(0)
+const afterOffset = ref(0)
+</script>
+
+<template>
+  <n-input-number v-model:value="beforeOffset" :min="0" />
+  <n-divider title-placement="before" :offset="beforeOffset">
+    Before
+  </n-divider>
+  <n-input-number v-model:value="afterOffset" :min="0" />
+  <n-divider title-placement="after" type="dashed" :offset="afterOffset">
+    After
+  </n-divider>
+</template>

--- a/src/divider/demos/enUS/index.demo-entry.md
+++ b/src/divider/demos/enUS/index.demo-entry.md
@@ -8,17 +8,22 @@ Divide something.
 basic.vue
 content.vue
 vertical.vue
+content.offset.vue
+vertical.content.vue
 ```
 
 ## API
 
 ### Divider Props
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| dashed | `boolean` | `false` | Whether to show dashed line. |
-| title-placement | `'left' \| 'right' \| 'center'` | `'center'` | Title placement. |
-| vertical | `boolean` | `false` | Whether to show vertical direction. |
+| Name | Type | Default | Description | Version |
+| --- | --- | --- | --- | --- |
+| type | `'solid' \| 'dashed' \| 'dotted'` | `'solid'` | The type of divider line | NEXT_VERSION |
+| title-placement | `'start' \| 'center' \| 'end'` | `'center'` | Title placement. | NEXT_VERSION |
+| offset | `number` | `28` | The offset between the dividing line and the title. Only valid when `title-placement` is `start` or `end` | NEXT_VERSION |
+| vertical | `boolean` | `false` | Whether to show vertical direction. |  |
+| title-class | `string` | `undefined` | The class name of the title div | NEXT_VERSION |
+| title-style | `string \| object` | `undefined` | The style of the title div | NEXT_VERSION |
 
 ### Divider Slots
 

--- a/src/divider/demos/enUS/vertical.content.demo.vue
+++ b/src/divider/demos/enUS/vertical.content.demo.vue
@@ -1,0 +1,33 @@
+<markdown>
+# Vertical Title
+</markdown>
+
+<template>
+  <div style="height: 200px">
+    This
+    <n-divider vertical title-placement="before">
+      Solid
+    </n-divider>
+    And
+    <n-divider
+      vertical
+      type="dashed"
+      :theme-overrides="{
+        borderWidth: '4px',
+      }"
+    >
+      Dashed
+    </n-divider>
+    And
+    <n-divider
+      vertical
+      type="dotted"
+      title-placement="after"
+      :theme-overrides="{
+        borderWidth: '4px',
+      }"
+    >
+      Dotted
+    </n-divider>
+  </div>
+</template>

--- a/src/divider/demos/zhCN/basic.demo.vue
+++ b/src/divider/demos/zhCN/basic.demo.vue
@@ -3,7 +3,10 @@
 </markdown>
 
 <template>
-  啊
+  实线
   <n-divider />
-  啊
+  虚线
+  <n-divider type="dashed" />
+  点线
+  <n-divider type="dotted" />
 </template>

--- a/src/divider/demos/zhCN/content.demo.vue
+++ b/src/divider/demos/zhCN/content.demo.vue
@@ -4,16 +4,14 @@
 
 <template>
   啊
-  <n-divider title-placement="left">
-    左
+  <n-divider title-placement="before">
+    前
   </n-divider>
   啊
-  <n-divider title-placement="right">
-    右
+  <n-divider title-placement="after">
+    后
   </n-divider>
   啊
-  <n-divider dashed>
-    虚线
-  </n-divider>
+  <n-divider> 居中 </n-divider>
   啊
 </template>

--- a/src/divider/demos/zhCN/content.offset.demo.vue
+++ b/src/divider/demos/zhCN/content.offset.demo.vue
@@ -1,0 +1,23 @@
+<markdown>
+# 标题偏移
+
+在 `title-placement` 为 `before` 或 `after` 时，添加 `offset` 属性可以设置标题与分割线的偏移量。
+</markdown>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const beforeOffset = ref(0)
+const afterOffset = ref(0)
+</script>
+
+<template>
+  <n-input-number v-model:value="beforeOffset" :min="0" />
+  <n-divider title-placement="before" :offset="beforeOffset">
+    前
+  </n-divider>
+  <n-input-number v-model:value="afterOffset" :min="0" />
+  <n-divider title-placement="after" type="dashed" :offset="afterOffset">
+    后
+  </n-divider>
+</template>

--- a/src/divider/demos/zhCN/index.demo-entry.md
+++ b/src/divider/demos/zhCN/index.demo-entry.md
@@ -8,17 +8,22 @@
 basic.vue
 content.vue
 vertical.vue
+content.offset.vue
+vertical.content.vue
 ```
 
 ## API
 
 ### Divider Props
 
-| 名称 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| dashed | `boolean` | `false` | 是否使用虚线分割 |
-| title-placement | `'left' \| 'right' \| 'center'` | `'center'` | 标题的位置 |
-| vertical | `boolean` | `false` | 是否垂直分隔 |
+| 名称 | 类型 | 默认值 | 说明 | 版本 |
+| --- | --- | --- | --- | --- |
+| type | `'solid' \| 'dashed' \| 'dotted'` | `'solid'` | 分割线的类型 | NEXT_VERSION |
+| title-placement | `'before' \| 'center' \| 'after'` | `'center'` | 标题的位置 | NEXT_VERSION |
+| offset | `number` | `28` | 分割线与标题的偏移量，只在 `title-placement` 为 `before` 或 `after` 时生效 | NEXT_VERSION |
+| vertical | `boolean` | `false` | 是否垂直分隔 |  |
+| title-class | `string` | `undefined` | 标题 div 的类名 | NEXT_VERSION |
+| title-style | `string \| object` | `undefined` | 标题 div 的 style | NEXT_VERSION |
 
 ### Divider Slots
 

--- a/src/divider/demos/zhCN/vertical.content.demo.vue
+++ b/src/divider/demos/zhCN/vertical.content.demo.vue
@@ -1,0 +1,37 @@
+<markdown>
+# 垂直标题
+</markdown>
+
+<template>
+  <div style="height: 200px">
+    这个
+    <n-divider vertical title-placement="before">
+      实线
+    </n-divider>
+    和
+    <n-divider
+      vertical
+      type="dashed"
+      :theme-overrides="{
+        borderWidth: '4px',
+      }"
+    >
+      虚线
+    </n-divider>
+    还有
+    <n-divider
+      vertical
+      type="dotted"
+      title-placement="after"
+      :theme-overrides="{
+        borderWidth: '4px',
+      }"
+    >
+      点线
+    </n-divider>
+    英文
+    <n-divider vertical>
+      What ?
+    </n-divider>
+  </div>
+</template>

--- a/src/divider/src/Divider.tsx
+++ b/src/divider/src/Divider.tsx
@@ -15,11 +15,20 @@ import style from './styles/index.cssr'
 
 export const dividerProps = {
   ...(useTheme.props as ThemeProps<DividerTheme>),
+  type: {
+    type: String as PropType<'solid' | 'dashed' | 'dotted'>,
+    default: 'solid'
+  },
   titlePlacement: {
-    type: String as PropType<'left' | 'center' | 'right'>,
+    type: String as PropType<'before' | 'center' | 'after' | 'left' | 'right'>,
     default: 'center'
   },
-  dashed: Boolean,
+  offset: {
+    type: Number,
+    default: 28
+  },
+  titleClass: String,
+  titleStyle: [Object, String] as PropType<string | Record<string, any>>,
   vertical: Boolean
 } as const
 
@@ -41,13 +50,26 @@ export default defineComponent({
     const cssVarsRef = computed(() => {
       const {
         common: { cubicBezierEaseInOut },
-        self: { color, textColor, fontWeight }
+        self: {
+          color,
+          textColor,
+          fontWeight,
+          borderWidth,
+          fontSize,
+          margin,
+          verticalMargin
+        }
       } = themeRef.value
       return {
         '--n-bezier': cubicBezierEaseInOut,
         '--n-color': color,
         '--n-text-color': textColor,
-        '--n-font-weight': fontWeight
+        '--n-font-size': fontSize,
+        '--n-font-weight': fontWeight,
+        '--n-border-width': borderWidth,
+        '--n-margin': margin,
+        '--n-vertical-margin': verticalMargin,
+        '--n-offset': `${props.offset || 0}px`
       }
     })
     const themeClassHandle = inlineThemeDisabled
@@ -65,10 +87,20 @@ export default defineComponent({
       $slots,
       titlePlacement,
       vertical,
-      dashed,
+      type,
       cssVars,
-      mergedClsPrefix
+      mergedClsPrefix,
+      titleClass,
+      titleStyle
     } = this
+
+    const placement
+      = titlePlacement === 'left'
+        ? 'before'
+        : titlePlacement === 'right'
+          ? 'after'
+          : titlePlacement
+
     this.onRender?.()
     return (
       <div
@@ -78,24 +110,26 @@ export default defineComponent({
           this.themeClass,
           {
             [`${mergedClsPrefix}-divider--vertical`]: vertical,
-            [`${mergedClsPrefix}-divider--no-title`]: !$slots.default,
-            [`${mergedClsPrefix}-divider--dashed`]: dashed,
-            [`${mergedClsPrefix}-divider--title-position-${titlePlacement}`]:
-              $slots.default && titlePlacement
+            [`${mergedClsPrefix}-divider--${type}`]: type,
+            [`${mergedClsPrefix}-divider--title-position-${placement}`]:
+              $slots.default && placement
           }
         ]}
         style={cssVars as CSSProperties}
       >
-        {!vertical ? (
-          <div
-            class={`${mergedClsPrefix}-divider__line ${mergedClsPrefix}-divider__line--left`}
-          />
-        ) : null}
-        {!vertical && $slots.default ? (
+        <div
+          class={`${mergedClsPrefix}-divider__line ${mergedClsPrefix}-divider__line--before`}
+        />
+        {$slots.default ? (
           <>
-            <div class={`${mergedClsPrefix}-divider__title`}>{this.$slots}</div>
             <div
-              class={`${mergedClsPrefix}-divider__line ${mergedClsPrefix}-divider__line--right`}
+              class={[`${mergedClsPrefix}-divider__title`, titleClass]}
+              style={titleStyle}
+            >
+              {this.$slots}
+            </div>
+            <div
+              class={`${mergedClsPrefix}-divider__line ${mergedClsPrefix}-divider__line--after`}
             />
           </>
         ) : null}

--- a/src/divider/src/styles/index.cssr.ts
+++ b/src/divider/src/styles/index.cssr.ts
@@ -74,6 +74,10 @@ export default cB('divider', `
           `)
     ]),
   ]),
+  cE('title', `
+    white-space: nowrap;
+    font-weight: var(--n-font-weight);
+  `),
   cE('line', `
     transition:
       border-color .3s var(--n-bezier);

--- a/src/divider/src/styles/index.cssr.ts
+++ b/src/divider/src/styles/index.cssr.ts
@@ -4,83 +4,78 @@ import { cB, cE, cM, cNotM } from '../../../_utils/cssr'
 // --n-bezier
 // --n-color
 // --n-text-color
+// --n-font-size
 // --n-font-weight
+// --n-offset
+// --n-border-width
 export default cB('divider', `
   position: relative;
-  display: flex;
-  width: 100%;
+  display: grid;
   box-sizing: border-box;
-  font-size: 16px;
+  font-size: var(--n-font-size);
   color: var(--n-text-color);
   transition:
-    color .3s var(--n-bezier),
-    background-color .3s var(--n-bezier);
+    color .3s var(--n-bezier);
 `, [
-  cNotM('vertical', `
-    margin-top: 24px;
-    margin-bottom: 24px;
-  `, [
-    cNotM('no-title', `
-      display: flex;
-      align-items: center;
-    `)
-  ]),
-  cE('title', `
-    display: flex;
-    align-items: center;
-    margin-left: 12px;
-    margin-right: 12px;
-    white-space: nowrap;
-    font-weight: var(--n-font-weight);
-  `),
-  cM('title-position-left', [
-    cE('line', [
-      cM('left', {
-        width: '28px'
-      })
-    ])
-  ]),
-  cM('title-position-right', [
-    cE('line', [
-      cM('right', {
-        width: '28px'
-      })
-    ])
-  ]),
-  cM('dashed', [
-    cE('line', `
-      background-color: #0000;
-      height: 0px;
-      width: 100%;
-      border-style: dashed;
-      border-width: 1px 0 0;
-    `)
-  ]),
-  cM('vertical', `
-    display: inline-block;
-    height: 1em;
-    margin: 0 8px;
-    vertical-align: middle;
-    width: 1px;
-  `),
-  cE('line', `
-    border: none;
-    transition: background-color .3s var(--n-bezier), border-color .3s var(--n-bezier);
-    height: 1px;
+  cNotM('vertical', [
+    `
     width: 100%;
-    margin: 0;
-  `),
-  cNotM('dashed', [
-    cE('line', {
-      backgroundColor: 'var(--n-color)'
-    })
+    align-items: center;
+    margin: var(--n-margin);
+    `,
+    cM('title-position-before', `grid-template-columns: var(--n-offset) auto 1fr;`),
+    cM('title-position-center', `grid-template-columns: 1fr auto 1fr;`),
+    cM('title-position-after', `grid-template-columns: 1fr auto var(--n-offset);`),
+    cE('title', `margin: 0 16px;`),
+    cE('line', `
+        width: 100%;
+        border-color: var(--n-color);
+        border-top-width: var(--n-border-width);
+        border-top-style: solid;
+      `),
+    cM('dashed', [
+      cE('line', `
+          border-top-style: dashed;
+        `)
+    ]),
+    cM('dotted', [
+      cE('line', `
+          border-top-style: dotted;
+        `)
+    ]),
   ]),
-  cM('dashed', [
-    cE('line', {
-      borderColor: 'var(--n-color)'
-    })
+  cM('vertical', [
+    `
+    display: inline-grid;
+    vertical-align: middle;
+    min-height: 1em;
+    height: 100%;
+    justify-items: center;
+    margin: var(--n-vertical-margin);
+    `,
+    cM('title-position-before', `grid-template-rows: var(--n-offset) auto 1fr;`),
+    cM('title-position-center', `grid-template-rows: 1fr auto 1fr;`),
+    cM('title-position-after', `grid-template-rows: 1fr auto var(--n-offset);`),
+    cE('title', `margin: 16px 0;writing-mode: vertical-lr;`),
+    cE('line', `
+        height: 100%;
+        border-color: var(--n-color);
+        border-left-width: var(--n-border-width);
+        border-left-style: solid;
+      `),
+    cM('dashed', [
+      cE('line', `
+            border-left-style: dashed;
+          `)
+    ]),
+    cM('dotted', [
+      cE('line', `
+            border-left-style: dotted;
+          `)
+    ]),
   ]),
-  cM('vertical', {
-    backgroundColor: 'var(--n-color)'
-  })
+  cE('line', `
+    transition:
+      border-color .3s var(--n-bezier);
+  `)
 ])

--- a/src/divider/styles/light.ts
+++ b/src/divider/styles/light.ts
@@ -7,7 +7,11 @@ export function self(vars: ThemeCommonVars) {
   return {
     textColor: textColor1,
     color: dividerColor,
-    fontWeight: fontWeightStrong
+    fontWeight: fontWeightStrong,
+    borderWidth: '1px',
+    fontSize: '16px',
+    margin: '24px 0',
+    verticalMargin: '0 8px'
   }
 }
 

--- a/src/divider/tests/Divider.spec.ts
+++ b/src/divider/tests/Divider.spec.ts
@@ -19,28 +19,25 @@ describe('n-divider', () => {
 
   it('should work with `title-placement` prop', async () => {
     const wrapper = mount(NDivider, {
-      props: { titlePlacement: 'left' },
+      props: { titlePlacement: 'before' },
       slots: { default: () => 'test' }
     })
     expect(wrapper.find('.n-divider').classes()).toContain(
-      'n-divider--title-position-left'
+      'n-divider--title-position-before'
     )
 
-    await wrapper.setProps({ titlePlacement: 'right' })
+    await wrapper.setProps({ titlePlacement: 'after' })
     expect(wrapper.find('.n-divider').classes()).toContain(
-      'n-divider--title-position-right'
+      'n-divider--title-position-after'
     )
     wrapper.unmount()
   })
 
-  it('should work with `dashed` prop', async () => {
+  it('should work with `type` prop', async () => {
     const wrapper = mount(NDivider)
 
-    await wrapper.setProps({ dashed: true })
+    await wrapper.setProps({ type: 'dashed' })
     expect(wrapper.find('.n-divider').classes()).toContain('n-divider--dashed')
-    expect(wrapper.find('.n-divider').classes()).toContain(
-      'n-divider--no-title'
-    )
     wrapper.unmount()
   })
 
@@ -53,5 +50,43 @@ describe('n-divider', () => {
       'n-divider--vertical'
     )
     wrapper.unmount()
+  })
+
+  it('should work with `offset` prop', async () => {
+    const wrapper = mount(NDivider, {
+      props: { titlePlacement: 'before' }
+    })
+
+    expect(wrapper.find('.n-divider').attributes('style')).toContain(
+      '--n-offset: 28px'
+    )
+    await wrapper.setProps({ offset: 50 })
+    expect(wrapper.find('.n-divider').attributes('style')).toContain(
+      '--n-offset: 50px'
+    )
+    wrapper.unmount()
+  })
+
+  it('should work with `titleClass` prop', async () => {
+    const wrapper = mount(NDivider, {
+      props: { titleClass: 'title-class' },
+      slots: { default: () => 'test' }
+    })
+
+    expect(
+      wrapper.find('.n-divider').find('.n-divider__title').classes()
+    ).toContain('title-class')
+    wrapper.unmount()
+  })
+
+  it('should work with `titleStyle` prop', async () => {
+    const wrapper = mount(NDivider, {
+      props: { titleStyle: 'color: red;' },
+      slots: { default: () => 'test' }
+    })
+
+    expect(
+      wrapper.find('.n-divider').find('.n-divider__title').attributes('style')
+    ).toContain('color: red;')
   })
 })


### PR DESCRIPTION
增加属性
- `type`
- `offset`
- `title-class`
- `title-style` 

~~`dashed`~~ 属性替换为 `type="dashed"`, `type = 'solid' | 'dashed' | 'dotted'`

`title-placement` 类型改为 `'before' | 'center' | 'after'`，支持 `vertical` 排版使用标题

增加主题变量（关闭 [#5348](https://github.com/tusen-ai/naive-ui/issues/5348)）
-  `borderWidth`
- `fontSize`
- `margin`
- `verticalMargin` 



修复
- 1px的分割线条显示粗细不均的问题，`height` -> `border`


<img width="1704" height="1216" alt="image" src="https://github.com/user-attachments/assets/d647529c-7748-4d10-b49b-f04cff4b8a83" />


close https://github.com/tusen-ai/naive-ui/issues/5348

