### PR TITLE
fix(dropdown,menu): style conflicts and shared attributes

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -20,6 +20,7 @@
 - Fix `n-input-group-label` not injecting `formItemInjectionKey`, causing the `size` property to fail, and close [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - Fix the issue of style confusion in `n-carousel` when there is only one image, close [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
 - Fix `n-dropdown`'s `suffix` element `z-index` layer style occlusion problem.
+- Fix `n-menu`'s `dropdown-props` property shares problem with its own `render-icon` `render-label` properties.
 
 ### Features
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - Fix `n-menu`'s disabled style not working when parent node is set to `disabled` and child node has `type: "group"`, closes [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - Fix `n-input-group-label` not injecting `formItemInjectionKey`, causing the `size` property to fail, and close [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - Fix the issue of style confusion in `n-carousel` when there is only one image, close [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- Fix `n-dropdown`'s `suffix` element `z-index` layer style occlusion problem.
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -20,6 +20,7 @@
 - 修复 `n-input-group-label` 没有注入 `formItemInjectionKey`，导致 `size` 属性失效的问题，关闭 [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - 修复 `n-carousel` 只有一张图的情況下样式错乱的问题，关闭 [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
 - 修复 `n-dropdown` 的 `suffix` 元素 `z-index` 层级样式遮挡问题
+- 修复 `n-menu` 的 `dropdown-props` 属性与自身的 `render-icon` `render-label` 属性共用问题
 
 ### Features
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - 修复 `n-menu` 在父节点设置 `disabled`，子节点为 `type: "group"` 的禁用样式失效，关闭 [#6792](https://github.com/tusen-ai/naive-ui/issues/6792)
 - 修复 `n-input-group-label` 没有注入 `formItemInjectionKey`，导致 `size` 属性失效的问题，关闭 [#7066](https://github.com/tusen-ai/naive-ui/issues/7066)
 - 修复 `n-carousel` 只有一张图的情況下样式错乱的问题，关闭 [#6476](https://github.com/tusen-ai/naive-ui/issues/6476)
+- 修复 `n-dropdown` 的 `suffix` 元素 `z-index` 层级样式遮挡问题
 
 ### Features
 

--- a/src/dropdown/src/styles/index.cssr.ts
+++ b/src/dropdown/src/styles/index.cssr.ts
@@ -148,7 +148,6 @@ export default cB('dropdown-menu', `
         padding: 0 8px;
         transition: color .3s var(--n-bezier);
         color: var(--n-suffix-color);
-        z-index: 1;
       `, [
         cM('has-submenu', `
           width: var(--n-option-icon-suffix-width);

--- a/src/menu/src/Submenu.tsx
+++ b/src/menu/src/Submenu.tsx
@@ -128,6 +128,12 @@ export const NSubmenu = defineComponent({
       mergedClsPrefix,
       menuProps: { renderIcon, renderLabel }
     } = this
+
+    const mergedRenderIcon
+      = this.menuProps?.dropdownProps?.renderIcon || renderIcon
+    const mergedRenderLabel
+      = this.menuProps?.dropdownProps?.renderLabel || renderLabel
+
     const createSubmenuItem = (): VNode => {
       const {
         isHorizontal,
@@ -213,8 +219,8 @@ export const NSubmenu = defineComponent({
         options={this.rawNodes}
         onSelect={this.doSelect}
         inverted={this.inverted}
-        renderIcon={renderIcon}
-        renderLabel={renderLabel}
+        renderIcon={mergedRenderIcon}
+        renderLabel={mergedRenderLabel}
       >
         {{
           default: () => (


### PR DESCRIPTION
### dropdown: 
- 当 `label` 属性为 `a` 元素时，菜单项中 `suffix` 元素 `z-index` 会遮挡 `a` 属性的点击跳转 `(a:before)`
<img width="970" height="596" alt="image" src="https://github.com/user-attachments/assets/f9d516e2-e5a7-4fd0-9864-dd706a90604f" />

### menu:
- `menu` 中的 `render-icon` `render-label` 和 `dropdown-props`  可以分开设置，不再共用

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
