### PR TITLE
feat: (form, form-item) expose calculate label width method 

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -57,6 +57,7 @@
 - `useModal` add `render` function, closes [#5857](https://github.com/tusen-ai/naive-ui/issues/5857).
 - `n-card` add `close-focusable` prop.
 - `n-dialog` add `close-focusable` prop.
+- `n-form-item` adds `calcLabelWidth` method，`n-form` adds `calcLabelWidths` method，closes [#5939](https://github.com/tusen-ai/naive-ui/issues/5939)
 
 ## 2.42.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -56,6 +56,7 @@
 - `useModal` 新增 `render` 函数，关闭 [#5857](https://github.com/tusen-ai/naive-ui/issues/5857)
 - `n-card` 新增 `close-focusable` 属性
 - `n-dialog` 新增 `close-focusable` 属性
+- `n-form-item` 增加 `calcLabelWidth` 方法，`n-form` 增加 `calcLabelWidths` 方法，关闭 [#5939](https://github.com/tusen-ai/naive-ui/issues/5939)
 
 ## 2.42.0
 

--- a/src/form/src/Form.tsx
+++ b/src/form/src/Form.tsx
@@ -87,6 +87,14 @@ export default defineComponent({
         maxChildLabelWidthRef.value = currentWidth
       }
     }
+    function calcChildLabelWidths(): void {
+      for (const key of keysOf(formItems)) {
+        const formItemInstances = formItems[key]
+        for (const formItemInstance of formItemInstances) {
+          formItemInstance.calcLabelWidth?.()
+        }
+      }
+    }
     async function validate(
       validateCallback?: FormValidateCallback,
       shouldRuleBeApplied: ShouldRuleBeApplied = () => true
@@ -151,7 +159,8 @@ export default defineComponent({
     provide(formItemInstsInjectionKey, { formItems })
     const formExposedMethod: FormInst = {
       validate,
-      restoreValidation
+      restoreValidation,
+      calcChildLabelWidths
     }
     return Object.assign(formExposedMethod, {
       mergedClsPrefix: mergedClsPrefixRef

--- a/src/form/src/FormItem.tsx
+++ b/src/form/src/FormItem.tsx
@@ -176,6 +176,7 @@ export default defineComponent({
       }>
     >([])
     const feedbackIdRef = ref(createId())
+    const labelElementRef = ref<null | HTMLLabelElement>(null)
     const mergedDisabledRef = NForm
       ? toRef(NForm.props, 'disabled')
       : ref(false)
@@ -192,6 +193,20 @@ export default defineComponent({
         return
       restoreValidation()
     })
+    function calcLabelWidth(): void {
+      if (!formItemMiscRefs.isAutoLabelWidth.value)
+        return
+      const labelElement = labelElementRef.value
+      if (labelElement !== null) {
+        const memoizedWhitespace = labelElement.style.whiteSpace
+        labelElement.style.whiteSpace = 'nowrap'
+        labelElement.style.width = ''
+        NForm?.deriveMaxChildLabelWidth(
+          Number(getComputedStyle(labelElement).width.slice(0, -2))
+        )
+        labelElement.style.whiteSpace = memoizedWhitespace
+      }
+    }
     function restoreValidation(): void {
       renderExplainsRef.value = []
       validationErroredRef.value = false
@@ -421,23 +436,10 @@ export default defineComponent({
     const exposedRef: FormItemInst = {
       validate,
       restoreValidation,
-      internalValidate
+      internalValidate,
+      calcLabelWidth
     }
-    const labelElementRef = ref<null | HTMLLabelElement>(null)
-    onMounted((): void => {
-      if (!formItemMiscRefs.isAutoLabelWidth.value)
-        return
-      const labelElement = labelElementRef.value
-      if (labelElement !== null) {
-        const memoizedWhitespace = labelElement.style.whiteSpace
-        labelElement.style.whiteSpace = 'nowrap'
-        labelElement.style.width = ''
-        NForm?.deriveMaxChildLabelWidth(
-          Number(getComputedStyle(labelElement).width.slice(0, -2))
-        )
-        labelElement.style.whiteSpace = memoizedWhitespace
-      }
-    })
+    onMounted(calcLabelWidth)
     const cssVarsRef = computed(() => {
       const { value: size } = mergedSizeRef
       const { value: labelPlacement } = labelPlacementRef

--- a/src/form/src/interface.ts
+++ b/src/form/src/interface.ts
@@ -67,6 +67,7 @@ export type FormItemValidate = ((options: FormItemValidateOptions) => Promise<{
 export interface FormItemInst {
   validate: FormItemValidate
   restoreValidation: () => void
+  calcLabelWidth: () => void
   path?: string
   internalValidate: FormItemInternalValidate
 }
@@ -112,6 +113,7 @@ export type FormValidationError = ValidateError[]
 export interface FormInst {
   validate: FormValidate
   restoreValidation: () => void
+  calcChildLabelWidths: () => void
 }
 
 export interface FormValidateMessages extends ValidateMessages {}


### PR DESCRIPTION
When the label-width is set to auto, the component dynamically calculates the label width for each form-item upon mounting. However, this calculation is performed only once during the mounted lifecycle. If a form item is subsequently hidden or removed, or is initially in an invisible state (e.g., display: none), its label width cannot be accurately obtained, leading to layout misalignment.

To address this, both components expose a method for recalculating the label width, allowing developers to manually trigger an update at the appropriate time to ensure accurate width calculation.
CLOSES #5939