### PR TITLE
feat(message): add border theme variable for message types

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Features
+
+- `n-message` add `border` theme variable for each type, closes [#7105](https://github.com/tusen-ai/naive-ui/issues/7105).
+
 ## 2.43.1
 
 `2025-09-15`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -6,7 +6,7 @@
 
 ### Features
 
-- `n-message` 增加 各类型的 `border` 主题变量，关闭 [#7105](https://github.com/tusen-ai/naive-ui/issues/7105)
+- `n-message` 增加各类型的 `border` 主题变量，关闭 [#7105](https://github.com/tusen-ai/naive-ui/issues/7105)
 
 ## 2.43.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Features
+
+- `n-message` 增加 各类型的 `border` 主题变量，关闭 [#7105](https://github.com/tusen-ai/naive-ui/issues/7105)
+
 ## 2.43.1
 
 `2025-09-15`

--- a/src/message/src/Message.tsx
+++ b/src/message/src/Message.tsx
@@ -1,12 +1,7 @@
 import type { CSSProperties, PropType, VNodeChild } from 'vue'
 /* eslint-disable no-cond-assign */
 import type { MessageRenderMessage, MessageType } from './types'
-import {
-  computed,
-  defineComponent,
-  h,
-  inject
-} from 'vue'
+import { computed, defineComponent, h, inject } from 'vue'
 import {
   NBaseClose,
   NBaseIcon,
@@ -69,22 +64,18 @@ export default defineComponent({
           fontSize,
           lineHeight,
           borderRadius,
-          border,
-          iconColorInfo,
-          iconColorSuccess,
-          iconColorWarning,
-          iconColorError,
-          iconColorLoading,
           closeIconSize,
           closeBorderRadius,
           [createKey('textColor', type)]: textColor,
           [createKey('boxShadow', type)]: boxShadow,
+          [createKey('border', type)]: border,
           [createKey('color', type)]: color,
           [createKey('closeColorHover', type)]: closeColorHover,
           [createKey('closeColorPressed', type)]: closeColorPressed,
           [createKey('closeIconColor', type)]: closeIconColor,
           [createKey('closeIconColorPressed', type)]: closeIconColorPressed,
-          [createKey('closeIconColorHover', type)]: closeIconColorHover
+          [createKey('closeIconColorHover', type)]: closeIconColorHover,
+          [createKey('iconColor', type)]: iconColor
         }
       } = themeRef.value
       return {
@@ -102,11 +93,7 @@ export default defineComponent({
         '--n-text-color': textColor,
         '--n-color': color,
         '--n-box-shadow': boxShadow,
-        '--n-icon-color-info': iconColorInfo,
-        '--n-icon-color-success': iconColorSuccess,
-        '--n-icon-color-warning': iconColorWarning,
-        '--n-icon-color-error': iconColorError,
-        '--n-icon-color-loading': iconColorLoading,
+        '--n-icon-color': iconColor,
         '--n-close-color-hover': closeColorHover,
         '--n-close-color-pressed': closeColorPressed,
         '--n-close-icon-color': closeIconColor,
@@ -179,9 +166,7 @@ export default defineComponent({
           >
             {(iconNode = createIconVNode(icon, type, mergedClsPrefix))
               && showIcon ? (
-                  <div
-                    class={`${mergedClsPrefix}-message__icon ${mergedClsPrefix}-message__icon--${type}-type`}
-                  >
+                  <div class={`${mergedClsPrefix}-message__icon`}>
                     <NIconSwitchTransition>
                       {{
                         default: () => iconNode

--- a/src/message/src/styles/index.cssr.ts
+++ b/src/message/src/styles/index.cssr.ts
@@ -81,15 +81,9 @@ export default c([
       font-size: var(--n-icon-size);
       flex-shrink: 0;
     `, [
-      ['default', 'info', 'success', 'warning', 'error', 'loading'].map(type =>
-        cM(`${type}-type`, [
-          c('> *', `
-            color: var(--n-icon-color-${type});
-            transition: color .3s var(--n-bezier);
-          `)
-        ])
-      ),
       c('> *', `
+        color: var(--n-icon-color);
+        transition: color .3s var(--n-bezier);
         position: absolute;
         left: 0;
         top: 0;

--- a/src/message/styles/light.ts
+++ b/src/message/styles/light.ts
@@ -81,7 +81,12 @@ export function self(vars: ThemeCommonVars) {
     loadingColor: primaryColor,
     lineHeight,
     borderRadius,
-    border: '0'
+    border: '0',
+    borderInfo: '0',
+    borderSuccess: '0',
+    borderWarning: '0',
+    borderError: '0',
+    borderLoading: '0'
   }
 }
 


### PR DESCRIPTION
给 `message` 新增 各类型的 `border` 变量，同时删除了 `.n-message-wrapper` 一些用不上的 `-n-icon-color-[type]` 图标颜色 `style` 变量，最终可以配置到如下的效果，关闭 #7105 


<img width="682" height="686" alt="image" src="https://github.com/user-attachments/assets/26426b7a-cc19-4d7f-bfa7-3846503b26d1" />



```json
{
  "Message": {
    "borderInfo": "1px solid #3b82f6",
    "borderSuccess": "1px solid #22c55e",
    "borderWarning": "1px solid #eab308",
    "borderError": "1px solid #ef4444",
    "borderLoading": "1px solid #10b981",
    "colorInfo": "#eff6ffFF",
    "colorSuccess": "#f0fdf4FF",
    "colorWarning": "#fefce8FF",
    "colorLoading": "#ecfdf5FF",
    "colorError": "#fef2f2FF",
    "iconColorLoading": "#059669FF",
    "iconColorWarning": "#ca8a04FF",
    "iconColorSuccess": "#16a34aFF",
    "iconColorInfo": "#2563ebFF",
    "iconColorError": "#dc2626FF",
    "textColorInfo": "#1d4ed8FF",
    "textColorSuccess": "#15803dFF",
    "textColorWarning": "#a16207FF",
    "textColorError": "#b91c1cFF",
    "textColorLoading": "#047857FF"
  }
}
```






<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
