### PR TITLE
feat(split): add resize-trigger-hit-size prop, the hit range can be adjusted

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+`NEXT_VERSION`
+
+### Features
+
+- `n-split` adds `resize-trigger-hit-size` prop, closes [#7223](https://github.com/tusen-ai/naive-ui/issues/7223).
+
 ## 2.43.1
 
 `2025-09-15`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Features
+
+- `n-split` 新增 `resize-trigger-hit-size` 属性，关闭 [#7223](https://github.com/tusen-ai/naive-ui/issues/7223)
+
 ## 2.43.1
 
 `2025-09-15`

--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -31,6 +31,7 @@ controlled.vue
 | pane2-class | `string` | `undefined` | The class name of the second pane. | 2.38.2 |
 | pane2-style | `Object \| string` | `undefined` | The Style of the second pane | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Size of the resize trigger. | 2.36.0 |
+| resize-trigger-hit-size | `number` | `0` | The hit size of the resize trigger, it's added to the `resize-trigger-size`. | NEXT_VERSION |
 | size | `string \| number` | `undefined` | Split is the controlled split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.38.0, `string` 2.38.2 |
 | watch-props | `Array<'defaultSize'>` | `undefined` | Default prop names that needed to be watched. Components will be updated after the prop is changed. Note: the `watch-props` itself is not reactive. | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | Callback function when drag start. | 2.36.0 |

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -32,6 +32,7 @@ pixel-value.vue
 | pane2-class | `string` | `undefined` | 第二个面板的类名 | 2.38.2 |
 | pane2-style | `Object \| string` | `undefined` | 第二个面板的样式 | 2.38.2 |
 | resize-trigger-size | `number` | `3` | Split 的分隔条大小 | 2.36.0 |
+| resize-trigger-hit-size | `number` | `0` | Split 的分隔条点击区域大小，在 `resize-trigger-size` 的基础上增加 | NEXT_VERSION |
 | size | `string \| number` | `undefined` | Split 的受控分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.38.0, `string` 2.38.2 |
 | watch-props | `Array<'defaultSize'>` | `undefined` | 需要检测变更的默认属性，检测后组件状态会更新。注意：`watch-props` 本身不是响应式的 | 2.38.0 |
 | on-drag-start | `(e: Event) => void` | `undefined` | 开始拖拽的回调函数 | 2.36.0 |

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -23,6 +23,10 @@ export const splitProps = {
     type: Number,
     default: 3
   },
+  resizeTriggerHitSize: {
+    type: Number,
+    default: 0
+  },
   disabled: Boolean,
   defaultSize: {
     type: [String, Number] as PropType<string | number>,
@@ -85,7 +89,8 @@ export default defineComponent({
       return {
         '--n-bezier': cubicBezierEaseInOut,
         '--n-resize-trigger-color': resizableTriggerColor,
-        '--n-resize-trigger-color-hover': resizableTriggerColorHover
+        '--n-resize-trigger-color-hover': resizableTriggerColorHover,
+        '--n-resize-trigger-hit-size': `${props.resizeTriggerHitSize}px`
       }
     })
     const resizeTriggerElRef = ref<HTMLElement | null>(null)

--- a/src/split/src/styles/index.cssr.ts
+++ b/src/split/src/styles/index.cssr.ts
@@ -11,10 +11,24 @@ export default cB('split', `
 `, [
   cM('horizontal', `
     flex-direction: row;
-  `),
+  `, [
+    cE('resize-trigger-wrapper', [
+      c('&::after', `
+        width: calc(100% + var(--n-resize-trigger-hit-size));
+        height: 100%;
+        `)
+    ]),
+  ]),
   cM('vertical', `
     flex-direction: column;
-  `),
+  `, [
+    cE('resize-trigger-wrapper', [
+      c('&::after', `
+        width: 100%;
+        height: calc(100% + var(--n-resize-trigger-hit-size));
+        `)
+    ]),
+  ]),
   cB('split-pane-1', `
     overflow: hidden;
   `),
@@ -22,6 +36,16 @@ export default cB('split', `
     overflow: hidden;
     flex: 1;
   `),
+  cE('resize-trigger-wrapper', `
+    position: relative;
+    `, [
+    c('&::after', `
+      content: '';
+      position: absolute;
+      inset: 50%;
+      transform: translate(-50%, -50%);
+      `)
+  ]),
   cE('resize-trigger', `
     background-color: var(--n-resize-trigger-color);
     transition: background-color .3s var(--n-bezier);


### PR DESCRIPTION
添加 `resize-trigger-hit-size` 属性，在 `resize-trigger-size` 上加算，使其可以设置拖动的命中范围大小
关闭 #7223 


<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
