### PR TITLE
refactor(loader): enhance parse logic with `@vue/compiler-sfc` 

### DIFF
--- a/build/types/vue-to-demo.ts
+++ b/build/types/vue-to-demo.ts
@@ -1,0 +1,28 @@
+export type VueApiStyle = 'composition' | 'options'
+export type ScriptLanguage = 'ts' | 'js'
+
+export interface DemoParts {
+  template?: string
+  script?: string
+  style?: string
+  title: string
+  content: string
+  language: ScriptLanguage
+  api: VueApiStyle
+}
+
+export interface TransformedCode {
+  tsCode: string
+  jsCode: string
+}
+
+export interface MergedParts extends DemoParts, TransformedCode {}
+
+export interface DemoPartsWithBuildOptions {
+  parts: DemoParts
+  isVue: boolean
+}
+
+export interface MergePartsWithBuildOptions extends DemoPartsWithBuildOptions {
+  mergedParts: MergedParts
+}

--- a/build/utils/handle-merge-code.ts
+++ b/build/utils/handle-merge-code.ts
@@ -1,25 +1,7 @@
+import type { MergePartsWithBuildOptions } from '../types/vue-to-demo'
 import { tsToJs } from './tsToJs'
 
-interface Parts {
-  api?: 'composition' | 'options'
-  language?: 'ts' | 'js'
-  template?: string
-  script?: string
-  style?: string
-}
-
-interface MergedParts {
-  tsCode: string
-  jsCode: string
-}
-
-interface MergeCodeOptions {
-  parts: Parts
-  mergedParts: MergedParts
-  isVue: boolean
-}
-
-export function handleMergeCode(options: MergeCodeOptions): void {
+export function handleMergeCode(options: MergePartsWithBuildOptions): void {
   const { parts, mergedParts, isVue } = options
   const isCompositionApi = parts.api === 'composition'
   if (isVue && parts.language === 'ts') {


### PR DESCRIPTION
- refactor `convert-vue-to-demo` parse logic with `@vue/compiler-sfc`.parse() instate of `RegExp`
- refactor type for common part of `convert-vue-to-demo.ts` and `hanleMergeCode`