### PR TITLE
feat(code,log,config-provider): add shiki support

### DIFF
--- a/demo/SiteRoot.vue
+++ b/demo/SiteRoot.vue
@@ -20,6 +20,7 @@ export default defineComponent({
   <component
     :is="configProvider"
     class="demo"
+    :data-theme="themeName"
     namespace="naive-ui-doc"
     preflight-style-disabled
     :theme-name="themeName"

--- a/demo/styles/demo.css
+++ b/demo/styles/demo.css
@@ -62,6 +62,22 @@ body {
   }
 }
 
+/*
+ * Keep Shiki code blocks in sync with the current site theme.
+ * Reference: https://shiki.style/guide/dual-themes
+ */
+.demo[data-theme='dark'] .shiki,
+.demo[data-theme='dark'] .shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style, inherit) !important;
+  font-weight: var(--shiki-dark-font-weight, inherit) !important;
+  text-decoration: var(
+    --shiki-dark-text-decoration,
+    var(--shiki-light-text-decoration, none)
+  ) !important;
+}
+
 @media only screen and (max-width: 639px) {
   body {
     overflow: visible;

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "rimraf": "^6.0.1",
     "rollup": "^4.45.1",
     "rollup-plugin-esbuild": "^6.2.1",
+    "shiki": "^3.17.0",
     "superagent": "^10.2.2",
     "tsx": "^4.20.3",
     "typescript": "^5.9.2",

--- a/src/_mixins/index.ts
+++ b/src/_mixins/index.ts
@@ -5,6 +5,8 @@ export { default as useHljs } from './use-hljs'
 export type { Hljs } from './use-hljs'
 export { default as useLocale } from './use-locale'
 export { useRtl } from './use-rtl'
+export { default as useShiki } from './use-shiki'
+export type { Shiki } from './use-shiki'
 export { default as useStyle } from './use-style'
 export { createTheme, default as useTheme } from './use-theme'
 export type {

--- a/src/_mixins/use-shiki.ts
+++ b/src/_mixins/use-shiki.ts
@@ -1,0 +1,21 @@
+import type { ComputedRef } from 'vue'
+import { computed, inject } from 'vue'
+import { configProviderInjectionKey } from '../config-provider/src/context'
+
+interface UseShikiProps {
+  shiki?: unknown
+  [key: string]: unknown
+}
+
+export interface Shiki {
+  codeToHtml: (code: string, options: any) => string
+}
+
+export default function useShiki(
+  props: UseShikiProps
+): ComputedRef<Shiki | undefined> {
+  const NConfigProvider = inject(configProviderInjectionKey, null)
+  return computed(() => {
+    return (props.shiki as any) || NConfigProvider?.mergedShikiRef?.value
+  })
+}

--- a/src/_mixins/use-shiki.ts
+++ b/src/_mixins/use-shiki.ts
@@ -2,13 +2,17 @@ import type { ComputedRef } from 'vue'
 import { computed, inject } from 'vue'
 import { configProviderInjectionKey } from '../config-provider/src/context'
 
-interface UseShikiProps {
-  shiki?: unknown
-  [key: string]: unknown
+export interface Shiki {
+  /**
+   * The consumer (e.g. n-code / n-log) only cares about the rendered HTML string.
+   * Users may configure languages, themes or hooks when constructing the Shiki
+   * instance, but all those details should be hidden behind this single method.
+   */
+  codeToHtml: (code: string) => string
 }
 
-export interface Shiki {
-  codeToHtml: (code: string, options: any) => string
+interface UseShikiProps {
+  shiki?: Shiki
 }
 
 export default function useShiki(

--- a/src/code/demos/enUS/index.demo-entry.md
+++ b/src/code/demos/enUS/index.demo-entry.md
@@ -1,9 +1,11 @@
 # Code
 
+Starting from NEXT_VERSION, Shiki is supported as an alternative code highlighter.
+
 ## Prequisites
 
 <n-alert title="Note" type="warning" style="margin-bottom: 16px;" :bordered="false">
-  Due to package size, Naive UI doesn't include highlight.js. If you want to use Code, make sure you have set highlightjs before using it.
+  Due to package size, Naive UI doesn't include highlight.js or Shiki. If you want to use Code, make sure you have set highlight.js or Shiki before using it.
 </n-alert>
 
 The following code shows how to set hljs of Code. Importing highlight.js on demand is recommonded, because it can significantly reduce bundle size of your app.
@@ -32,6 +34,50 @@ The following code shows how to set hljs of Code. Importing highlight.js on dema
 </script>
 ```
 
+The following code shows how to set Shiki for Code. For more details please check the [Shiki](https://shiki.style/) documentation.
+
+```html
+<template>
+  <n-config-provider :shiki="shiki">
+    <my-app />
+  </n-config-provider>
+</template>
+
+<script>
+  import { defineComponent } from 'vue'
+  import { onMounted, ref } from 'vue'
+  import { createHighlighter } from 'shiki'
+
+  export default defineComponent({
+    setup() {
+      const shiki = ref(null)
+      onMounted(async () => {
+        const highlighter = await createHighlighter({
+          themes: ['github-light', 'github-dark'],
+          langs: ['javascript']
+        })
+
+        shiki.value = {
+          codeToHtml(code: string) {
+            return highlighter.codeToHtml(code, {
+              lang: 'javascript',
+              themes: {
+                light: 'github-light',
+                dark: 'github-dark'
+              }
+            })
+          }
+        }
+      })
+
+      return {
+        shiki
+      }
+    }
+  })
+</script>
+```
+
 ## Demos
 
 ```demo
@@ -39,6 +85,7 @@ basic.vue
 inline.vue
 softwrap.vue
 line-numbers.vue
+shiki.vue
 ```
 
 ## API
@@ -54,3 +101,20 @@ line-numbers.vue
 | show-line-numbers | `boolean` | `false` | Whether to show line numbers. Won't work if `inline` or `word-wrap` is `true`. | 2.32.0 |
 | trim | `boolean` | `true` | Whether to display trimmed code. |  |
 | word-wrap | `boolean` | `false` | Whether to display word-wrapped code. | 2.24.0 |
+| shiki | `Shiki` | `undefined` | Provide a Shiki instance if you'd like to use Shiki for highlighting. | NEXT_VERSION |
+
+### Shiki Type
+
+```ts
+interface Shiki {
+  /**
+   * The consumer (e.g. n-code / n-log) only cares about the rendered HTML string.
+   * Users may configure languages, themes or hooks when constructing the Shiki
+   * instance, but all those details should be hidden behind this single method.
+   */
+  codeToHtml: (
+    code: string,
+    options: { lang: string, theme?: string | object }
+  ) => string
+}
+```

--- a/src/code/demos/enUS/shiki.demo.vue
+++ b/src/code/demos/enUS/shiki.demo.vue
@@ -1,7 +1,7 @@
 <markdown>
-# 使用 Shiki
+# Use Shiki
 
-使用 `Shiki` 来高亮代码。
+Highlight code with `Shiki`.
 </markdown>
 
 <script lang="ts" setup>
@@ -36,3 +36,4 @@ onMounted(async () => {
 <template>
   <n-code :shiki="shiki" :code="code" show-line-numbers />
 </template>
+```

--- a/src/code/demos/zhCN/index.demo-entry.md
+++ b/src/code/demos/zhCN/index.demo-entry.md
@@ -1,9 +1,11 @@
 # 代码 Code
 
+自 NEXT_VERSION 起, 支持 Shiki 作为代码高亮的选项之一
+
 ## 预备条件
 
 <n-alert title="注意" type="warning" style="margin-bottom: 16px;" :bordered="false">
-  由于包体积原因，Naive UI 不内置 highlight.js。如果你需要使用代码组件，请确保你在使用之前已经设定了 highlight.js。
+  由于包体积原因，Naive UI 不内置 highlight.js 或 Shiki。如果你需要使用代码组件，请确保你在使用之前已经设定了 highlight.js 或 Shiki。
 </n-alert>
 
 下面的代码展示了如何为 Code 设定 hljs。比较推荐的方式是按需引入，因为它可以极大地减小打包尺寸。
@@ -26,6 +28,48 @@
     setup() {
       return {
         hljs
+      }
+    }
+  })
+</script>
+```
+
+下面的代码展示了如何为 Code 设定 shiki。更多内容请参考 [Shiki](https://shiki.style/) 文档。
+
+```html
+<template>
+  <n-config-provider :shiki="shiki">
+    <my-app />
+  </n-config-provider>
+</template>
+
+<script>
+  import { defineComponent } from 'vue'
+  import { onMounted, ref } from 'vue'
+  import { createHighlighter } from 'shiki'
+  export default defineComponent({
+    setup() {
+      const shiki = ref(null)
+      onMounted(async () => {
+        const highlighter = await createHighlighter({
+          themes: ['github-light', 'github-dark'],
+          langs: ['javascript']
+        })
+
+        shiki.value = {
+          codeToHtml(code: string) {
+            return highlighter.codeToHtml(code, {
+              lang: 'javascript',
+              themes: {
+                light: 'github-light',
+                dark: 'github-dark'
+              }
+            })
+          }
+        }
+      })
+      return {
+        shiki
       }
     }
   })
@@ -56,3 +100,20 @@ shiki.vue
 | show-line-numbers | `boolean` | `false` | 是否显示行号，在 `inline` 或 `word-wrap` 的情况下不生效 | 2.32.0 |
 | trim | `boolean` | `true` | 是否显示 trim 后的代码 |  |
 | word-wrap | `boolean` | `false` | 代码过长时是否自动换行 | 2.24.0 |
+| shiki | `Shiki` | `undefined` | 如果你想使用 shiki 进行代码高亮，可以通过这个属性传给组件 | NEXT_VERSION |
+
+### Shiki 类型
+
+```ts
+interface Shiki {
+  /**
+   * The consumer (e.g. n-code / n-log) only cares about the rendered HTML string.
+   * Users may configure languages, themes or hooks when constructing the Shiki
+   * instance, but all those details should be hidden behind this single method.
+   */
+  codeToHtml: (
+    code: string,
+    options: { lang: string, theme?: string | object }
+  ) => string
+}
+```

--- a/src/code/demos/zhCN/index.demo-entry.md
+++ b/src/code/demos/zhCN/index.demo-entry.md
@@ -40,6 +40,7 @@ inline.vue
 softwrap.vue
 loop-debug.vue
 line-numbers.vue
+shiki.vue
 ```
 
 ## API

--- a/src/code/demos/zhCN/shiki.demo.vue
+++ b/src/code/demos/zhCN/shiki.demo.vue
@@ -4,37 +4,32 @@
 使用 `shiki` 来高亮代码。
 </markdown>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { createHighlighter } from 'shiki'
-import { defineComponent, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 
-export default defineComponent({
-  setup() {
-    const shikiRef = ref<any>(null)
-    const code = `function sayHello() {
+const shiki = ref()
+const code = `function sayHello() {
   console.log('Hello Shiki')
 }`
 
-    onMounted(async () => {
-      const highlighter = await createHighlighter({
-        themes: ['nord'],
-        langs: ['javascript']
-      })
-      shikiRef.value = {
-        codeToHtml: (code: string, options: any) => {
-          return highlighter.codeToHtml(code, { ...options, theme: 'nord' })
-        }
-      }
-    })
+onMounted(async () => {
+  const highlighter = await createHighlighter({
+    themes: ['nord'],
+    langs: ['javascript']
+  })
 
-    return {
-      shiki: shikiRef,
-      code
+  shiki.value = {
+    codeToHtml(code: string) {
+      return highlighter.codeToHtml(code, {
+        lang: 'javascript',
+        theme: 'nord'
+      })
     }
   }
 })
 </script>
 
 <template>
-  <n-code :shiki="shiki" :code="code" language="javascript" />
+  <n-code :shiki="shiki" :code="code" language="javascript" show-line-numbers />
 </template>

--- a/src/code/demos/zhCN/shiki.demo.vue
+++ b/src/code/demos/zhCN/shiki.demo.vue
@@ -1,0 +1,40 @@
+<markdown>
+# 使用 Shiki
+
+使用 `shiki` 来高亮代码。
+</markdown>
+
+<script lang="ts">
+import { createHighlighter } from 'shiki'
+import { defineComponent, onMounted, ref } from 'vue'
+
+export default defineComponent({
+  setup() {
+    const shikiRef = ref<any>(null)
+    const code = `function sayHello() {
+  console.log('Hello Shiki')
+}`
+
+    onMounted(async () => {
+      const highlighter = await createHighlighter({
+        themes: ['nord'],
+        langs: ['javascript']
+      })
+      shikiRef.value = {
+        codeToHtml: (code: string, options: any) => {
+          return highlighter.codeToHtml(code, { ...options, theme: 'nord' })
+        }
+      }
+    })
+
+    return {
+      shiki: shikiRef,
+      code
+    }
+  }
+})
+</script>
+
+<template>
+  <n-code :shiki="shiki" :code="code" language="javascript" />
+</template>

--- a/src/config-provider/src/ConfigProvider.ts
+++ b/src/config-provider/src/ConfigProvider.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, ExtractPropTypes, PropType } from 'vue'
-import type { Hljs } from '../../_mixins'
+import type { Hljs, Shiki } from '../../_mixins'
 import type { NDateLocale, NLocale } from '../../locales'
 import type {
   GlobalComponentConfig,
@@ -37,6 +37,7 @@ export const configProviderProps = {
     default: 'div'
   },
   hljs: Object as PropType<Hljs>,
+  shiki: Object as PropType<Shiki>,
   katex: Object as PropType<Katex>,
   theme: Object as PropType<GlobalTheme | null>,
   themeOverrides: Object as PropType<GlobalThemeOverrides | null>,
@@ -209,6 +210,12 @@ export default defineComponent({
       mergedHljsRef: computed(() => {
         const { hljs } = props
         return hljs === undefined ? NConfigProvider?.mergedHljsRef.value : hljs
+      }),
+      mergedShikiRef: computed(() => {
+        const { shiki } = props
+        return shiki === undefined
+          ? NConfigProvider?.mergedShikiRef?.value
+          : shiki
       }),
       mergedKatexRef: computed(() => {
         const { katex } = props

--- a/src/config-provider/src/internal-interface.ts
+++ b/src/config-provider/src/internal-interface.ts
@@ -3,7 +3,7 @@ import type { Ref, VNodeChild } from 'vue'
 import type { ScrollbarTheme } from '../../_internal/scrollbar/styles'
 import type { InternalSelectMenuTheme } from '../../_internal/select-menu/styles'
 import type { InternalSelectionTheme } from '../../_internal/selection/styles'
-import type { Hljs } from '../../_mixins'
+import type { Hljs, Shiki } from '../../_mixins'
 import type { AlertTheme } from '../../alert/styles'
 import type { AnchorTheme } from '../../anchor/styles'
 import type { AutoCompleteTheme } from '../../auto-complete/styles'
@@ -264,6 +264,7 @@ export interface ConfigProviderInjection {
   mergedLocaleRef: Ref<NLocale | undefined>
   mergedDateLocaleRef: Ref<NDateLocale | undefined>
   mergedHljsRef: Ref<Hljs | undefined>
+  mergedShikiRef: Ref<Shiki | undefined>
   mergedKatexRef: Ref<Katex | undefined>
   mergedComponentPropsRef: Ref<GlobalComponentConfig | undefined>
   mergedIconsRef: Ref<GlobalIconConfig | undefined>

--- a/src/log/demos/enUS/index.demo-entry.md
+++ b/src/log/demos/enUS/index.demo-entry.md
@@ -4,11 +4,15 @@
 
 If you have some logs to show, use log.
 
+Shiki highlighting is supported starting from `NEXT_VERSION`.
+
 <n-alert title="Note" type="warning" style="margin-bottom: 16px;" :bordered="false">
-  Due to package size, Naive UI doesn't include highlight.js. If you want highlight logs, make sure you have set highlightjs before using it.
+  Due to package size, Naive UI doesn't include highlight.js or Shiki. If you want highlight logs, make sure you have set highlight.js or Shiki before using it.
 </n-alert>
 
-In highlight demo, we defined a language called `naive-log` which will highlight all the numbers of line. The following code shows how we defined it. If you want to know more about highlight.js, see <n-a href="https://highlightjs.org/" target="_blank">highlight.js</n-a> and <n-a href="https://highlightjs.readthedocs.io/en/latest/index.html" target="_blank">highlight.js developer documentation</n-a>
+In the highlight.js demo on this page, we defined a language called `naive-log` which will highlight all the numbers of the line. The following code shows how we defined it. If you want to know more about highlight.js, see <n-a href="https://highlightjs.org/" target="_blank">highlight.js</n-a> and <n-a href="https://highlightjs.readthedocs.io/en/latest/index.html" target="_blank">highlight.js developer documentation</n-a>
+
+For Shiki highlighting, refer to the Shiki example below. You can read the <n-a href="https://shiki.matsu.io/" target="_blank">Shiki</n-a> documentation to learn more about how to use it.
 
 ```html
 <template>
@@ -40,6 +44,66 @@ In highlight demo, we defined a language called `naive-log` which will highlight
 </script>
 ```
 
+```html
+<template>
+  <n-config-provider :shiki="shiki">
+    <my-app />
+  </n-config-provider>
+</template>
+
+<script lang="ts">
+  import { defineComponent, onMounted, ref } from 'vue'
+  import { createHighlighter } from 'shiki'
+
+  export default defineComponent({
+    setup() {
+      const shiki = ref()
+
+      const naiveLogLanguage: LanguageInput = {
+        name: 'naive-shiki-log',
+        scopeName: 'source.naive-shiki-log',
+        patterns: [
+          {
+            name: 'constant.numeric.naive-shiki-log',
+            match: '\\b\\d+(?:\\.\\d+)?\\b'
+          },
+          {
+            name: 'keyword.operator.naive-shiki-log',
+            match: '\\b(INFO|WARN|ERROR|DEBUG)\\b'
+          },
+          {
+            begin: '\\[',
+            end: '\\]',
+            name: 'punctuation.definition.bracket.naive-shiki-log'
+          }
+        ],
+        repository: {}
+      }
+
+      onMounted(async () => {
+        const highlighter = await createHighlighter({
+          themes: ['vitesse-light'],
+          langs: [naiveLogLanguage]
+        })
+
+        shiki.value = {
+          codeToHtml(code: string) {
+            return highlighter.codeToHtml(code, {
+              lang: 'naive-shiki-log',
+              theme: 'vitesse-light'
+            })
+          }
+        }
+      })
+
+      return {
+        shiki
+      }
+    }
+  })
+</script>
+```
+
 ## Demos
 
 ```demo
@@ -47,6 +111,7 @@ size.vue
 event.vue
 scroll.vue
 highlight.vue
+shiki.vue
 loading.vue
 auto-bottom.vue
 ```
@@ -55,23 +120,37 @@ auto-bottom.vue
 
 ### Log Props
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| font-size | `number` | `14` | Font size. |
-| hljs | `Object` | `undefined` | If you want to set `hljs` locally, pass it using this prop. |
-| language | `string` | `undefined` | The language of the log in `highlightjs`. |
-| line-height | `number` | `1.25` | Line height. |
-| lines | `Array<string>` | `undefined` | Display the log content by line. When the `log` parameter exists at the same time, the parameter is invalid. |
-| loading | `boolean` | `false` | Whether to show loading. |
-| log | `string` | `undefined` | The content of the log. |
-| rows | `number` | `15` | Log size. |
-| trim | `boolean` | `false` | Whether to display the log after `trim`. |
-| on-require-more | `(from: 'top' \| 'bottom') => void` | `undefined` | Callback function for scroll loading log. |
-| on-reach-top | `() => void` | `undefined` | Scroll to the top callback function. |
-| on-reach-bottom | `() => void` | `undefined` | Scroll to the bottom callback function. |
+| Name | Type | Default | Description | Version |
+| --- | --- | --- | --- | --- |
+| font-size | `number` | `14` | Font size. |  |
+| hljs | `Object` | `undefined` | If you want to set `hljs` locally, pass it using this prop. |  |
+| language | `string` | `undefined` | The language of the log in `highlightjs`. |  |
+| line-height | `number` | `1.25` | Line height. |  |
+| lines | `Array<string>` | `undefined` | Display the log content by line. When the `log` parameter exists at the same time, the parameter is invalid. |  |
+| loading | `boolean` | `false` | Whether to show loading. |  |
+| log | `string` | `undefined` | The content of the log. |  |
+| rows | `number` | `15` | Log size. |  |
+| trim | `boolean` | `false` | Whether to display the log after `trim`. |  |
+| on-require-more | `(from: 'top' \| 'bottom') => void` | `undefined` | Callback function for scroll loading log. |  |
+| on-reach-top | `() => void` | `undefined` | Scroll to the top callback function. |  |
+| on-reach-bottom | `() => void` | `undefined` | Scroll to the bottom callback function. |  |
+| shiki | `Shiki` | `undefined` | If you want to set `shiki` locally, pass it using this prop. | NEXT_VERSION |
 
 ### Log Methods
 
 | Name | Parameters | Description |
 | --- | --- | --- |
 | scrollTo | `(options: { top?: number, position?: 'top' \| 'bottom', silent?: boolean })` | Callback function for scroll event. |
+
+### Shiki Interface
+
+```ts
+interface Shiki {
+  /**
+   * The consumer (e.g. n-code / n-log) only cares about the rendered HTML string.
+   * Users may configure languages, themes or hooks when constructing the Shiki
+   * instance, but all those details should be hidden behind this single method.
+   */
+  codeToHtml: (code: string) => string
+}
+```

--- a/src/log/demos/enUS/shiki.demo.vue
+++ b/src/log/demos/enUS/shiki.demo.vue
@@ -1,7 +1,7 @@
 <markdown>
-# 使用 Shiki
+# Use Shiki
 
-使用 `shiki` 自定义一门 `naive-shiki-log` 语言，并让 `n-log` 高亮数字与日志级别。
+Use `shiki` to define a custom `naive-shiki-log` language so that `n-log` can highlight numbers and log levels.
 </markdown>
 
 <script lang="ts" setup>

--- a/src/log/demos/zhCN/index.demo-entry.md
+++ b/src/log/demos/zhCN/index.demo-entry.md
@@ -47,6 +47,7 @@ size.vue
 event.vue
 scroll.vue
 highlight.vue
+shiki.vue
 loading.vue
 auto-bottom.vue
 ```

--- a/src/log/demos/zhCN/index.demo-entry.md
+++ b/src/log/demos/zhCN/index.demo-entry.md
@@ -4,11 +4,15 @@
 
 如果你有一些日志要展示，可以使用 Log。
 
+自 NEXT_VERSION 起支持使用 Shiki 高亮
+
 <n-alert title="注意" type="warning" style="margin-bottom: 16px;" :bordered="false">
-  由于尺寸原因，Naive UI 不内置 highlight.js。如果你需要高亮日志，请确保你在使用之前已经设定了 highlight.js。
+  由于尺寸原因，Naive UI 不内置高亮器 highlight.js 或 shiki。如果你需要高亮日志，请确保你在使用之前已经设定了 highlight.js 或 shiki
 </n-alert>
 
-在本页如何高亮的演示中，我们定义了一个叫做 `naive-log` 的语言来高亮全部的数字。下面的代码是我们怎么定义的。如果你想了解 highlight.js，可以参考 <n-a href="https://highlightjs.org/" target="_blank">highlight.js</n-a> 和 <n-a href="https://highlightjs.readthedocs.io/en/latest/index.html" target="_blank">highlight.js developer documentation</n-a>
+在本页如何 highlight.js 高亮的演示中，我们定义了一个叫做 `naive-log` 的语言来高亮全部的数字。下面的代码是我们怎么定义的。如果你想了解 highlight.js，可以参考 <n-a href="https://highlightjs.org/" target="_blank">highlight.js</n-a> 和 <n-a href="https://highlightjs.readthedocs.io/en/latest/index.html" target="_blank">highlight.js developer documentation</n-a>
+
+Shiki 的高亮用法参考下方的 Shiki 示例，你可以阅读 <n-a href="https://shiki.matsu.io/" target="_blank">Shiki</n-a> 文档了解更多 Shiki 的用法
 
 ```html
 <template>
@@ -40,6 +44,66 @@
 </script>
 ```
 
+```html
+<template>
+  <n-config-provider :shiki="shiki">
+    <my-app />
+  </n-config-provider>
+</template>
+
+<script lang="ts">
+  import { defineComponent, onMounted, ref } from 'vue'
+  import { createHighlighter } from 'shiki'
+
+  export default defineComponent({
+    setup() {
+      const shiki = ref()
+
+      const naiveLogLanguage: LanguageInput = {
+        name: 'naive-shiki-log',
+        scopeName: 'source.naive-shiki-log',
+        patterns: [
+          {
+            name: 'constant.numeric.naive-shiki-log',
+            match: '\\b\\d+(?:\\.\\d+)?\\b'
+          },
+          {
+            name: 'keyword.operator.naive-shiki-log',
+            match: '\\b(INFO|WARN|ERROR|DEBUG)\\b'
+          },
+          {
+            begin: '\\[',
+            end: '\\]',
+            name: 'punctuation.definition.bracket.naive-shiki-log'
+          }
+        ],
+        repository: {}
+      }
+
+      onMounted(async () => {
+        const highlighter = await createHighlighter({
+          themes: ['vitesse-light'],
+          langs: [naiveLogLanguage]
+        })
+
+        shiki.value = {
+          codeToHtml(code: string) {
+            return highlighter.codeToHtml(code, {
+              lang: 'naive-shiki-log',
+              theme: 'vitesse-light'
+            })
+          }
+        }
+      })
+
+      return {
+        shiki
+      }
+    }
+  })
+</script>
+```
+
 ## 演示
 
 ```demo
@@ -56,8 +120,8 @@ auto-bottom.vue
 
 ### Log Props
 
-| 名称 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
+| 名称 | 类型 | 默认值 | 说明 | 版本 |
+| --- | --- | --- | --- | --- |
 | font-size | `number` | `14` | 文字大小 |
 | hljs | `Object` | `undefined` | 如果你想局部设定 `hljs` ，可以通过这个属性传给组件 |
 | language | `string` | `undefined` | 日志在 `highlightjs` 中的语言 |
@@ -70,9 +134,23 @@ auto-bottom.vue
 | on-require-more | `(from: 'top' \| 'bottom') => void` | `undefined` | 滚动加载日志的回调函数 |
 | on-reach-top | `() => void` | `undefined` | 滚动到顶部的回调函数 |
 | on-reach-bottom | `() => void` | `undefined` | 滚动到底部的回调函数 |
+| shiki | `Shiki` | `undefined` | 如果你想局部设定 `shiki` ，可以通过这个属性传给组件 | NEXT_VERSION |
 
 ### Log Methods
 
 | 名称 | 参数 | 说明 |
 | --- | --- | --- |
 | scrollTo | `(options: { top?: number, position?: 'top' \| 'bottom', silent?: boolean })` | 滚动事件的回调函数 |
+
+### Shiki Interface
+
+```ts
+interface Shiki {
+  /**
+   * The consumer (e.g. n-code / n-log) only cares about the rendered HTML string.
+   * Users may configure languages, themes or hooks when constructing the Shiki
+   * instance, but all those details should be hidden behind this single method.
+   */
+  codeToHtml: (code: string) => string
+}
+```

--- a/src/log/demos/zhCN/shiki.demo.vue
+++ b/src/log/demos/zhCN/shiki.demo.vue
@@ -1,0 +1,41 @@
+<markdown>
+# 使用 Shiki
+
+使用 `shiki` 来高亮代码。
+</markdown>
+
+<script lang="ts">
+import { createHighlighter } from 'shiki'
+import { defineComponent, onMounted, ref } from 'vue'
+
+export default defineComponent({
+  setup() {
+    const shikiRef = ref<any>(null)
+    const log = `console.log('Hello Shiki')
+const a = 1
+const b = 2
+console.log(a + b)`
+
+    onMounted(async () => {
+      const highlighter = await createHighlighter({
+        themes: ['nord'],
+        langs: ['javascript']
+      })
+      shikiRef.value = {
+        codeToHtml: (code: string, options: any) => {
+          return highlighter.codeToHtml(code, { ...options, theme: 'nord' })
+        }
+      }
+    })
+
+    return {
+      shiki: shikiRef,
+      log
+    }
+  }
+})
+</script>
+
+<template>
+  <n-log :shiki="shiki" :log="log" language="javascript" />
+</template>

--- a/src/log/src/Log.tsx
+++ b/src/log/src/Log.tsx
@@ -1,6 +1,6 @@
 import type { PropType, Ref } from 'vue'
 import type { ScrollbarInst } from '../../_internal'
-import type { Hljs, ThemeProps } from '../../_mixins'
+import type { Hljs, Shiki, ThemeProps } from '../../_mixins'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import type { LogTheme } from '../styles'
 import { throttle as _throttle } from 'lodash-es'
@@ -15,7 +15,13 @@ import {
   Transition
 } from 'vue'
 import { NScrollbar } from '../../_internal'
-import { useConfig, useHljs, useTheme, useThemeClass } from '../../_mixins'
+import {
+  useConfig,
+  useHljs,
+  useShiki,
+  useTheme,
+  useThemeClass
+} from '../../_mixins'
 import { warn } from '../../_utils'
 import { NCode } from '../../code'
 import { logLight } from '../styles'
@@ -32,6 +38,7 @@ export interface LogInjection {
   languageRef: Ref<string | undefined>
   highlightRef: Ref<boolean>
   mergedHljsRef: Ref<Hljs | undefined>
+  mergedShikiRef: Ref<Shiki | undefined>
 }
 
 export interface LogInst {
@@ -73,6 +80,7 @@ export const logProps = {
     default: 0
   },
   hljs: Object,
+  shiki: Object,
   onReachTop: Function as PropType<() => void>,
   onReachBottom: Function as PropType<() => void>,
   onRequireMore: Function as PropType<(from: 'top' | 'bottom') => void>
@@ -218,6 +226,7 @@ export default defineComponent({
     provide(logInjectionKey, {
       languageRef: toRef(props, 'language'),
       mergedHljsRef: useHljs(props, highlightRef),
+      mergedShikiRef: useShiki(props),
       trimRef: toRef(props, 'trim'),
       highlightRef
     })

--- a/src/log/src/Log.tsx
+++ b/src/log/src/Log.tsx
@@ -80,7 +80,7 @@ export const logProps = {
     default: 0
   },
   hljs: Object,
-  shiki: Object,
+  shiki: Object as PropType<Shiki>,
   onReachTop: Function as PropType<() => void>,
   onReachBottom: Function as PropType<() => void>,
   onRequireMore: Function as PropType<(from: 'top' | 'bottom') => void>

--- a/src/log/src/LogLine.tsx
+++ b/src/log/src/LogLine.tsx
@@ -1,13 +1,4 @@
-import {
-  computed,
-  defineComponent,
-  h,
-  inject,
-  onMounted,
-  ref,
-  toRef,
-  watch
-} from 'vue'
+import { computed, defineComponent, h, inject, ref, watchEffect } from 'vue'
 import { logInjectionKey } from './context'
 
 export default defineComponent({
@@ -43,14 +34,9 @@ export default defineComponent({
     ): string {
       const { value: shiki } = mergedShikiRef
       if (shiki) {
-        const html = shiki.codeToHtml(code, { lang: language })
-        const match = html.match(
-          /<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/
-        )
-        if (match) {
-          return match[1]
+        if (language) {
+          return shiki.codeToHtml(code)
         }
-        return html
       }
       const { value: hljs } = mergedHljsRef
       if (hljs) {
@@ -58,18 +44,15 @@ export default defineComponent({
           return hljs.highlight(code, { language }).value
         }
       }
+
       return code
     }
-    onMounted(() => {
-      if (highlightRef.value) {
-        setInnerHTML()
-      }
+    watchEffect(() => {
+      if (!highlightRef.value)
+        return
+      setInnerHTML()
     })
-    watch(toRef(props, 'line'), () => {
-      if (highlightRef.value) {
-        setInnerHTML()
-      }
-    })
+
     return {
       highlight: highlightRef,
       selfRef,

--- a/src/log/src/LogLine.tsx
+++ b/src/log/src/LogLine.tsx
@@ -18,8 +18,13 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { trimRef, highlightRef, languageRef, mergedHljsRef }
-      = inject(logInjectionKey)!
+    const {
+      trimRef,
+      highlightRef,
+      languageRef,
+      mergedHljsRef,
+      mergedShikiRef
+    } = inject(logInjectionKey)!
     const selfRef = ref<HTMLElement | null>(null)
     const maybeTrimmedLinesRef = computed(() => {
       return trimRef.value ? props.line.trim() : props.line
@@ -36,6 +41,17 @@ export default defineComponent({
       language: string | undefined,
       code: string
     ): string {
+      const { value: shiki } = mergedShikiRef
+      if (shiki) {
+        const html = shiki.codeToHtml(code, { lang: language })
+        const match = html.match(
+          /<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/
+        )
+        if (match) {
+          return match[1]
+        }
+        return html
+      }
       const { value: hljs } = mergedHljsRef
       if (hljs) {
         if (language && hljs.getLanguage(language)) {


### PR DESCRIPTION
since [shiki](https://shiki.style/) become a popular and powerfull hilighting tool. 
I'm trying to add shiki support for us,so that users can choose their preferred highlighting tool.

<img width="1377" height="643" alt="image" src="https://github.com/user-attachments/assets/ad784ef4-9d02-4494-b470-5077522510d3" />

<img width="867" height="391" alt="image" src="https://github.com/user-attachments/assets/932580d1-231f-4df9-9731-60416e74c2b4" />




