### PR TITLE
fix(data-table): add HTMLAttributes type to CommonColumnInfo.ellipsis

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- data-table: Add HTMLAttributes type support for CommonColumnInfo.ellipsis (#7266)
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- data-table: 为 CommonColumnInfo.ellipsis 添加 HTMLAttributes 类型支持 (#7266)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -240,7 +240,7 @@ export interface CommonColumnInfo<T = InternalRowData> {
   className?: string
   align?: 'left' | 'center' | 'right'
   titleAlign?: 'left' | 'center' | 'right'
-  ellipsis?: Ellipsis
+  ellipsis?: Ellipsis | HTMLAttributes
   ellipsisComponent?: 'ellipsis' | 'performant-ellipsis'
   allowExport?: boolean
   cellProps?: (rowData: T, rowIndex: number) => HTMLAttributes


### PR DESCRIPTION
- Add HTMLAttributes union type to ellipsis property
- The functionality was already working but lacked type declaration

Closes #7266

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
