### PR TITLE
fix(data-table): fix cell misalignment when using ellipsis.lineClamp

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- Fix `n-data-table` cell misalignment when using `ellipsis.lineClamp`, closes [#7345](https://github.com/tusen-ai/naive-ui/issues/7345) by [@pstrh](https://github.com/pstrh).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- 修复 `n-data-table` 使用 `ellipsis.lineClamp` 时单元格错位的问题，关闭 [#7345](https://github.com/tusen-ai/naive-ui/issues/7345) by [@pstrh](https://github.com/pstrh)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/data-table/src/styles/index.cssr.ts
+++ b/src/data-table/src/styles/index.cssr.ts
@@ -257,6 +257,11 @@ export default c([
         white-space: nowrap;
         max-width: 100%;
       `),
+      cB('ellipsis', [
+        cM('line-clamp', `
+          vertical-align: middle;
+        `)
+      ]),
       cM('hover', `
         background-color: var(--n-merged-th-color-hover);
       `),
@@ -409,6 +414,11 @@ export default c([
         vertical-align: bottom;
         max-width: calc(100% - var(--indent-offset, -1.5) * 16px - 24px);
       `),
+      cB('ellipsis', [
+        cM('line-clamp', `
+          vertical-align: middle;
+        `)
+      ]),
       cM('selection, expand', `
         text-align: center;
         padding: 0;


### PR DESCRIPTION
## Description

Fix cell misalignment in `NDataTable` when using `ellipsis.lineClamp` on columns.

Closes #7345

## Problem

When a column has `ellipsis.lineClamp` configured, the cells (both `th` and `td`) in that column appear taller than cells in other columns, causing visual misalignment.

## Root Cause

The `.n-ellipsis--line-clamp` class uses `display: -webkit-inline-box` for multi-line text truncation. As an inline-level box, its default `vertical-align: baseline` causes inconsistent height calculation compared to regular inline elements in adjacent columns.

## Solution

Add `vertical-align: middle` to `.n-ellipsis--line-clamp` within `data-table-th` and `data-table-td` to ensure consistent vertical alignment.

## Changes

- [src/data-table/src/styles/index.cssr.ts]: Added `vertical-align: middle` style override for `.n-ellipsis--line-clamp` inside table header and body cells.