### PR TITLE
fix(data-table): allow rowSpan and colSpan on selection column type

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- Fix `n-data-table` `TableSelectionColumn` type definition not allowing `rowSpan` and `colSpan` properties, closes [#7347](https://github.com/tusen-ai/naive-ui/issues/7347) by [@pstrh](https://github.com/pstrh).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- 修复 `n-data-table` 的 `TableSelectionColumn` 类型定义不允许 `rowSpan` 和 `colSpan` 属性的问题，关闭 [#7347](https://github.com/tusen-ai/naive-ui/issues/7347) by [@pstrh](https://github.com/pstrh)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -343,10 +343,8 @@ export type RenderExpandIcon = ({
 
 // TODO: we should deprecate `index` since it would change after row is expanded
 export type Expandable<T = InternalRowData> = (row: T) => boolean
-export interface TableExpandColumn<T = InternalRowData> extends Omit<
-  TableSelectionColumn<T>,
-  'type'
-> {
+export interface TableExpandColumn<T = InternalRowData>
+  extends Omit<TableSelectionColumn<T>, 'type'> {
   type: 'expand'
   title?: TableExpandColumnTitle
   renderExpand: RenderExpand<T>

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -325,8 +325,8 @@ export type TableSelectionColumn<T = InternalRowData> = {
   filterOptions?: never
   filterOptionValues?: never
   filterOptionValue?: never
-  colSpan?: never
-  rowSpan?: never
+  colSpan?: (rowData: T, rowIndex: number) => number
+  rowSpan?: (rowData: T, rowIndex: number) => number
 } & CommonColumnInfo<T>
 
 export type RenderExpand<T = InternalRowData> = (
@@ -343,8 +343,10 @@ export type RenderExpandIcon = ({
 
 // TODO: we should deprecate `index` since it would change after row is expanded
 export type Expandable<T = InternalRowData> = (row: T) => boolean
-export interface TableExpandColumn<T = InternalRowData>
-  extends Omit<TableSelectionColumn<T>, 'type'> {
+export interface TableExpandColumn<T = InternalRowData> extends Omit<
+  TableSelectionColumn<T>,
+  'type'
+> {
   type: 'expand'
   title?: TableExpandColumnTitle
   renderExpand: RenderExpand<T>


### PR DESCRIPTION
## Description

Fix TypeScript type definition for [TableSelectionColumn] to allow `rowSpan` and `colSpan` properties.

Closes #7347

## Problem

When using `rowSpan` or `colSpan` on a selection column, TypeScript reports an error:
Type '(rowData: T) => number' is not assignable to type 'undefined'.

However, the runtime behavior works correctly - selection cells can be merged as expected.

## Root Cause

In commit `f56d978` (2021-03-24), when `rowSpan` and `colSpan` were added to [TableBaseColumn], they were explicitly set to `never` on [TableSelectionColumn] This was likely an intentional design decision at the time, but it doesn't match the actual runtime behavior where these properties are supported.

## Solution
Change the type definition from:
```
colSpan?: never
rowSpan?: never
```
to:
```
colSpan?: (rowData: T, rowIndex: number) => number
rowSpan?: (rowData: T, rowIndex: number) => number
```
This aligns the type definition with the actual runtime behavior.