### PR TITLE
fix(cascader): fix position calculation on reopening menu, closes #7321

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- Fix `n-cascader` position calculation error when reopening the dropdown menu, closes [#7321](https://github.com/tusen-ai/naive-ui/issues/7321) by [@pstrh](https://github.com/pstrh).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- 修复 `n-cascader` 第二次打开下拉菜单时位置计算错误的问题，关闭 [#7321](https://github.com/tusen-ai/naive-ui/issues/7321) by [@pstrh](https://github.com/pstrh)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/cascader/src/Cascader.tsx
+++ b/src/cascader/src/Cascader.tsx
@@ -896,7 +896,17 @@ export default defineComponent({
       selectMenuFollowerRef.value?.syncPosition()
     }
     function syncCascaderMenuPosition(): void {
-      cascaderMenuFollowerRef.value?.syncPosition()
+      const followerInst = cascaderMenuFollowerRef.value
+      if (followerInst) {
+        // Reset transform before syncPosition to ensure getBoundingClientRect
+        // returns correct values for position calculation.
+        const followerEl = (followerInst as any)
+          .followerRef as HTMLElement | null
+        if (followerEl) {
+          followerEl.style.transform = ''
+        }
+        followerInst.syncPosition()
+      }
     }
     function handleTriggerResize(): void {
       if (mergedShowRef.value) {


### PR DESCRIPTION
## Description
Fix NCascader position calculation error when reopening the dropdown menu.

Closes #7321

## Problem
When NCascader is positioned near the right edge of the screen:
1. First open: expanding multiple levels correctly shifts the popup left (because there's not enough space on the right)
2. Second open: the popup doesn't shift left, causing later level content to be clipped

## Root Cause
The original [useOnResize] only registers the resize handler once on component mount. However, the CascaderMenu DOM is destroyed when `show=false` (returns `null` in render). When reopened, a new DOM element is created but the resize handler is still bound to the old element, so expanding levels doesn't trigger [syncCascaderMenuPosition].

## Solution
1. **CascaderMenu.tsx**: Replace [useOnResize] with `watch(selfElRef)` to re-register resize handler when DOM is recreated
2. **Cascader.tsx**: Reset `transform` style before calling `syncPosition` to ensure `getBoundingClientRect` returns correct values for position calculation