### PR TITLE
fix(input): autosize width not updated when value changed from outside

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- Fix `n-input` with `type="text"` and `autosize` not updating width when value is modified externally, closes [#7269](https://github.com/tusen-ai/naive-ui/issues/7269) by [@pstrh](https://github.com/pstrh).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- 修复 `n-input` 在 `type="text"` 且设置 `autosize` 时，外部修改值后宽度不更新的问题，关闭 [#7269](https://github.com/tusen-ai/naive-ui/issues/7269) by [@pstrh](https://github.com/pstrh)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -844,8 +844,8 @@ export default defineComponent({
 
     let stopWatchMergedValue1: WatchStopHandle | null = null
     watchEffect(() => {
-      const { autosize, type } = props
-      if (autosize && type === 'textarea') {
+      const { autosize } = props
+      if (autosize) {
         stopWatchMergedValue1 = watch(mergedValueRef, (value) => {
           if (!Array.isArray(value) && value !== syncSource) {
             syncMirror(value)


### PR DESCRIPTION
## Description

Fix #7269

When using `type="text"` input with `autosize` prop, if the bound value is modified externally (e.g., from another textarea sharing the same v-model), the input width does not update accordingly.

## Root Cause

The watch logic for syncing mirror only triggered when `autosize && type === 'textarea'`, which excluded `type="text"` inputs from receiving external value change updates.

## Solution

Remove the `type === 'textarea'` condition so that all autosize inputs (both text and textarea) will sync their dimensions when the value changes from outside.