### PR TITLE
fix(input): placeholder covering cursor in light mode, closes #7267

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- Fix `n-input` placeholder text covering the cursor in light mode, closes [#7267](https://github.com/tusen-ai/naive-ui/issues/7267) by [@pstrh](https://github.com/pstrh).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Fixes
+
+- 修复 `n-input` 在浅色模式下 placeholder 文本遮挡光标的问题，关闭 [#7267](https://github.com/tusen-ai/naive-ui/issues/7267) by [@pstrh](https://github.com/pstrh)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/input/src/styles/input.cssr.ts
+++ b/src/input/src/styles/input.cssr.ts
@@ -81,6 +81,8 @@ export default cB('input', `
     color: var(--n-text-color);
     caret-color: var(--n-caret-color);
     background-color: transparent;
+    position: relative;
+    z-index: 1;
   `, [
     c('&::-webkit-scrollbar, &::-webkit-scrollbar-track-piece, &::-webkit-scrollbar-thumb', `
       width: 0;


### PR DESCRIPTION
## Description

Fix the issue where the placeholder text covers the cursor in light mode.

Closes #7267

## Root Cause

The input component uses a custom absolutely positioned `<span>` element to display placeholder text (native placeholder is set to transparent). This custom placeholder element lacks a `z-index`, causing it to render above the cursor in certain scenarios.

## Solution

Add `position: relative` and `z-index: 1` to `input-el` and `textarea-el` to ensure the input element (including the cursor) always renders above the placeholder.