### PR TITLE
feat(date-picker): add prefix slot support

### DIFF
--- a/src/date-picker/demos/enUS/index.demo-entry.md
+++ b/src/date-picker/demos/enUS/index.demo-entry.md
@@ -30,6 +30,7 @@ update-on-close.vue
 focus.vue
 status.vue
 icon.vue
+prefix.vue
 panel.vue
 ```
 
@@ -192,15 +193,16 @@ panel.vue
 
 ### DatePicker Slots
 
-| Name       | Parameters | Description                       | Version |
-| ---------- | ---------- | --------------------------------- | ------- |
-| date-icon  | `()`       | Date icon of the input box.       | 2.29.0  |
-| footer     | `()`       | Extra Footer.                     |         |
-| next-month | `()`       | Next icon of the date panel.      | 2.33.4  |
-| next-year  | `()`       | Fast next icon of the date panel. | 2.33.4  |
-| prev-month | `()`       | Prev icon of the date panel.      | 2.33.4  |
-| prev-year  | `()`       | Fast prev icon of the date panel. | 2.33.4  |
-| separator  | `()`       | Separator of range picker.        | 2.29.0  |
+| Name       | Parameters | Description                       | Version      |
+| ---------- | ---------- | --------------------------------- | ------------ |
+| date-icon  | `()`       | Date icon of the input box.       | 2.29.0       |
+| footer     | `()`       | Extra Footer.                     |              |
+| next-month | `()`       | Next icon of the date panel.      | 2.33.4       |
+| next-year  | `()`       | Fast next icon of the date panel. | 2.33.4       |
+| prefix     | `()`       | Prefix content of the input box.  | NEXT_VERSION |
+| prev-month | `()`       | Prev icon of the date panel.      | 2.33.4       |
+| prev-year  | `()`       | Fast prev icon of the date panel. | 2.33.4       |
+| separator  | `()`       | Separator of range picker.        | 2.29.0       |
 
 ### Date, Year, QuarterRange, Week Slots
 

--- a/src/date-picker/demos/enUS/prefix.demo.vue
+++ b/src/date-picker/demos/enUS/prefix.demo.vue
@@ -1,0 +1,24 @@
+<markdown>
+# Prefix
+
+Use the `prefix` slot to add content before the input.
+</markdown>
+
+<script lang="ts" setup>
+import { CalendarOutline } from '@vicons/ionicons5'
+</script>
+
+<template>
+  <n-space vertical>
+    <n-date-picker type="date" placeholder="With prefix">
+      <template #prefix>
+        <n-icon :size="16" :component="CalendarOutline" />
+      </template>
+    </n-date-picker>
+    <n-date-picker type="daterange">
+      <template #prefix>
+        <n-icon :size="16" :component="CalendarOutline" />
+      </template>
+    </n-date-picker>
+  </n-space>
+</template>

--- a/src/date-picker/demos/zhCN/index.demo-entry.md
+++ b/src/date-picker/demos/zhCN/index.demo-entry.md
@@ -28,6 +28,7 @@ format.vue
 footerslot.vue
 status.vue
 icon.vue
+prefix.vue
 panel.vue
 panel-debug.vue
 form-debug.vue
@@ -192,15 +193,16 @@ form-debug.vue
 
 ### DatePicker Slots
 
-| 名称       | 参数 | 说明                         | 版本   |
-| ---------- | ---- | ---------------------------- | ------ |
-| date-icon  | `()` | 日期输入框的图标             | 2.29.0 |
-| footer     | `()` | 添加额外的页脚               |        |
-| next-month | `()` | 日期面板的 `下一个` 图标     | 2.33.4 |
-| next-year  | `()` | 日期面板的 `快速下一个` 图标 | 2.33.4 |
-| prev-month | `()` | 日期面板的 `上一个` 图标     | 2.33.4 |
-| prev-year  | `()` | 日期面板的 `快速上一个` 图标 | 2.33.4 |
-| separator  | `()` | 日期范围分隔符号             | 2.29.0 |
+| 名称       | 参数 | 说明                         | 版本         |
+| ---------- | ---- | ---------------------------- | ------------ |
+| date-icon  | `()` | 日期输入框的图标             | 2.29.0       |
+| footer     | `()` | 添加额外的页脚               |              |
+| next-month | `()` | 日期面板的 `下一个` 图标     | 2.33.4       |
+| next-year  | `()` | 日期面板的 `快速下一个` 图标 | 2.33.4       |
+| prefix     | `()` | 输入框的前缀内容             | NEXT_VERSION |
+| prev-month | `()` | 日期面板的 `上一个` 图标     | 2.33.4       |
+| prev-year  | `()` | 日期面板的 `快速上一个` 图标 | 2.33.4       |
+| separator  | `()` | 日期范围分隔符号             | 2.29.0       |
 
 ### Date, Year, QuarterRange, Week Slots
 

--- a/src/date-picker/demos/zhCN/prefix.demo.vue
+++ b/src/date-picker/demos/zhCN/prefix.demo.vue
@@ -1,0 +1,24 @@
+<markdown>
+# 前缀
+
+使用 `prefix` 插槽在输入框前添加内容
+</markdown>
+
+<script lang="ts" setup>
+import { CalendarOutline } from '@vicons/ionicons5'
+</script>
+
+<template>
+  <n-space vertical>
+    <n-date-picker type="date" placeholder="带前缀">
+      <template #prefix>
+        <n-icon :size="16" :component="CalendarOutline" />
+      </template>
+    </n-date-picker>
+    <n-date-picker type="daterange">
+      <template #prefix>
+        <n-icon :size="16" :component="CalendarOutline" />
+      </template>
+    </n-date-picker>
+  </n-space>
+</template>

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -78,6 +78,7 @@ export interface DatePickerSlots {
   'next-year'?: () => VNode[]
   'prev-month'?: () => VNode[]
   'prev-year'?: () => VNode[]
+  prefix?: () => VNode[]
   separator?: () => VNode[]
   confirm?: (props: {
     onConfirm: () => void
@@ -1093,6 +1094,7 @@ export default defineComponent({
                         {...commonInputProps}
                       >
                         {{
+                          prefix: $slots.prefix,
                           separator: () =>
                             this.separator === undefined
                               ? resolveSlot($slots.separator, () => [
@@ -1139,6 +1141,7 @@ export default defineComponent({
                         {...commonInputProps}
                       >
                         {{
+                          prefix: $slots.prefix,
                           [clearable ? 'clear-icon-placeholder' : 'suffix']:
                             () => (
                               <NBaseIcon


### PR DESCRIPTION
### What does this PR do?

Adds a \`prefix\` slot to the DatePicker component, allowing users to add custom content before the input.

### Related Issue

Closes #6787

### Changes

- Added \`prefix\` slot to \`DatePickerSlots\` interface
- Pass prefix slot to both single and range NInput components
- Added demo files for both English and Chinese
- Updated documentation with slot description

### Demo

\`\`\`vue
<n-date-picker type="date">
  <template #prefix>
    <n-icon :component="CalendarOutline" />
  </template>
</n-date-picker>
\`\`\`