### PR TITLE
feat(date-picker): 添加 date slot 支持自定义日期单元格内容

### DIFF
--- a/src/date-picker/demos/enUS/date-slot.demo.vue
+++ b/src/date-picker/demos/enUS/date-slot.demo.vue
@@ -1,0 +1,63 @@
+<markdown>
+# Custom Date Cell
+
+Use the `date` slot to customize the content of date cells, such as adding lunar calendar dates or holidays.
+</markdown>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  setup() {
+    // Simple holiday mapping example (for demonstration only)
+    const holidays: Record<string, string> = {
+      '2024-1-1': 'NY',
+      '2024-12-25': 'Xmas',
+      '2024-7-4': 'July 4'
+    }
+
+    const getHoliday = (year: number, month: number, date: number) => {
+      const key = `${year}-${month + 1}-${date}`
+      return holidays[key]
+    }
+
+    return {
+      getHoliday
+    }
+  }
+})
+</script>
+
+<template>
+  <n-space vertical>
+    <n-date-picker type="date" :default-value="Date.now()">
+      <template #date="{ year, month, date }">
+        <div style="display: flex; flex-direction: column; align-items: center">
+          <span>{{ date }}</span>
+          <span
+            v-if="getHoliday(year, month, date)"
+            style="font-size: 10px; color: #18a058"
+          >
+            {{ getHoliday(year, month, date) }}
+          </span>
+        </div>
+      </template>
+    </n-date-picker>
+    <n-date-picker
+      type="daterange"
+      :default-value="[Date.now(), Date.now() + 86400000 * 7]"
+    >
+      <template #date="{ year, month, date }">
+        <div style="display: flex; flex-direction: column; align-items: center">
+          <span>{{ date }}</span>
+          <span
+            v-if="getHoliday(year, month, date)"
+            style="font-size: 10px; color: #18a058"
+          >
+            {{ getHoliday(year, month, date) }}
+          </span>
+        </div>
+      </template>
+    </n-date-picker>
+  </n-space>
+</template>

--- a/src/date-picker/demos/enUS/date-slot.demo.vue
+++ b/src/date-picker/demos/enUS/date-slot.demo.vue
@@ -4,28 +4,18 @@
 Use the `date` slot to customize the content of date cells, such as adding lunar calendar dates or holidays.
 </markdown>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+// Simple holiday mapping example (for demonstration only)
+const holidays: Record<string, string> = {
+  '2024-1-1': 'NY',
+  '2024-12-25': 'Xmas',
+  '2024-7-4': 'July 4'
+}
 
-export default defineComponent({
-  setup() {
-    // Simple holiday mapping example (for demonstration only)
-    const holidays: Record<string, string> = {
-      '2024-1-1': 'NY',
-      '2024-12-25': 'Xmas',
-      '2024-7-4': 'July 4'
-    }
-
-    const getHoliday = (year: number, month: number, date: number) => {
-      const key = `${year}-${month + 1}-${date}`
-      return holidays[key]
-    }
-
-    return {
-      getHoliday
-    }
-  }
-})
+function getHoliday(year: number, month: number, date: number) {
+  const key = `${year}-${month + 1}-${date}`
+  return holidays[key]
+}
 </script>
 
 <template>

--- a/src/date-picker/demos/enUS/index.demo-entry.md
+++ b/src/date-picker/demos/enUS/index.demo-entry.md
@@ -26,6 +26,7 @@ shortcuts.vue
 events.vue
 format.vue
 footerslot.vue
+date-slot.vue
 update-on-close.vue
 focus.vue
 status.vue
@@ -192,15 +193,16 @@ panel.vue
 
 ### DatePicker Slots
 
-| Name       | Parameters | Description                       | Version |
-| ---------- | ---------- | --------------------------------- | ------- |
-| date-icon  | `()`       | Date icon of the input box.       | 2.29.0  |
-| footer     | `()`       | Extra Footer.                     |         |
-| next-month | `()`       | Next icon of the date panel.      | 2.33.4  |
-| next-year  | `()`       | Fast next icon of the date panel. | 2.33.4  |
-| prev-month | `()`       | Prev icon of the date panel.      | 2.33.4  |
-| prev-year  | `()`       | Fast prev icon of the date panel. | 2.33.4  |
-| separator  | `()`       | Separator of range picker.        | 2.29.0  |
+| Name | Parameters | Description | Version |
+| --- | --- | --- | --- |
+| date | `(props: { year: number, month: number, date: number })` | Custom date cell content. | NEXT_VERSION |
+| date-icon | `()` | Date icon of the input box. | 2.29.0 |
+| footer | `()` | Extra Footer. |  |
+| next-month | `()` | Next icon of the date panel. | 2.33.4 |
+| next-year | `()` | Fast next icon of the date panel. | 2.33.4 |
+| prev-month | `()` | Prev icon of the date panel. | 2.33.4 |
+| prev-year | `()` | Fast prev icon of the date panel. | 2.33.4 |
+| separator | `()` | Separator of range picker. | 2.29.0 |
 
 ### Date, Year, QuarterRange, Week Slots
 

--- a/src/date-picker/demos/zhCN/date-slot.demo.vue
+++ b/src/date-picker/demos/zhCN/date-slot.demo.vue
@@ -1,0 +1,64 @@
+<markdown>
+# 自定义日期
+
+使用 `date` 插槽可以自定义日期单元格的内容，例如添加农历、节日等信息。
+</markdown>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  setup() {
+    // 简单的农历映射示例（仅用于演示）
+    const lunarDates: Record<string, string> = {
+      '2024-1-1': '廿一',
+      '2024-1-15': '初五',
+      '2024-2-10': '初一',
+      '2024-12-25': '圣诞'
+    }
+
+    const getLunarDate = (year: number, month: number, date: number) => {
+      const key = `${year}-${month + 1}-${date}`
+      return lunarDates[key]
+    }
+
+    return {
+      getLunarDate
+    }
+  }
+})
+</script>
+
+<template>
+  <n-space vertical>
+    <n-date-picker type="date" :default-value="Date.now()">
+      <template #date="{ year, month, date }">
+        <div style="display: flex; flex-direction: column; align-items: center">
+          <span>{{ date }}</span>
+          <span
+            v-if="getLunarDate(year, month, date)"
+            style="font-size: 10px; color: #999"
+          >
+            {{ getLunarDate(year, month, date) }}
+          </span>
+        </div>
+      </template>
+    </n-date-picker>
+    <n-date-picker
+      type="daterange"
+      :default-value="[Date.now(), Date.now() + 86400000 * 7]"
+    >
+      <template #date="{ year, month, date }">
+        <div style="display: flex; flex-direction: column; align-items: center">
+          <span>{{ date }}</span>
+          <span
+            v-if="getLunarDate(year, month, date)"
+            style="font-size: 10px; color: #999"
+          >
+            {{ getLunarDate(year, month, date) }}
+          </span>
+        </div>
+      </template>
+    </n-date-picker>
+  </n-space>
+</template>

--- a/src/date-picker/demos/zhCN/index.demo-entry.md
+++ b/src/date-picker/demos/zhCN/index.demo-entry.md
@@ -195,7 +195,7 @@ form-debug.vue
 
 | 名称 | 参数 | 说明 | 版本 |
 | --- | --- | --- | --- |
-| date | `(props: { year: number, month: number, date: number })` | 自定义日期单元格内容 | NEXT_VERISON |
+| date | `(props: { year: number, month: number, date: number })` | 自定义日期单元格内容 | NEXT_VERSION |
 | date-icon | `()` | 日期输入框的图标 | 2.29.0 |
 | footer | `()` | 添加额外的页脚 |  |
 | next-month | `()` | 日期面板的 `下一个` 图标 | 2.33.4 |

--- a/src/date-picker/demos/zhCN/index.demo-entry.md
+++ b/src/date-picker/demos/zhCN/index.demo-entry.md
@@ -26,6 +26,7 @@ shortcuts.vue
 events.vue
 format.vue
 footerslot.vue
+date-slot.vue
 status.vue
 icon.vue
 panel.vue
@@ -192,15 +193,16 @@ form-debug.vue
 
 ### DatePicker Slots
 
-| 名称       | 参数 | 说明                         | 版本   |
-| ---------- | ---- | ---------------------------- | ------ |
-| date-icon  | `()` | 日期输入框的图标             | 2.29.0 |
-| footer     | `()` | 添加额外的页脚               |        |
-| next-month | `()` | 日期面板的 `下一个` 图标     | 2.33.4 |
-| next-year  | `()` | 日期面板的 `快速下一个` 图标 | 2.33.4 |
-| prev-month | `()` | 日期面板的 `上一个` 图标     | 2.33.4 |
-| prev-year  | `()` | 日期面板的 `快速上一个` 图标 | 2.33.4 |
-| separator  | `()` | 日期范围分隔符号             | 2.29.0 |
+| 名称 | 参数 | 说明 | 版本 |
+| --- | --- | --- | --- |
+| date | `(props: { year: number, month: number, date: number })` | 自定义日期单元格内容 | NEXT_VERISON |
+| date-icon | `()` | 日期输入框的图标 | 2.29.0 |
+| footer | `()` | 添加额外的页脚 |  |
+| next-month | `()` | 日期面板的 `下一个` 图标 | 2.33.4 |
+| next-year | `()` | 日期面板的 `快速下一个` 图标 | 2.33.4 |
+| prev-month | `()` | 日期面板的 `上一个` 图标 | 2.33.4 |
+| prev-year | `()` | 日期面板的 `快速上一个` 图标 | 2.33.4 |
+| separator | `()` | 日期范围分隔符号 | 2.29.0 |
 
 ### Date, Year, QuarterRange, Week Slots
 

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -71,8 +71,15 @@ import {
 
 export type DatePickerSetupProps = ExtractPropTypes<typeof datePickerProps>
 
+export interface DatePickerDateSlotProps {
+  year: number
+  month: number
+  date: number
+}
+
 export interface DatePickerSlots {
   'date-icon'?: () => VNode[]
+  date?: (props: DatePickerDateSlotProps) => VNode[]
   footer?: () => VNode[]
   'next-month'?: () => VNode[]
   'next-year'?: () => VNode[]

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -62,6 +62,7 @@ import DatetimerangePanel from './panel/datetimerange'
 import MonthPanel from './panel/month'
 import MonthRangePanel from './panel/monthrange'
 import { datePickerProps } from './props'
+import type { DatePickerDateSlotProps } from './public-types'
 import style from './styles/index.cssr'
 import { strictParse } from './utils'
 import {
@@ -70,12 +71,6 @@ import {
 } from './validation-utils'
 
 export type DatePickerSetupProps = ExtractPropTypes<typeof datePickerProps>
-
-export interface DatePickerDateSlotProps {
-  year: number
-  month: number
-  date: number
-}
 
 export interface DatePickerSlots {
   'date-icon'?: () => VNode[]

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -16,7 +16,7 @@ import type {
   Value
 } from './interface'
 import type { UsePanelCommonProps } from './panel/use-panel-common'
-import type { DatePickerInst } from './public-types'
+import type { DatePickerDateSlotProps, DatePickerInst } from './public-types'
 import { format, getTime, isValid } from 'date-fns'
 import { getPreciseEventTarget, happensIn } from 'seemly'
 import { clickoutside } from 'vdirs'
@@ -62,7 +62,6 @@ import DatetimerangePanel from './panel/datetimerange'
 import MonthPanel from './panel/month'
 import MonthRangePanel from './panel/monthrange'
 import { datePickerProps } from './props'
-import type { DatePickerDateSlotProps } from './public-types'
 import style from './styles/index.cssr'
 import { strictParse } from './utils'
 import {

--- a/src/date-picker/src/panel/date.tsx
+++ b/src/date-picker/src/panel/date.tsx
@@ -160,7 +160,9 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {dateItem.dateObject.date}
+                {datePickerSlots.date
+                  ? datePickerSlots.date(dateItem.dateObject)
+                  : dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}

--- a/src/date-picker/src/panel/date.tsx
+++ b/src/date-picker/src/panel/date.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../_utils'
 import { NButton, NxButton } from '../../../button'
 import PanelHeader from './panelHeader'
+import { renderDate } from './renderDate'
 import { useCalendar, useCalendarProps } from './use-calendar'
 
 /**
@@ -160,9 +161,7 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {datePickerSlots.date
-                  ? datePickerSlots.date(dateItem.dateObject)
-                  : dateItem.dateObject.date}
+                {renderDate(datePickerSlots.date, dateItem.dateObject)}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}

--- a/src/date-picker/src/panel/daterange.tsx
+++ b/src/date-picker/src/panel/daterange.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../_utils'
 import { NButton, NxButton } from '../../../button'
 import PanelHeader from './panelHeader'
+import { renderDate } from './renderDate'
 import { useDualCalendar, useDualCalendarProps } from './use-dual-calendar'
 
 export default defineComponent({
@@ -148,9 +149,7 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {datePickerSlots.date
-                  ? datePickerSlots.date(dateItem.dateObject)
-                  : dateItem.dateObject.date}
+                {renderDate(datePickerSlots.date, dateItem.dateObject)}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}
@@ -249,9 +248,7 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {datePickerSlots.date
-                  ? datePickerSlots.date(dateItem.dateObject)
-                  : dateItem.dateObject.date}
+                {renderDate(datePickerSlots.date, dateItem.dateObject)}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}

--- a/src/date-picker/src/panel/daterange.tsx
+++ b/src/date-picker/src/panel/daterange.tsx
@@ -148,7 +148,9 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {dateItem.dateObject.date}
+                {datePickerSlots.date
+                  ? datePickerSlots.date(dateItem.dateObject)
+                  : dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}
@@ -247,7 +249,9 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {dateItem.dateObject.date}
+                {datePickerSlots.date
+                  ? datePickerSlots.date(dateItem.dateObject)
+                  : dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}

--- a/src/date-picker/src/panel/datetime.tsx
+++ b/src/date-picker/src/panel/datetime.tsx
@@ -167,7 +167,9 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {dateItem.dateObject.date}
+                {datePickerSlots.date
+                  ? datePickerSlots.date(dateItem.dateObject)
+                  : dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}

--- a/src/date-picker/src/panel/datetime.tsx
+++ b/src/date-picker/src/panel/datetime.tsx
@@ -16,6 +16,7 @@ import { NButton, NxButton } from '../../../button'
 import { NInput } from '../../../input'
 import { NTimePicker } from '../../../time-picker'
 import PanelHeader from './panelHeader'
+import { renderDate } from './renderDate'
 import { useCalendar, useCalendarProps } from './use-calendar'
 
 /**
@@ -167,9 +168,7 @@ export default defineComponent({
                 }}
               >
                 <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                {datePickerSlots.date
-                  ? datePickerSlots.date(dateItem.dateObject)
-                  : dateItem.dateObject.date}
+                {renderDate(datePickerSlots.date, dateItem.dateObject)}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                 ) : null}

--- a/src/date-picker/src/panel/datetimerange.tsx
+++ b/src/date-picker/src/panel/datetimerange.tsx
@@ -19,6 +19,7 @@ import { NButton, NxButton } from '../../../button'
 import { NInput } from '../../../input'
 import { NTimePicker } from '../../../time-picker'
 import PanelHeader from './panelHeader'
+import { renderDate } from './renderDate'
 import { useDualCalendar, useDualCalendarProps } from './use-dual-calendar'
 
 export default defineComponent({
@@ -224,15 +225,13 @@ export default defineComponent({
                           this.handleDateMouseEnter(dateItem)
                         }
                   }
-                >
-                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                  {datePickerSlots.date
-                    ? datePickerSlots.date(dateItem.dateObject)
-                    : dateItem.dateObject.date}
-                  {dateItem.isCurrentDate ? (
-                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
-                  ) : null}
-                </div>
+	                >
+	                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
+	                  {renderDate(datePickerSlots.date, dateItem.dateObject)}
+	                  {dateItem.isCurrentDate ? (
+	                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
+	                  ) : null}
+	                </div>
               )
             })}
           </div>
@@ -335,15 +334,13 @@ export default defineComponent({
                           this.handleDateMouseEnter(dateItem)
                         }
                   }
-                >
-                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                  {datePickerSlots.date
-                    ? datePickerSlots.date(dateItem.dateObject)
-                    : dateItem.dateObject.date}
-                  {dateItem.isCurrentDate ? (
-                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
-                  ) : null}
-                </div>
+	                >
+	                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
+	                  {renderDate(datePickerSlots.date, dateItem.dateObject)}
+	                  {dateItem.isCurrentDate ? (
+	                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
+	                  ) : null}
+	                </div>
               )
             })}
           </div>

--- a/src/date-picker/src/panel/datetimerange.tsx
+++ b/src/date-picker/src/panel/datetimerange.tsx
@@ -226,7 +226,9 @@ export default defineComponent({
                   }
                 >
                   <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                  {dateItem.dateObject.date}
+                  {datePickerSlots.date
+                    ? datePickerSlots.date(dateItem.dateObject)
+                    : dateItem.dateObject.date}
                   {dateItem.isCurrentDate ? (
                     <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                   ) : null}
@@ -335,7 +337,9 @@ export default defineComponent({
                   }
                 >
                   <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-                  {dateItem.dateObject.date}
+                  {datePickerSlots.date
+                    ? datePickerSlots.date(dateItem.dateObject)
+                    : dateItem.dateObject.date}
                   {dateItem.isCurrentDate ? (
                     <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
                   ) : null}

--- a/src/date-picker/src/panel/datetimerange.tsx
+++ b/src/date-picker/src/panel/datetimerange.tsx
@@ -225,13 +225,13 @@ export default defineComponent({
                           this.handleDateMouseEnter(dateItem)
                         }
                   }
-	                >
-	                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-	                  {renderDate(datePickerSlots.date, dateItem.dateObject)}
-	                  {dateItem.isCurrentDate ? (
-	                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
-	                  ) : null}
-	                </div>
+                >
+                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
+                  {renderDate(datePickerSlots.date, dateItem.dateObject)}
+                  {dateItem.isCurrentDate ? (
+                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
+                  ) : null}
+                </div>
               )
             })}
           </div>
@@ -334,13 +334,13 @@ export default defineComponent({
                           this.handleDateMouseEnter(dateItem)
                         }
                   }
-	                >
-	                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
-	                  {renderDate(datePickerSlots.date, dateItem.dateObject)}
-	                  {dateItem.isCurrentDate ? (
-	                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
-	                  ) : null}
-	                </div>
+                >
+                  <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
+                  {renderDate(datePickerSlots.date, dateItem.dateObject)}
+                  {dateItem.isCurrentDate ? (
+                    <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
+                  ) : null}
+                </div>
               )
             })}
           </div>

--- a/src/date-picker/src/panel/renderDate.ts
+++ b/src/date-picker/src/panel/renderDate.ts
@@ -1,0 +1,12 @@
+import type { VNodeChild } from 'vue'
+import type { DatePickerDateSlotProps } from '../public-types'
+
+export type DatePickerDateSlot = (props: DatePickerDateSlotProps) => VNodeChild
+
+export function renderDate(
+  dateSlot: DatePickerDateSlot | undefined,
+  dateObject: DatePickerDateSlotProps
+): VNodeChild {
+  return dateSlot ? dateSlot(dateObject) : dateObject.date
+}
+

--- a/src/date-picker/src/panel/renderDate.ts
+++ b/src/date-picker/src/panel/renderDate.ts
@@ -9,4 +9,3 @@ export function renderDate(
 ): VNodeChild {
   return dateSlot ? dateSlot(dateObject) : dateObject.date
 }
-

--- a/src/date-picker/src/public-types.ts
+++ b/src/date-picker/src/public-types.ts
@@ -26,3 +26,9 @@ export interface DatePickerConfirmSlotProps {
   disabled: boolean
   text: string
 }
+
+export interface DatePickerDateSlotProps {
+  year: number
+  month: number
+  date: number
+}


### PR DESCRIPTION
### 功能描述

为 DatePicker 组件添加 \`date\` 插槽，允许用户自定义日期单元格的内容，例如添加农历、节日等信息。

### 关联 Issue

Closes #6751

### 修改内容

- 在 \`DatePickerSlots\` 接口中添加 \`date\` 插槽定义，接受 \`{ year, month, date }\` 参数
- 在 \`public-types.ts\` 中导出 \`DatePickerDateSlotProps\` 类型
- 在以下面板文件中支持 date 插槽：
  - \`date.tsx\`
  - \`datetime.tsx\`
  - \`daterange.tsx\`（两处）
  - \`datetimerange.tsx\`（两处）
- 添加中英文演示文件
- 更新中英文文档

### 用法示例

\`\`\`vue
<n-date-picker type="date">
  <template #date="{ year, month, date }">
    <div style="display: flex; flex-direction: column; align-items: center">
      <span>{{ date }}</span>
      <span style="font-size: 10px; color: #999">
        {{ getLunarDate(year, month, date) }}
      </span>
    </div>
  </template>
</n-date-picker>
\`\`\`