### PR TITLE
feat(select): add separators prop

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-select` adds `separators` prop to split input in multiple mode, closes [#2368](https://github.com/tusen-ai/naive-ui/issues/2368).
+
+### Fixes
+
+- Fix `n-select` may delete disabled selected options.
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Feats
+
+- `n-select` 增加 `separators` 属性，用于多选模式下按分隔符拆分输入并选中/创建，关闭 [#2368](https://github.com/tusen-ai/naive-ui/issues/2368)
+
+### Fixes
+
+- 修复 `n-select` 可能删除已选中的禁用选项
+
 ## 2.43.2
 
 ### Fixes

--- a/src/_internal/selection/src/Selection.tsx
+++ b/src/_internal/selection/src/Selection.tsx
@@ -105,6 +105,7 @@ export default defineComponent({
     ellipsisTagPopoverProps: Object as PropType<PopoverProps>,
     onClear: Function as PropType<(e: MouseEvent) => void>,
     onPatternInput: Function as PropType<(e: InputEvent) => void>,
+    onPatternInputPaste: Function as PropType<(e: ClipboardEvent) => void>,
     onPatternFocus: Function as PropType<(e: FocusEvent) => void>,
     onPatternBlur: Function as PropType<(e: FocusEvent) => void>,
     renderLabel: Function as PropType<RenderLabel>,
@@ -275,7 +276,14 @@ export default defineComponent({
         if (!props.pattern.length) {
           const { selectedOptions } = props
           if (selectedOptions?.length) {
-            handleDeleteOption(selectedOptions[selectedOptions.length - 1])
+            // Find the last non-disabled option to delete
+            for (let i = selectedOptions.length - 1; i >= 0; i--) {
+              const option = selectedOptions[i]
+              if (!option.disabled) {
+                handleDeleteOption(option)
+                return
+              }
+            }
           }
         }
       }
@@ -397,6 +405,9 @@ export default defineComponent({
         clearEnterTimer()
         showTagsPopoverRef.value = false
       }
+    }
+    function handlePatternInputPaste(e: ClipboardEvent): void {
+      props.onPatternInputPaste?.(e)
     }
     watch(selectedRef, (value) => {
       if (!value) {
@@ -578,6 +589,7 @@ export default defineComponent({
       handleDeleteOption,
       handlePatternKeyDown,
       handlePatternInputInput,
+      handlePatternInputPaste,
       handlePatternInputBlur,
       handlePatternInputFocus,
       handleMouseEnterCounter,
@@ -696,6 +708,7 @@ export default defineComponent({
             onFocus={this.handlePatternInputFocus}
             onKeydown={this.handlePatternKeyDown}
             onInput={this.handlePatternInputInput as any}
+            onPaste={this.handlePatternInputPaste}
             onCompositionstart={this.handleCompositionStart}
             onCompositionend={this.handleCompositionEnd}
           />
@@ -893,6 +906,7 @@ export default defineComponent({
               onInput={this.handlePatternInputInput as any}
               onCompositionstart={this.handleCompositionStart}
               onCompositionend={this.handleCompositionEnd}
+              onPaste={this.handlePatternInputPaste}
             />
             {showSelectedLabel ? (
               <div

--- a/src/select/demos/enUS/index.demo-entry.md
+++ b/src/select/demos/enUS/index.demo-entry.md
@@ -11,6 +11,7 @@ multiple.vue
 events.vue
 filterable.vue
 tag.vue
+separators.vue
 menu-width.vue
 remote.vue
 remote-multiple.vue
@@ -69,6 +70,7 @@ custom-field.vue
 | show-arrow | `boolean` | `true` | Whether to show the dropdown arrow. |  |
 | show-checkmark | `boolean` | `true` | Whether to show checkmark. | 2.33.4 |
 | show-on-focus | `boolean` | `false` | Whether to show menu on focus. | 2.34.3 |
+| separators | `string[]` | `undefined` | Separators in `multiple` mode. When input (or pasted text) contains a separator, it will be split and Naive UI will try to select options (`tag` mode will create). | NEXT_VERSION |
 | size | `'tiny' \| 'small' \| 'medium' \| 'large'` | `'medium'` | Size of the select input. |  |
 | status | `'success' \| 'warning' \| 'error'` | `undefined` | Validation status. | 2.27.0 |
 | tag | `boolean` | `false` | Whether users can create new options. This should be used with `filterable`. |  |

--- a/src/select/demos/enUS/separators.demo.vue
+++ b/src/select/demos/enUS/separators.demo.vue
@@ -1,0 +1,42 @@
+<markdown>
+# Separators
+
+In `multiple` mode, set `separators`. When the input (or pasted text) contains a separator, it will be split immediately and Naive UI will try to select matching options (`tag` mode will create options).
+</markdown>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const tagValue = ref<Array<string | number>>([])
+const selectValue = ref<Array<string | number>>([])
+
+const options = [
+  { label: '123', value: 'xxx' },
+  { label: '456', value: 'yyy' }
+]
+</script>
+
+<template>
+  <n-space vertical>
+    <n-text>Type or paste: aa;bb;cc</n-text>
+    <n-select
+      v-model:value="tagValue"
+      filterable
+      tag
+      multiple
+      :separators="[';']"
+      placeholder="Type or paste: aa;bb;cc"
+      :show-arrow="false"
+      :options="options"
+    />
+    <n-text>Type or paste: 123,456;</n-text>
+    <n-select
+      v-model:value="selectValue"
+      multiple
+      filterable
+      :options="options"
+      :separators="[';', ',']"
+      placeholder="Type or paste: 123,456;"
+    />
+  </n-space>
+</template>

--- a/src/select/demos/zhCN/index.demo-entry.md
+++ b/src/select/demos/zhCN/index.demo-entry.md
@@ -11,6 +11,7 @@ multiple.vue
 events.vue
 filterable.vue
 tag.vue
+separators.vue
 menu-width.vue
 remote.vue
 remote-multiple.vue
@@ -80,6 +81,7 @@ create-debug.vue
 | show-arrow | `boolean` | `true` | 是否展示箭头 |  |
 | show-checkmark | `boolean` | `true` | 是否展示对勾 | 2.33.4 |
 | show-on-focus | `boolean` | `false` | 聚焦时是否展示菜单 | 2.34.3 |
+| separators | `string[]` | `undefined` | 多选模式下的分隔符，输入或粘贴包含分隔符时会按分隔符拆分并尝试选中（`tag` 模式会创建） | NEXT_VERSION |
 | size | `'tiny' \| 'small' \| 'medium' \| 'large'` | `'medium'` | 组件尺寸 |  |
 | status | `'success' \| 'warning' \| 'error'` | `undefined` | 验证状态 | 2.27.0 |
 | tag | `boolean` | `false` | 是否可以创建新的选项，需要和 `filterable` 一起使用 |  |

--- a/src/select/demos/zhCN/separators.demo.vue
+++ b/src/select/demos/zhCN/separators.demo.vue
@@ -1,0 +1,42 @@
+<markdown>
+# 分隔符
+
+在 `multiple` 模式下配置 `separators`，当输入或粘贴内容包含分隔符时，会按分隔符立即拆分并尝试选中（`tag` 模式会创建）。
+</markdown>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const tagValue = ref<Array<string | number>>([])
+const selectValue = ref<Array<string | number>>([])
+
+const options = [
+  { label: '123', value: 'xxx' },
+  { label: '456', value: 'yyy' }
+]
+</script>
+
+<template>
+  <n-space vertical>
+    <n-text>输入或粘贴：aa;bb;cc</n-text>
+    <n-select
+      v-model:value="tagValue"
+      filterable
+      tag
+      multiple
+      :separators="[';']"
+      placeholder="输入或粘贴：aa;bb;cc"
+      :show-arrow="false"
+      :options="options"
+    />
+    <n-text>输入或粘贴：123,456;</n-text>
+    <n-select
+      v-model:value="selectValue"
+      multiple
+      filterable
+      :options="options"
+      :separators="[';', ',']"
+      placeholder="输入或粘贴：123,456;"
+    />
+  </n-space>
+</template>

--- a/src/select/demos/zhCN/tag.demo.vue
+++ b/src/select/demos/zhCN/tag.demo.vue
@@ -7,7 +7,7 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 
-const multipleSelectValue = ref(null)
+const multipleSelectValue = ref(['song0'])
 const selectValue = ref(null)
 const options = [
   {

--- a/src/select/src/utils.ts
+++ b/src/select/src/utils.ts
@@ -6,6 +6,7 @@ import type {
   SelectMixedOption,
   SelectOption
 } from './interface'
+import { escapeRegExp } from 'lodash-es'
 
 export function getIsGroup(option: SelectMixedOption): boolean {
   return option.type === 'group'
@@ -24,6 +25,23 @@ export function patternMatched(pattern: string, value: string): boolean {
   catch {
     return false
   }
+}
+
+export function doPatternSplit(
+  pattern: string,
+  separators: string[]
+): string[] | null {
+  const escapedSeparators = separators.map(escapeRegExp).join('|')
+  const re = new RegExp(escapedSeparators)
+  const patterns = pattern
+    .split(re)
+    .map(s => s.trim())
+    .filter(Boolean)
+
+  if (patterns.length > 1 || patterns[0] !== pattern) {
+    return patterns
+  }
+  return null
 }
 
 export function createTmOptions(

--- a/src/select/tests/SelectSeparators.spec.tsx
+++ b/src/select/tests/SelectSeparators.spec.tsx
@@ -1,0 +1,647 @@
+import { mount } from '@vue/test-utils'
+import { vi } from 'vitest'
+import { nextTick } from 'vue'
+import { NInternalSelection, NInternalSelectMenu } from '../../_internal'
+import { NSelect } from '../index'
+
+describe('separators related cases', () => {
+  it('should not tokenize if no separator matched', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('abc')
+    await nextTick()
+
+    expect(onUpdateValue).not.toHaveBeenCalled()
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe(
+      'abc'
+    )
+
+    wrapper.unmount()
+  })
+
+  it('tokenize input with multiple separators', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [' ', ',', ';'],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('1 2,3;4;5,,,,;6 7,8 ')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8'
+    ])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('tokenize input with multi-char separator', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: ['||'],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('a||b||c||')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a', 'b', 'c'])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('tokenize input with repeated single separator', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: ['.'],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('a1.a2.a3.a4.')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a1', 'a2', 'a3', 'a4'])
+
+    const tagTexts = wrapper.findAll('.n-tag').map(node => node.text())
+    expect(tagTexts).toEqual(['a1', 'a2', 'a3', 'a4'])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('tokenize input with Chinese comma', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: ['，'],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('a，b')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a', 'b'])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should ignore empty tokens', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue(',,,')
+    await nextTick()
+
+    expect(onUpdateValue).not.toHaveBeenCalled()
+    expect(wrapper.findAll('.n-tag')).toHaveLength(0)
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should keep menu open after tokenization', async () => {
+    const onUpdateShow = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        separators: [','],
+        onUpdateShow,
+        options: [
+          { label: '1', value: '1' },
+          { label: '2', value: '2' }
+        ],
+        virtualScroll: false
+      }
+    })
+
+    const selection = wrapper.findComponent(NInternalSelection)
+    await selection.trigger('click')
+    await nextTick()
+    expect(wrapper.findComponent(NInternalSelectMenu).exists()).toBe(true)
+
+    await wrapper.find('input').setValue('2,3,4')
+    await nextTick()
+
+    expect(wrapper.findComponent(NInternalSelectMenu).exists()).toBe(true)
+    expect(onUpdateShow).not.toHaveBeenLastCalledWith(false)
+
+    wrapper.unmount()
+  })
+
+  it('tokenize input (tag + multiple)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('a,b,,c,')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a', 'b', 'c'])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('tokenize input (tags, include existing option)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        options: [
+          { label: '1', value: '1' },
+          { label: '2', value: '2' }
+        ],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('2,3,4')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['2', '3', '4'])
+    const tagTexts = wrapper.findAll('.n-tag').map(node => node.text())
+    expect(tagTexts).toEqual(['2', '3', '4'])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('paste should fully consume and clear input (tag + multiple)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('paste', {
+      clipboardData: { getData: () => 'a,b,c' }
+    })
+    await input.setValue('a,b,c')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a', 'b', 'c'])
+    expect((input.element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('paste should trim tokens (tag + multiple)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('paste', {
+      clipboardData: { getData: () => ' a ,  b ,c ' }
+    })
+    await input.setValue(' a ,  b ,c ')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a', 'b', 'c'])
+    expect((input.element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('paste should select only matching tokens and clear all input (multiple)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        multiple: true,
+        show: false,
+        virtualScroll: false,
+        separators: [','],
+        options: [
+          { label: 'red', value: 'red' },
+          { label: 'blue', value: 'blue' }
+        ],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('paste', {
+      clipboardData: { getData: () => 'red,green,blue,yellow' }
+    })
+    await input.setValue('red,green,blue,yellow')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['red', 'blue'])
+    expect((input.element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('paste with no separator matched should behave like normal paste (tag + multiple)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('paste', {
+      clipboardData: { getData: () => 'abc' }
+    })
+    await input.setValue('abc')
+    await nextTick()
+
+    expect(onUpdateValue).not.toHaveBeenCalled()
+    expect((input.element as HTMLInputElement).value).toBe('abc')
+
+    wrapper.unmount()
+  })
+
+  // special cases
+  ;[
+    {
+      separators: [' ', '\n'],
+      clipboardText: '\n  light\n  bamboo\n  ',
+      inputValue: '   light   bamboo   '
+    },
+    {
+      separators: ['\r\n'], // Windows related
+      clipboardText: '\r\nlight\r\nbamboo\r\n',
+      inputValue: ' light bamboo'
+    },
+    {
+      separators: [' ', '\r\n'],
+      clipboardText: '\r\n light\r\n bamboo\r\n ',
+      inputValue: '  light  bamboo  '
+    },
+    {
+      separators: ['\n'],
+      clipboardText: '\nlight\nbamboo\n',
+      inputValue: ' light bamboo'
+    }
+  ].forEach(({ separators, clipboardText, inputValue }) => {
+    it(`paste content to split (tag + multiple) (${JSON.stringify(separators)})`, async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = mount(NSelect, {
+        attachTo: document.body,
+        props: {
+          filterable: true,
+          tag: true,
+          multiple: true,
+          show: false,
+          virtualScroll: false,
+          separators,
+          onUpdateValue
+        }
+      })
+
+      const input = wrapper.find('input')
+      await input.trigger('paste', {
+        clipboardData: { getData: () => clipboardText }
+      })
+      await input.setValue(inputValue)
+      await nextTick()
+
+      expect(onUpdateValue).toHaveBeenCalledTimes(1)
+      expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['light', 'bamboo'])
+
+      wrapper.unmount()
+    })
+  })
+
+  // it('typing should keep non-matching suffix (multiple)', async () => {
+  //   const onUpdateValue = vi.fn()
+  //   const wrapper = mount(NSelect, {
+  //     attachTo: document.body,
+  //     props: {
+  //       filterable: true,
+  //       multiple: true,
+  //       show: false,
+  //       virtualScroll: false,
+  //       separators: [','],
+  //       options: [
+  //         { label: 'apple', value: 'apple' },
+  //         { label: 'banana', value: 'banana' }
+  //       ],
+  //       onUpdateValue
+  //     }
+  //   })
+
+  //   await wrapper.find('input').setValue('apple,c')
+  //   await nextTick()
+
+  //   expect(onUpdateValue).toHaveBeenCalledTimes(1)
+  //   expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['apple'])
+  //   expect((wrapper.find('input').element as HTMLInputElement).value).toBe('c')
+
+  //   wrapper.unmount()
+  // })
+
+  it('tokenize input (multiple respects labelField)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        multiple: true,
+        show: false,
+        virtualScroll: false,
+        separators: [','],
+        labelField: 'name',
+        options: [
+          { name: 'One', value: 1 },
+          { name: 'Two', value: 2 }
+        ],
+        onUpdateValue
+      }
+    })
+
+    await wrapper.find('input').setValue('One,Two')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual([1, 2])
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should work when menu is closed (tag + composition + enter)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('compositionstart')
+    await input.setValue('Star Kirby')
+    await input.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+    expect(onUpdateValue).not.toHaveBeenCalled()
+
+    await input.trigger('compositionend')
+    await input.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['Star Kirby'])
+
+    wrapper.unmount()
+  })
+
+  it('should not tokenize during composition but trigger after composition end (tag + multiple)', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [','],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('compositionstart')
+    await input.setValue('a,b')
+    await nextTick()
+    expect(onUpdateValue).not.toHaveBeenCalled()
+
+    await input.trigger('compositionend')
+    await nextTick()
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['a', 'b'])
+
+    wrapper.unmount()
+  })
+
+  it('shouldn\'t tokenize words during composition in multiple mode', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        multiple: true,
+        show: false,
+        virtualScroll: false,
+        separators: [','],
+        options: [
+          { label: 'One', value: 1 },
+          { label: 'Two', value: 2 }
+        ],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('compositionstart')
+    await input.setValue('One,Two,Three')
+    await nextTick()
+    expect(onUpdateValue).not.toHaveBeenCalled()
+
+    await input.trigger('compositionend')
+    await input.setValue('One,Two,Three')
+    await nextTick()
+
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual([1, 2])
+
+    wrapper.unmount()
+  })
+
+  it('chinese input composition should not tokenize prematurely', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        tag: true,
+        multiple: true,
+        show: false,
+        separators: [',', '，'],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+
+    // Simulate Chinese IME input: typing "nihao,shijie" becomes "你好,世界"
+    await input.trigger('compositionstart')
+    await input.setValue('nihao,shijie')
+    await nextTick()
+
+    // Should not tokenize during composition even though ',' is present
+    expect(onUpdateValue).not.toHaveBeenCalled()
+    expect((input.element as HTMLInputElement).value).toBe('nihao,shijie')
+
+    // User confirms composition - setValue triggers input event which causes tokenization
+    await input.trigger('compositionend')
+    await nextTick()
+
+    // Should tokenize after composition ends
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['nihao', 'shijie'])
+    expect((input.element as HTMLInputElement).value).toBe('')
+
+    wrapper.unmount()
+  })
+
+  // This is different from the original behavior
+  it('backspace should delete selected tag but should not delete disabled option', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NSelect, {
+      attachTo: document.body,
+      props: {
+        filterable: true,
+        multiple: true,
+        show: false,
+        virtualScroll: false,
+        value: ['Option2', 'Option1'],
+        options: [
+          { label: 'Option1', value: 'Option1', disabled: true },
+          { label: 'Option2', value: 'Option2', disabled: false }
+        ],
+        onUpdateValue
+      }
+    })
+
+    const input = wrapper.find('input')
+    expect(wrapper.findAll('.n-tag')).toHaveLength(2)
+
+    await input.trigger('keydown', { key: 'Backspace' })
+    await nextTick()
+
+    // Should remove Option2 and keep disabled Option1
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0]?.[0]).toEqual(['Option1'])
+
+    // Update value prop to reflect the change (simulating controlled component update)
+    await wrapper.setProps({ value: ['Option1'] })
+    await nextTick()
+    expect(wrapper.findAll('.n-tag')).toHaveLength(1)
+
+    await input.trigger('keydown', { key: 'Backspace' })
+    await nextTick()
+
+    // Should not remove disabled Option1
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(wrapper.findAll('.n-tag')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

- Adds `separators: string[]` prop to `n-select` (multiple) to split input/paste by separators and select/create options. Includes demos, docs, tests, and changelog entries.
- Fix may delete selected disabled option
Closes #2368.
