### PR TITLE
fix(tag): icon inherits checked text color

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-tag` icon slot doesn't inherit checked text color when used with `checkable`, closes [#7407](https://github.com/tusen-ai/naive-ui/issues/7407).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-tag` 在 `checkable` 且使用 `#icon` 插槽时，checked 状态下图标不继承文字颜色，关闭 [#7407](https://github.com/tusen-ai/naive-ui/issues/7407)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/tag/demos/enUS/checkable.demo.vue
+++ b/src/tag/demos/enUS/checkable.demo.vue
@@ -5,6 +5,7 @@ It can be checkable.
 </markdown>
 
 <script lang="ts" setup>
+import { CheckmarkCircle } from '@vicons/ionicons5'
 import { ref } from 'vue'
 
 const checked = ref(false)
@@ -26,6 +27,9 @@ const checked = ref(false)
     </n-tag>
     <n-tag v-model:checked="checked" checkable>
       I'm Looking Through You
+      <template #icon>
+        <n-icon :component="CheckmarkCircle" />
+      </template>
     </n-tag>
   </n-space>
 </template>

--- a/src/tag/demos/zhCN/checkable.demo.vue
+++ b/src/tag/demos/zhCN/checkable.demo.vue
@@ -5,6 +5,7 @@
 </markdown>
 
 <script lang="ts" setup>
+import { CheckmarkCircle } from '@vicons/ionicons5'
 import { ref } from 'vue'
 
 const checked = ref(false)
@@ -26,6 +27,9 @@ const checked = ref(false)
     </n-tag>
     <n-tag v-model:checked="checked" checkable>
       哪里都是你
+      <template #icon>
+        <n-icon :component="CheckmarkCircle" />
+      </template>
     </n-tag>
   </n-space>
 </template>

--- a/src/tag/src/styles/index.cssr.ts
+++ b/src/tag/src/styles/index.cssr.ts
@@ -66,7 +66,7 @@ export default cB('tag', `
   cE('icon', `
     display: flex;
     margin: 0 4px 0 0;
-    color: var(--n-text-color);
+    color: inherit;
     transition: color .3s var(--n-bezier);
     font-size: var(--n-avatar-size-override);
   `),

--- a/src/tag/tests/Tag.spec.ts
+++ b/src/tag/tests/Tag.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { h } from 'vue'
 import { NAvatar } from '../../avatar'
 import { NTag } from '../index'
+import tagStyle from '../src/styles/index.cssr'
 
 describe('n-tag', () => {
   it('should work with import on demand', () => {
@@ -42,6 +43,12 @@ describe('n-tag', () => {
 
     await wrapper.setProps({ checked: false })
     expect(wrapper.find('.n-tag').classes()).not.toContain('n-tag--checked')
+  })
+
+  it('icon should inherit tag text color', () => {
+    const css = tagStyle.render()
+    expect(css).toContain('.n-tag .n-tag__icon')
+    expect(css).toContain('color: inherit;')
   })
 
   it('should work with `on-update:checked` prop', () => {


### PR DESCRIPTION
## Summary
Fixes `n-tag` checkable checked state: the icon rendered by the `#icon` slot now follows the checked text color.

## Changes
- Make `.n-tag__icon` inherit color from `.n-tag` (so `--n-text-color-checked` applies in checked state).
- Add a regression test for the generated CSS.
- Update the checkable demo (enUS/zhCN) to show an icon on the last tag.
- Add changelog entries.

## Related
Closes #7407

## Testing
- `pnpm test -- src/tag/tests/Tag.spec.ts src/tag/tests/server.spec.tsx`
- `pnpm dev` then toggle the last checkable tag in the Tag demo page.
