### PR TITLE
fix: use function slot syntax for VResizeObserver to avoid performance warning

### DIFF
--- a/src/marquee/src/Marquee.tsx
+++ b/src/marquee/src/Marquee.tsx
@@ -98,12 +98,12 @@ export default defineComponent({
         <div
           class={`${mergedClsPrefix}-marquee__item ${mergedClsPrefix}-marquee__original-item`}
         >
-          {$slots}
+          {$slots.default?.()}
         </div>
       </VResizeObserver>
     )
     const mirrorNode = (
-      <div class={`${mergedClsPrefix}-marquee__item`}>{$slots}</div>
+      <div class={`${mergedClsPrefix}-marquee__item`}>{$slots.default?.()}</div>
     )
     if (this.autoFill) {
       return (


### PR DESCRIPTION
use function slot syntax for VResizeObserver to avoid performance warning `Non-function value encountered for default slot. Prefer function slots for better performance`