### PR TITLE
fix(tab-bar): 修复tab-bar无过渡动画的问题

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.43.3
+
+`2026-01-22`
+
+- tab-bar: Fix no transition animation when switching [#7406](https://github.com/tusen-ai/naive-ui/issues/7406)
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.43.3
+
+`2026-01-22`
+
+- 修复在 `n-tabs` 在 `#Suffix` 宽度变化的情况下，动画效果丢失的问题，关闭[#7406](https://github.com/tusen-ai/naive-ui/issues/7406)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -242,8 +242,14 @@ export default defineComponent({
             barEl.style.maxWidth = `${barWidth}px`
           }
           else {
-            barEl.style.left = `${tabEl.offsetLeft}px`
-            barEl.style.maxWidth = `${tabEl.offsetWidth}px`
+            void nextTick(() => {
+              requestAnimationFrame(() =>
+                requestAnimationFrame(() => {
+                  barEl.style.left = `${tabEl.offsetLeft}px`
+                  barEl.style.maxWidth = `${tabEl.offsetWidth}px`
+                })
+              )
+            })
           }
           barEl.style.width = '8192px'
           if (barIsHide) {


### PR DESCRIPTION
### 相关 Issue
https://github.com/tusen-ai/naive-ui/issues/7406 （tab-bar 组件无过渡动画问题）

### 修改描述
修复 Issue #7406 中 tab-bar 组件切换时无过渡动画的问题：
1. 调整了 tab-bar 子元素的渲染时机，保证过渡动画触发。

### 测试情况
- [ ] pnpm lint --fix 执行无 error（代码格式符合规范）
- [ ] pnpm run build:site 因 Windows 环境 bash 脚本/权限问题暂未验证（不影响核心组件逻辑）

### 补充说明
本地 Windows 环境下，因项目构建脚本对 bash 环境的依赖及权限限制，暂未完成官网（site）的构建验证，但核心的 tab-bar 组件逻辑已本地验证无误，过渡动画可正常触发。
