### PR TITLE
fix(checkbox): click causing contenteditable elements to require two clicks to focus

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-checkbox` click causing `contenteditable` elements to require two clicks to focus, closes [#7420](https://github.com/tusen-ai/naive-ui/issues/7420).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-checkbox` 点击后导致 `contenteditable` 元素需要点击两次才能聚焦，关闭 [#7420](https://github.com/tusen-ai/naive-ui/issues/7420)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/checkbox/demos/zhCN/contenteditable-debug.demo.vue
+++ b/src/checkbox/demos/zhCN/contenteditable-debug.demo.vue
@@ -1,0 +1,35 @@
+<markdown>
+# Contenteditable Debug
+
+Issue #7420: 点击复选框后，contenteditable 的 div 需要点击两次才能输入内容。
+
+复现步骤：
+1. 点击复选框
+2. 点击下方的可编辑区域，尝试输入
+3. 如果修复成功，应该只需要点击一次就能输入
+</markdown>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const checked = ref(false)
+</script>
+
+<template>
+  <n-space vertical>
+    <n-checkbox v-model:checked="checked">
+      点击我
+    </n-checkbox>
+    <div
+      contenteditable="true"
+      style="
+        border: 1px solid #ccc;
+        padding: 8px;
+        min-height: 60px;
+        border-radius: 4px;
+      "
+    >
+      点击复选框后，再点击这里输入内容...
+    </div>
+  </n-space>
+</template>

--- a/src/checkbox/demos/zhCN/index.demo-entry.md
+++ b/src/checkbox/demos/zhCN/index.demo-entry.md
@@ -15,6 +15,7 @@ event.vue
 customize-value.vue
 focus.vue
 rtl-debug.vue
+contenteditable-debug.vue
 ```
 
 ## API

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -7,7 +7,6 @@ import type {
   OnUpdateChecked,
   OnUpdateCheckedImpl
 } from './interface'
-import { on } from 'evtd'
 import { createId } from 'seemly'
 import { useMemo, useMergedState } from 'vooks'
 import {
@@ -218,6 +217,15 @@ export default defineComponent({
           e.preventDefault()
       }
     }
+    function handleMousedown(): void {
+      const handleSelectStart = (e: Event): void => {
+        e.preventDefault()
+      }
+      window.addEventListener('selectstart', handleSelectStart)
+      setTimeout(() => {
+        window.removeEventListener('selectstart', handleSelectStart)
+      }, 0)
+    }
     const exposedMethods: CheckboxInst = {
       focus: () => {
         selfRef.value?.focus()
@@ -305,6 +313,7 @@ export default defineComponent({
       handleClick,
       handleKeyUp,
       handleKeyDown,
+      handleMousedown,
       cssVars: inlineThemeDisabled ? undefined : cssVarsRef,
       themeClass: themeClassHandle?.themeClass,
       onRender: themeClassHandle?.onRender
@@ -324,7 +333,8 @@ export default defineComponent({
       focusable,
       handleKeyUp,
       handleKeyDown,
-      handleClick
+      handleClick,
+      handleMousedown
     } = this
     this.onRender?.()
     const labelNode = resolveWrappedSlot($slots.default, (children) => {
@@ -358,18 +368,7 @@ export default defineComponent({
         onKeyup={handleKeyUp}
         onKeydown={handleKeyDown}
         onClick={handleClick}
-        onMousedown={() => {
-          on(
-            'selectstart',
-            window,
-            (e: Event): void => {
-              e.preventDefault()
-            },
-            {
-              once: true
-            }
-          )
-        }}
+        onMousedown={handleMousedown}
       >
         <div class={`${mergedClsPrefix}-checkbox-box-wrapper`}>
           &nbsp;


### PR DESCRIPTION
close #7420

**问题**：点击 checkbox 后，contenteditable 元素需要点击两次才能聚焦。

**原因**：`onMousedown` 中使用 `evtd` 的 `on()` + `once: true` 注册的 `selectstart` 监听器，只有在事件真正触发时才会移除。如果没有触发，监听器会保留并"吃掉"用户下一次点击其他元素时的 `selectstart` 事件。

**修复**：回退到之前的实现方式，使用 `addEventListener` + `setTimeout` 兜底，确保监听器在下一个事件循环中一定被移除。