### PR TITLE
fix(`n-rate`): use padding instead of margin for item spacing

### DIFF
--- a/src/rate/src/styles/index.cssr.ts
+++ b/src/rate/src/styles/index.cssr.ts
@@ -24,9 +24,13 @@ export default cB('rate', {
     transform: scale(1);
     font-size: var(--n-item-size);
     color: var(--n-item-color);
+    padding: 0 3px;
   `, [
-    c('&:not(:first-child)', `
-      margin-left: 6px;
+    c('&:first-child', `
+      padding-left: 0;
+    `),
+    c('&:last-child', `
+      padding-right: 0;
     `),
     cM('active', `
       color: var(--n-item-color-active);


### PR DESCRIPTION
close https://github.com/tusen-ai/naive-ui/issues/6070