### PR TITLE
feat(`n-image`): show error placeholder when src is empty string

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Feats
+
+- `n-image` shows error placeholder when `src` is empty string, closes [#7452](https://github.com/tusen-ai/naive-ui/issues/7452).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+`NEXT_VERSION`
+
+### Feats
+
+- `n-image` 当 `src` 为空字符串时显示错误占位图，关闭 [#7452](https://github.com/tusen-ai/naive-ui/issues/7452)
+
 ## 2.43.2
 
 ### Fixes

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -122,8 +122,8 @@ export default defineComponent({
     })
 
     watchEffect(() => {
-      void (props.src || props.imgProps?.src)
-      showErrorRef.value = false
+      const src = props.src ?? props.imgProps?.src
+      showErrorRef.value = !src
     })
 
     watchEffect((onInvalidate) => {

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -122,7 +122,7 @@ export default defineComponent({
     })
 
     watchEffect(() => {
-      const src = props.src ?? props.imgProps?.src
+      const src = props.src || props.imgProps?.src
       showErrorRef.value = !src
     })
 


### PR DESCRIPTION
close https://github.com/tusen-ai/naive-ui/issues/7452