### PR TITLE
fix(data-table): allow nested column groups in TableColumnGroup.children

### DIFF
--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -267,7 +267,7 @@ export type TableColumnGroup<T = InternalRowData> = {
   title?: TableColumnGroupTitle
   type?: never
   key: ColumnKey
-  children: Array<TableBaseColumn<T>>
+  children: Array<TableColumn<T>>
 
   // to suppress type error in table header
   resizable?: boolean


### PR DESCRIPTION
## Problem

The `TableColumnGroup` type declares:

```ts
children: Array<TableBaseColumn<T>>
```

This only allows leaf columns (`TableBaseColumn`) inside a column group, making it impossible to nest column groups inside other column groups from a TypeScript perspective. At runtime, the implementation **already supports** arbitrary nesting (see recursive calls in `use-group-header.ts`), so users who attempt to nest groups get a type error that doesn't reflect reality.

Fixes #7489.

## Root Cause

`TableBaseColumn` is the leaf column type. `TableColumn` is the union type that includes `TableColumnGroup`, `TableBaseColumn`, `TableSelectionColumn`, and `TableExpandColumn`. Using `TableBaseColumn` in `children` incorrectly prevents column group nesting at the type level.

## Fix

Change the `children` field to `Array<TableColumn<T>>`:

```ts
// Before
children: Array<TableBaseColumn<T>>

// After
children: Array<TableColumn<T>>
```

This is a **1-line change** in `src/data-table/src/interface.ts`.

## Why This Is Safe

1. **Implementation already handles nesting.** Both `ensureMaxDepth` and `ensureColLayout` in `use-group-header.ts` recursively process `column.children` when `'children' in column` is true — they've always supported nested groups.
2. **TypeScript recursive types are supported.** `TableColumnGroup → children: Array<TableColumn> → TableColumn = TableColumnGroup | ...` is a standard recursive type alias pattern supported since TypeScript 3.7. No circular-reference error is introduced.
3. **Type-checked.** Running `tsc --noEmit --skipLibCheck` on the modified codebase produces no new errors in `src/data-table`.