### PR TITLE
fix(radio): restore accessible hidden input sizing

### DIFF
--- a/src/radio/src/styles/radio.cssr.ts
+++ b/src/radio/src/styles/radio.cssr.ts
@@ -44,10 +44,14 @@ export default cB('radio', `
   cB('radio-input', `
     position: absolute;
     border: 0;
-    width: 0;
-    height: 0;
+    border-radius: inherit;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
     opacity: 0;
-    margin: 0;
+    z-index: 1;
+    cursor: pointer;
   `),
   cE('dot', `
     position: absolute;


### PR DESCRIPTION
Commit 319b0adf2 changed the radio input from a full-size transparent overlay (`left/right/top/bottom: 0`) to a collapsed element (`width: 0; height: 0`) to fix `n-popover`/`n-tooltip` usage inside radio labels (#6832).

However, this broke accessibility:
- Zero-dimension inputs are not interactable by automated testing tools (Selenium, Capybara) or assistive technologies that rely on hit testing
- The standard accessible pattern for hidden inputs uses full-size overlay with `opacity: 0`

This commit restores the accessible overlay sizing and adds `pointer-events: none` to prevent the input from intercepting clicks meant for nested tooltips/popovers, preserving the #6832 fix.

The parent `<label>` element still handles click-to-toggle, keyboard focus is unaffected by `pointer-events`, and screen readers can find the properly-sized input element.

### Before (broken, from 319b0adf2):
```css
.n-radio-input {
  position: absolute;
  border: 0;
  width: 0;
  height: 0;
  opacity: 0;
  margin: 0;
}
```

### After (this PR):
```css
.n-radio-input {
  position: absolute;
  border: 0;
  border-radius: inherit;
  left: 0;
  right: 0;
  top: 0;
  bottom: 0;
  opacity: 0;
  z-index: 1;
  cursor: pointer;
  pointer-events: none;
}
```

Closes #4631