### PR TITLE
fix(mention): add null guard to getInputEl to prevent crash on unmount

### DIFF
--- a/src/mention/src/Mention.tsx
+++ b/src/mention/src/Mention.tsx
@@ -231,14 +231,16 @@ export default defineComponent({
       nTriggerFormChange()
       uncontrolledValueRef.value = value
     }
-    function getInputEl(): HTMLInputElement | HTMLTextAreaElement {
+    function getInputEl(): HTMLInputElement | HTMLTextAreaElement | null {
+      if (!inputInstRef.value)
+        return null
       return props.type === 'text'
-        ? inputInstRef.value!.inputElRef!
-        : inputInstRef.value!.textareaElRef!
+        ? inputInstRef.value.inputElRef
+        : inputInstRef.value.textareaElRef
     }
     function deriveShowMenu(): void {
       const inputEl = getInputEl()
-      if (document.activeElement !== inputEl) {
+      if (!inputEl || document.activeElement !== inputEl) {
         doUpdateShowMenu(false)
         return
       }
@@ -275,6 +277,8 @@ export default defineComponent({
       if (!cursorAnchor)
         return
       const inputEl = getInputEl()
+      if (!inputEl)
+        return
       const cursorPos: {
         left: number
         top: number
@@ -385,6 +389,8 @@ export default defineComponent({
         rawNode: { value = '' }
       } = tmNode
       const inputEl = getInputEl()
+      if (!inputEl)
+        return
       const inputValue = inputEl.value
       const { separator } = props
       const nextEndPart = inputValue.slice(cachedPartialPatternEnd)


### PR DESCRIPTION
## Summary
- `getInputEl()` in the Mention component uses non-null assertions (`!`) on `inputInstRef.value` and its element refs (`inputElRef`/`textareaElRef`), causing a `TypeError: Cannot read properties of null (reading 'textareaElRef')` when called after the component has been unmounted.
- This occurs because `syncAfterCursorMove()` uses `setTimeout(..., 0)` to defer calls to `deriveShowMenu()` and `syncCursor()`. If the Mention component is conditionally rendered (e.g., via `v-if`) and gets destroyed between a focus event and the deferred callback, `inputInstRef.value` is `null` when the timeout fires.
- Added null guards in `getInputEl()`, `deriveShowMenu()`, `syncCursor()`, and `handleSelect()` to safely bail out when refs are unavailable, consistent with how the component already handles null refs elsewhere (e.g., `focus()` and `blur()` use optional chaining on `inputInstRef.value`).

## Test plan
- Conditionally render `<n-mention>` with `v-if` that toggles based on async data loading
- Focus the mention input, then trigger the condition to unmount it within the same tick
- Verify no TypeError is thrown from the deferred `syncAfterCursorMove` callback