### PR TITLE
fix(data-table): ensure `theme-overrides` prop in `n-data-table` inherits theme variables for `Checkbox` and `Radio` components

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -36,6 +36,7 @@
 - Fix `n-marquee` component Non-function value encountered for default slot warning.
 - Fix `n-data-table`'s empty slot is not shown in a `display: flex` container.
 - Fix `n-data-table` missing header scrollbar in `n-data-table` when in empty state with `max-height` or `flex-height`, closes [#7479](https://github.com/tusen-ai/naive-ui/pull/7479).
+- Fix `n-data-table`'s `theme-overrides` prop does not inherit theme variables for `Checkbox` and `Radio`.
 
 ## 2.43.2
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -36,6 +36,7 @@
 - 修复 `n-marquee` 组件 Non-function value encountered for default slot 警告
 - 修复 `n-data-table` 的 empty 状态在 `display: flex` 的容器中不展示
 - 修复 `n-data-table` 的在 empty 状态下，配合 `max-height` 或者 `flex-height`，header 部分没有滚动条，关闭 [#7479](https://github.com/tusen-ai/naive-ui/pull/7479)
+- 修复 `n-data-table` 的 `theme-overrides` 属性中的 `Checkbox` 和 `Radio` 的样式没有继承主题变量
 
 ## 2.43.2
 

--- a/src/data-table/src/TableParts/BodyCheckbox.tsx
+++ b/src/data-table/src/TableParts/BodyCheckbox.tsx
@@ -24,14 +24,18 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { mergedCheckedRowKeySetRef, mergedInderminateRowKeySetRef } = inject(
-      dataTableInjectionKey
-    )!
+    const {
+      mergedCheckedRowKeySetRef,
+      mergedInderminateRowKeySetRef,
+      mergedThemeRef
+    } = inject(dataTableInjectionKey)!
     return () => {
       const { rowKey } = props
       return (
         <NCheckbox
           privateInsideTable
+          theme={mergedThemeRef.value.peers.Checkbox}
+          themeOverrides={mergedThemeRef.value.peerOverrides.Checkbox}
           disabled={props.disabled}
           indeterminate={mergedInderminateRowKeySetRef.value.has(rowKey)}
           checked={mergedCheckedRowKeySetRef.value.has(rowKey)}

--- a/src/data-table/src/TableParts/BodyRadio.tsx
+++ b/src/data-table/src/TableParts/BodyRadio.tsx
@@ -22,7 +22,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { mergedCheckedRowKeySetRef, componentId } = inject(
+    const { mergedCheckedRowKeySetRef, componentId, mergedThemeRef } = inject(
       dataTableInjectionKey
     )!
     return () => {
@@ -30,6 +30,8 @@ export default defineComponent({
       return (
         <NRadio
           name={componentId}
+          theme={mergedThemeRef.value.peers.Radio}
+          themeOverrides={mergedThemeRef.value.peerOverrides.Radio}
           disabled={props.disabled}
           checked={mergedCheckedRowKeySetRef.value.has(rowKey)}
           onUpdateChecked={props.onUpdateChecked}

--- a/src/data-table/src/TableParts/Header.tsx
+++ b/src/data-table/src/TableParts/Header.tsx
@@ -235,6 +235,8 @@ export default defineComponent({
                 <NCheckbox
                   key={currentPage}
                   privateInsideTable
+                  theme={mergedTheme.peers.Checkbox}
+                  themeOverrides={mergedTheme.peerOverrides.Checkbox}
                   checked={allRowsChecked}
                   indeterminate={someRowsChecked}
                   disabled={headerCheckboxDisabled}

--- a/src/data-table/src/TableParts/SelectionMenu.tsx
+++ b/src/data-table/src/TableParts/SelectionMenu.tsx
@@ -89,9 +89,9 @@ export default defineComponent({
   },
   setup(props) {
     const {
-      props: dataTableProps,
       localeRef,
       checkOptionsRef,
+      mergedThemeRef,
       rawPaginatedDataRef,
       doCheckAll,
       doUncheckAll
@@ -111,8 +111,8 @@ export default defineComponent({
       const { clsPrefix } = props
       return (
         <NDropdown
-          theme={dataTableProps.theme?.peers?.Dropdown}
-          themeOverrides={dataTableProps.themeOverrides?.peers?.Dropdown}
+          theme={mergedThemeRef.value.peers.Dropdown}
+          themeOverrides={mergedThemeRef.value.peerOverrides.Dropdown}
           options={optionsRef.value}
           onSelect={handleSelectRef.value}
         >


### PR DESCRIPTION
closes #7516 