### PR TITLE
fix(input-otp): support multi-character input for browser extension autofill

### DIFF
--- a/src/input-otp/src/InputOtp.tsx
+++ b/src/input-otp/src/InputOtp.tsx
@@ -306,7 +306,39 @@ export default defineComponent({
       const currentValue = justifyValue(mergedValueRef.value)
       const currentValueAtIndex = currentValue[index]
       const diff = value.replace(currentValueAtIndex, '')
-      const char = diff[diff.length - 1] || value[value.length - 1] || ''
+      const text = diff || value
+
+      // Multi-character input (e.g. browser extension autofill)
+      if (text.length > 1) {
+        let startIndex = index
+        const allowInput = props.allowInput
+        let pasteApplied = false
+        let appendedText = ''
+        for (let i = 0; i < text.length; ++i) {
+          if (allowInput && !allowInput(text[i], startIndex, currentValue)) {
+            continue
+          }
+          pasteApplied = true
+          currentValue[startIndex] = text[i]
+          appendedText += text[i]
+          startIndex++
+          if (startIndex >= currentValue.length) {
+            break
+          }
+        }
+        if (pasteApplied) {
+          focusOnChar(Math.min(startIndex, props.length - 1))
+          doUpdateValue(currentValue, {
+            diff: appendedText,
+            index: startIndex,
+            source: 'input'
+          })
+        }
+        return
+      }
+
+      // Single character — original behavior
+      const char = text[text.length - 1] || ''
       const allowInput = props.allowInput
       if (allowInput && !allowInput(char, index, currentValue)) {
         return

--- a/src/input-otp/tests/InputOtp.spec.tsx
+++ b/src/input-otp/tests/InputOtp.spec.tsx
@@ -1,8 +1,90 @@
 import { mount } from '@vue/test-utils'
 import { NInputOtp } from '../index'
 
-describe('n-input-number', () => {
+describe('n-input-otp', () => {
   it('should work with import on demand', () => {
     mount(NInputOtp)
+  })
+
+  describe('handleInput multi-character (autofill)', () => {
+    it('should distribute multi-char input across fields', async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = mount(NInputOtp, {
+        props: {
+          length: 6,
+          onUpdateValue
+        }
+      })
+      const inputs = wrapper.findAll('input')
+      // Simulate autofill setting full value on first input
+      await inputs[0].setValue('123456')
+      expect(onUpdateValue).toHaveBeenCalled()
+      const value = onUpdateValue.mock.calls[0][0]
+      expect(value).toEqual(['1', '2', '3', '4', '5', '6'])
+    })
+
+    it('should distribute multi-char input from middle index', async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = mount(NInputOtp, {
+        props: {
+          length: 6,
+          defaultValue: ['1', '2', '3', '', '', ''],
+          onUpdateValue
+        }
+      })
+      const inputs = wrapper.findAll('input')
+      await inputs[3].setValue('456')
+      expect(onUpdateValue).toHaveBeenCalled()
+      const value = onUpdateValue.mock.calls[0][0]
+      expect(value).toEqual(['1', '2', '3', '4', '5', '6'])
+    })
+
+    it('should respect allowInput for multi-char input', async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = mount(NInputOtp, {
+        props: {
+          length: 6,
+          allowInput: (char: string) => /\d/.test(char),
+          onUpdateValue
+        }
+      })
+      const inputs = wrapper.findAll('input')
+      await inputs[0].setValue('12a456')
+      expect(onUpdateValue).toHaveBeenCalled()
+      const value = onUpdateValue.mock.calls[0][0]
+      // 'a' should be skipped
+      expect(value).toEqual(['1', '2', '4', '5', '6', ''])
+    })
+
+    it('should stop at length boundary', async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = mount(NInputOtp, {
+        props: {
+          length: 4,
+          onUpdateValue
+        }
+      })
+      const inputs = wrapper.findAll('input')
+      await inputs[0].setValue('123456')
+      expect(onUpdateValue).toHaveBeenCalled()
+      const value = onUpdateValue.mock.calls[0][0]
+      expect(value).toEqual(['1', '2', '3', '4'])
+    })
+
+    it('should handle single-char input unchanged', async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = mount(NInputOtp, {
+        props: {
+          length: 6,
+          defaultValue: ['1', '2', '', '', '', ''],
+          onUpdateValue
+        }
+      })
+      const inputs = wrapper.findAll('input')
+      await inputs[2].setValue('5')
+      expect(onUpdateValue).toHaveBeenCalled()
+      const value = onUpdateValue.mock.calls[0][0]
+      expect(value[2]).toBe('5')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Browser extension autofill (e.g. Authenticator) sets the full OTP value on a single `<input>` element, but `handleInput` only extracted the last character
- Now multi-character input is distributed across fields using the same logic as `handlePaste`
- Single-character input path is unchanged

## Test plan
- [x] Multi-char input distributes across all fields
- [x] Multi-char input from a middle index fills remaining fields
- [x] `allowInput` filtering respected for multi-char input
- [x] Input stops at length boundary
- [x] Single-char input behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)