### PR TITLE
Fix  modal usecontent scrollable warning

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - `n-config-provider` fixes `size` prop doesn't work for some components.
+- Fix `n-card` internal scrollbar emits Non-function value encountered for default slot warning when `content-scrollable` is enabled, closes [#7556](https://github.com/tusen-ai/naive-ui/issues/7556).
 
 ## 2.44.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - 修复 `n-config-provider` 部分组件的 `size` 全局配置不生效
+- 修复 `n-card` 开启 `content-scrollable` 时内部 scrollbar 触发 Non-function value encountered for default slot 的vue警告，关闭 [#7556](https://github.com/tusen-ai/naive-ui/issues/7556)
 
 ## 2.44.0
 

--- a/src/card/src/Card.tsx
+++ b/src/card/src/Card.tsx
@@ -318,7 +318,7 @@ export default defineComponent({
                 ]}
                 contentStyle={this.contentStyle}
               >
-                {mergedChildren}
+                {{ default: () => mergedChildren }}
               </NScrollbar>
             ) : (
               <div


### PR DESCRIPTION
本人首次向本仓库提交 PR，若有不当之处请指正。

closes #7556 
## 问题
当 n-card 开启 content-scrollable 时，内部会对内容包一层 NScrollbar。原先在 JSX 中使用 {mergedChildren} 作为子节点，导致默认插槽以非函数形式传入，Vue 在开发模式下会报 Non-function value encountered for default slot。

## 改动
改为使用函数形式的默认插槽：{{ default: () => mergedChildren }}

## 关联
issue地址:  #7556 