### PR TITLE
fix(spin): preserve size-based strokeWidth defaults in NSpin

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `n-color-picker` passed `style` and `click` (onClick) not applied to trigger, closes [#7528](https://github.com/tusen-ai/naive-ui/issues/7528).
+- fix(spin): preserve size-based strokeWidth defaults in NSpin, closes [#8061](https://github.com/tusen-ai/naive-ui/issues/8061)
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - 修复 `n-color-picker` 传入的 style、click 事件不生效，关闭 [#7528](https://github.com/tusen-ai/naive-ui/issues/7528)
+- fix(spin): preserve size-based strokeWidth defaults in NSpin, closes [#8061](https://github.com/tusen-ai/naive-ui/issues/8061)
 
 ## 2.44.1
 

--- a/src/spin/src/Spin.tsx
+++ b/src/spin/src/Spin.tsx
@@ -43,7 +43,8 @@ export const spinProps = {
     default: undefined
   },
   delay: Number,
-  ...exposedLoadingProps
+  ...exposedLoadingProps,
+  strokeWidth: Number
 }
 
 export type SpinProps = ExtractPublicPropTypes<typeof spinProps>


### PR DESCRIPTION
Fixes #8061

  ## Summary

  `NSpin` currently inherits `strokeWidth` from `exposedLoadingProps`, where it has a default value of `28`.

  Because of that, `strokeWidth` is always defined and `NSpin` no longer uses its internal size-based mapping:

  - `small => 20`
  - `medium => 18`
  - `large => 16`

  This makes the default spinner visibly thicker than before.

  ## Fix

  Re-declare `strokeWidth` in `spinProps` after `...exposedLoadingProps`:

  ```ts
  ...exposedLoadingProps,
  strokeWidth: Number

  This keeps the prop available, but removes the inherited default at the NSpin level, so:

  - explicit strokeWidth still works
  - default NSpin behavior goes back to the size-based mapping