### PR TITLE
fix(log): add missing props version header

### DIFF
--- a/src/log/demos/enUS/index.demo-entry.md
+++ b/src/log/demos/enUS/index.demo-entry.md
@@ -55,7 +55,7 @@ auto-bottom.vue
 
 ### Log Props
 
-| Name | Type | Default | Description |
+| Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
 | font-size | `number` | `14` | Font size. |
 | hljs | `Object` | `undefined` | If you want to set `hljs` locally, pass it using this prop. |

--- a/src/log/demos/zhCN/index.demo-entry.md
+++ b/src/log/demos/zhCN/index.demo-entry.md
@@ -55,7 +55,7 @@ auto-bottom.vue
 
 ### Log Props
 
-| 名称 | 类型 | 默认值 | 说明 |
+| 名称 | 类型 | 默认值 | 说明 | 版本 |
 | --- | --- | --- | --- | --- |
 | font-size | `number` | `14` | 文字大小 |
 | hljs | `Object` | `undefined` | 如果你想局部设定 `hljs` ，可以通过这个属性传给组件 |


### PR DESCRIPTION
## Summary

- add the missing Version column header to Log props tables in English and Chinese docs
- keep the table shape aligned with the existing five-column separator and rows

## Root cause

The Log props markdown tables had five data columns but only four header cells. The web-types table parser indexes header cells for every row cell, so the extra version column produced an undefined header and triggered `Failed to build table info` during post-build.

## Validation

- `pnpm exec eslint src/log/demos/enUS/index.demo-entry.md src/log/demos/zhCN/index.demo-entry.md`
- `pnpm exec tsx scripts/post-build/gen-web-types.ts`
