### PR TITLE
docs: fix install command - use dependencies instead of devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ What's more, ..., no more. Just enjoy it.
 Use npm to install.
 
 ```bash
-npm i -D naive-ui
+npm i naive-ui
 ```
 
 ### Fonts
 
 ```bash
-npm i -D vfonts
+npm i vfonts
 ```
 
 ### Icons


### PR DESCRIPTION
## Description

Fix the installation command in README.md to use regular dependencies instead of devDependencies.

### Problem
The current installation command uses `-D` flag which installs naive-ui as a devDependency:
```bash
npm i -D naive-ui
```

However, naive-ui is a Vue component library used at runtime and should be installed as a regular dependency.

### Solution
Remove the `-D` flag from the installation commands:
- `npm i -D naive-ui` → `npm i naive-ui`
- `npm i -D vfonts` → `npm i vfonts`

### Related Issue
Fixes #8074