### PR TITLE
fix(datatable): allow recursive nesting in TableColumnGroup children type

### DIFF
--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -268,7 +268,7 @@ export type TableColumnGroup<T = InternalRowData> = {
   title?: TableColumnGroupTitle
   type?: never
   key: ColumnKey
-  children: Array<TableBaseColumn<T>>
+  children: Array<TableColumn<T>>
 
   // to suppress type error in table header
   resizable?: boolean


### PR DESCRIPTION
## Description

Fixes #7489

The `children` field in `TableColumnGroup` currently has the type `Array<TableBaseColumn<T>>`, which limits column group nesting to exactly 2 levels. 

Changed to `Array<TableColumn<T>>` to support unlimited recursive nesting, since `TableColumn<T>` is the union type that includes `TableColumnGroup<T>` itself.

### Before
```ts
children: Array<TableBaseColumn<T>>  // max 2 levels
```

### After  
```ts
children: Array<TableColumn<T>>  // unlimited nesting
```

This is a purely type-level change with no runtime impact. TypeScript handles recursive type references in type aliases correctly.