### PR TITLE
fix(date-picker): prevent double update:value emission on datetime clear

### DIFF
--- a/src/date-picker/src/panel/use-calendar.ts
+++ b/src/date-picker/src/panel/use-calendar.ts
@@ -297,7 +297,6 @@ function useCalendar(
     panelCommon.doUpdateValue(null, true)
     dateInputValueRef.value = ''
     panelCommon.doClose(true)
-    panelCommon.handleClearClick()
   }
   function handleNowClick(): void {
     panelCommon.doUpdateValue(getTime(sanitizeValue(Date.now())), true)


### PR DESCRIPTION
## Problem

When `NDatePicker` has `type="datetime"` and `clearable` enabled, clicking the panel's **Clear** button emits `update:value` **twice** with `null` back-to-back in the same tick. All other panel types (`date`, `month`, `year`, `daterange`, etc.) emit it only once.

This causes any side effect wired to `@update:value` (API request, toast, validator, etc.) to run twice per clear.

Fixes #8070

## Root Cause

In `src/date-picker/src/panel/use-calendar.ts`, `clearSelectedDateTime()` calls:

```typescript
function clearSelectedDateTime(): void {
    panelCommon.doUpdateValue(null, true)  // 1st emission
    dateInputValueRef.value = ''
    panelCommon.doClose(true)
    panelCommon.handleClearClick()  // calls doUpdateValue(null, true) again -> 2nd emission
}
```

`handleClearClick()` internally calls `doUpdateValue(null, true)` again, causing the double emission.

## Fix

Remove the redundant `panelCommon.handleClearClick()` call since `clearSelectedDateTime()` already performs the same operations (`doUpdateValue` + `doClose`) directly.

## Comparison

Other panel types (date, month, year) use `handleClearClick` directly as their clear handler. The datetime panel has a custom `clearSelectedDateTime` that additionally clears `dateInputValueRef`, which is why it calls `doUpdateValue`/`doClose` separately — but then redundantly calls `handleClearClick()` as well.