### PR TITLE
fix(input): update model value during IME composition

### DIFF
--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -510,8 +510,35 @@ export default defineComponent({
         }
       }
       syncSource = targetValue
-      if (isComposingRef.value)
+      if (isComposingRef.value) {
+        // Update model during composition to keep it in sync with visible input
+        // Skip validation, cursor control, and forceUpdate to avoid interfering with IME
+        if (!props.pair) {
+          if (event === 'input') {
+            doUpdateValue(targetValue, { source: index })
+          }
+          else {
+            doChange(targetValue, { source: index })
+          }
+        }
+        else {
+          let { value } = mergedValueRef
+          if (!Array.isArray(value)) {
+            value = ['', '']
+          }
+          else {
+            value = [value[0], value[1]]
+          }
+          value[index] = targetValue
+          if (event === 'input') {
+            doUpdateValue(value, { source: index })
+          }
+          else {
+            doChange(value, { source: index })
+          }
+        }
         return
+      }
       focusedInputCursorControl.recordCursor()
       const isIncomingValueValid = allowInput(targetValue)
       if (isIncomingValueValid) {


### PR DESCRIPTION
## Problem

When typing with IME (Korean, Chinese, Japanese), the model value () is not updated during composition. This causes the model to fall out of sync with the visible input text.

**Reported in**: #8079

## Root Cause

In , the  function returns early when  is true (line 513-514):

```ts
syncSource = targetValue
if (isComposingRef.value)
  return  // model update is skipped for the entire composition window
```

This means during IME composition,  is never called, so the model value stays stale until  fires.

## Fix

Update the model value during composition while still skipping validation (), cursor control, and  to avoid interfering with IME behavior:

```ts
syncSource = targetValue
if (isComposingRef.value) {
  // Update model during composition to keep it in sync with visible input
  if (!props.pair) {
    if (event === 'input') {
      doUpdateValue(targetValue, { source: index })
    } else {
      doChange(targetValue, { source: index })
    }
  } else {
    // ... pair handling
  }
  return  // Skip validation, cursor control, and forceUpdate
}
```

## Testing

- Tested with Korean IME (2-Set Korean)
- Model value now reflects visible input during composition
- No interference with IME behavior (cursor position, composition window)