### PR TITLE
fix(date-picker): emit update:value once when clearing datetime picker

### DIFF
--- a/src/date-picker/src/panel/use-calendar.ts
+++ b/src/date-picker/src/panel/use-calendar.ts
@@ -294,9 +294,7 @@ function useCalendar(
     }
   }
   function clearSelectedDateTime(): void {
-    panelCommon.doUpdateValue(null, true)
     dateInputValueRef.value = ''
-    panelCommon.doClose(true)
     panelCommon.handleClearClick()
   }
   function handleNowClick(): void {


### PR DESCRIPTION
Fixes #8070

## Problem
When NDatePicker has type="datetime" and clearable enabled, clicking the panel Clear button emits update:value twice with null back-to-back.

## Root Cause
clearSelectedDateTime calls doUpdateValue(null, true) and then delegates to handleClearClick which calls doUpdateValue(null, true) again.

## Fix
Remove the redundant doUpdateValue and doClose calls from clearSelectedDateTime, letting handleClearClick be the single source of truth.