### PR TITLE
docs(Anchor): remove affix properties from n-anchor in ignore-gap and…

### DIFF
--- a/src/anchor/demos/enUS/ignore-gap.demo.vue
+++ b/src/anchor/demos/enUS/ignore-gap.demo.vue
@@ -13,13 +13,7 @@
       </n-col>
       <n-col :span="6">
         <div style="width: 160px">
-          <n-anchor
-            affix
-            :trigger-top="24"
-            :top="88"
-            style="z-index: 1"
-            ignore-gap
-          >
+          <n-anchor style="z-index: 1" ignore-gap>
             <n-anchor-link title="Demos" href="#Demos">
               <n-anchor-link title="Basic" href="#basic.vue" />
               <n-anchor-link title="Ignore-Gap" href="#ignore-gap.vue" />
@@ -32,7 +26,7 @@
       </n-col>
       <n-col :span="6">
         <div style="width: 160px">
-          <n-anchor affix :trigger-top="24" :top="88" style="z-index: 1">
+          <n-anchor style="z-index: 1">
             <n-anchor-link title="Demos" href="#Demos">
               <n-anchor-link title="Basic" href="#basic.vue" />
               <n-anchor-link title="Ignore-Gap" href="#ignore-gap.vue" />

--- a/src/anchor/demos/enUS/scrollto.demo.vue
+++ b/src/anchor/demos/enUS/scrollto.demo.vue
@@ -14,14 +14,7 @@ function scrollTo(href: string) {
 
 <template>
   <div style="height: 200px; padding-left: 200px">
-    <n-anchor
-      ref="anchorRef"
-      affix
-      :trigger-top="24"
-      :top="88"
-      :bound="24"
-      style="z-index: 1"
-    >
+    <n-anchor ref="anchorRef" :bound="24" style="z-index: 1">
       <n-anchor-link title="Demos" href="#Demos">
         <n-anchor-link title="Basic" href="#basic.vue" />
         <n-anchor-link title="Ignore-Gap" href="#ignore-gap.vue" />

--- a/src/anchor/demos/zhCN/ignore-gap.demo.vue
+++ b/src/anchor/demos/zhCN/ignore-gap.demo.vue
@@ -13,13 +13,7 @@
       </n-col>
       <n-col :span="6">
         <div style="width: 160px; float: right">
-          <n-anchor
-            affix
-            :trigger-top="24"
-            :top="88"
-            style="z-index: 1"
-            ignore-gap
-          >
+          <n-anchor style="z-index: 1" ignore-gap>
             <n-anchor-link title="演示" href="#演示">
               <n-anchor-link title="忽略间隔" href="#ignore-gap.vue" />
               <n-anchor-link title="固定" href="#affix.vue" />
@@ -31,7 +25,7 @@
       </n-col>
       <n-col :span="6">
         <div style="width: 160px; float: right">
-          <n-anchor affix :trigger-top="24" :top="88" style="z-index: 1">
+          <n-anchor style="z-index: 1">
             <n-anchor-link title="演示" href="#演示">
               <n-anchor-link title="忽略间隔" href="#ignore-gap.vue" />
               <n-anchor-link title="固定" href="#affix.vue" />

--- a/src/anchor/demos/zhCN/scrollto.demo.vue
+++ b/src/anchor/demos/zhCN/scrollto.demo.vue
@@ -14,14 +14,7 @@ function scrollTo(href: string) {
 
 <template>
   <div style="height: 200px; padding-left: 200px">
-    <n-anchor
-      ref="anchorRef"
-      affix
-      :trigger-top="24"
-      :top="88"
-      :bound="24"
-      style="z-index: 1"
-    >
+    <n-anchor ref="anchorRef" :bound="24" style="z-index: 1">
       <n-anchor-link title="演示" href="#演示">
         <n-anchor-link title="基础用法" href="#basic.vue" />
         <n-anchor-link title="忽略间隔" href="#ignore-gap.vue" />

--- a/src/log/demos/enUS/index.demo-entry.md
+++ b/src/log/demos/enUS/index.demo-entry.md
@@ -56,7 +56,7 @@ auto-bottom.vue
 ### Log Props
 
 | Name | Type | Default | Description |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- | --- |
 | font-size | `number` | `14` | Font size. |
 | hljs | `Object` | `undefined` | If you want to set `hljs` locally, pass it using this prop. |
 | language | `string` | `undefined` | The language of the log in `highlightjs`. |

--- a/src/log/demos/zhCN/index.demo-entry.md
+++ b/src/log/demos/zhCN/index.demo-entry.md
@@ -56,7 +56,7 @@ auto-bottom.vue
 ### Log Props
 
 | 名称 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- | --- |
 | font-size | `number` | `14` | 文字大小 |
 | hljs | `Object` | `undefined` | 如果你想局部设定 `hljs` ，可以通过这个属性传给组件 |
 | language | `string` | `undefined` | 日志在 `highlightjs` 中的语言 |


### PR DESCRIPTION
移除 ignore-gap 与 scrollto demo 中的 affix 相关属性，避免 hash 刷新后误固定；仅保留 “固定” demo 的固定行为。

Fixes #8097