### PR TITLE
fix(tabs): keep bar transition after nav resize

### DIFF
--- a/src/tabs/src/Tabs.tsx
+++ b/src/tabs/src/Tabs.tsx
@@ -455,7 +455,7 @@ export default defineComponent({
       const { value: barEl } = barElRef
       if (!barEl)
         return
-      if (!firstTimeUpdatePosition)
+      if (firstTimeUpdatePosition)
         firstTimeUpdatePosition = false
       const disableTransitionClassName = 'transition-disabled'
       barEl.classList.add(disableTransitionClassName)

--- a/src/tabs/tests/Tabs.spec.tsx
+++ b/src/tabs/tests/Tabs.spec.tsx
@@ -354,6 +354,48 @@ describe('n-tabs', () => {
     expect(wrapper.find('.n-tabs-nav__suffix').text()).toBe('test-suffix')
   })
 
+  it('should only disable bar transition for the first nav resize', async () => {
+    const wrapper = mount(NTabs, {
+      props: {
+        defaultValue: '1'
+      },
+      slots: {
+        default: () => [
+          h(NTabPane, {
+            tab: '1',
+            name: '1'
+          }),
+          h(NTabPane, {
+            tab: '2',
+            name: '2'
+          })
+        ]
+      }
+    })
+    const barEl = wrapper.find('.n-tabs-bar').element as HTMLElement
+    const addSpy = vi.spyOn(barEl.classList, 'add')
+
+    ;(wrapper.vm as any).handleNavResize({
+      contentRect: {
+        width: 100,
+        height: 20
+      }
+    })
+    await sleep(80)
+    ;(wrapper.vm as any).handleNavResize({
+      contentRect: {
+        width: 120,
+        height: 20
+      }
+    })
+
+    expect(
+      addSpy.mock.calls.filter(([className]) => {
+        return className === 'transition-disabled'
+      })
+    ).toHaveLength(1)
+  })
+
   it('should work with `tab-class` prop', () => {
     const wrapper = mount(NTabs, {
       props: {


### PR DESCRIPTION
﻿尝试修了一下 #7406。

suffix 内容宽度变化会触发 nav resize。第一次计算 bar 位置时会通过 `firstTimeUpdatePosition` 临时关掉 transition，但这个标记后续没有更新，导致后面切 tab 时 transition 还是会被关掉。
