### PR TITLE
chore: upgrade to TypeScript 6 and adapt configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "rimraf": "^6.0.1",
     "superagent": "^10.2.2",
     "tsx": "^4.20.3",
-    "typescript": "^5.9.2",
+    "typescript": "^6.0.3",
     "vfonts": "^0.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.5",

--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -4,8 +4,8 @@
     "target": "ES6",
     "jsx": "react",
     "rootDir": ".",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "../lib"
   },
   "exclude": ["./**/*.spec.*"]

--- a/src/tsconfig.demo.json
+++ b/src/tsconfig.demo.json
@@ -5,6 +5,7 @@
     "composite": false,
     "target": "ES6",
     "rootDirs": [".", "../generic"],
+    "rootDir": "..",
     "module": "es6",
     "noEmit": true
   },

--- a/themes/tusimple/tsconfig.cjs.json
+++ b/themes/tusimple/tsconfig.cjs.json
@@ -4,8 +4,8 @@
     "target": "ES6",
     "jsx": "react",
     "rootDir": "./src",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "./lib"
   },
   "references": [{ "path": "../../src/tsconfig.cjs.json" }]


### PR DESCRIPTION
## Summary

Upgrade naive-ui to TypeScript 6.0 and adapt tsconfig settings for deprecated/breaking changes.

## Changes

### Dependency
- `typescript`: `^5.9.2` → `^6.0.3`

### tsconfig adaptations
- **CJS configs** (`src/tsconfig.cjs.json`, `themes/tusimple/tsconfig.cjs.json`):
  - `moduleResolution`: `node` → `nodenext` (deprecated in TS6)
  - `module`: `CommonJS` → `nodenext` (required by TS6 when using `nodenext` resolution)
  - Output remains CJS format (verified)

- **Demo tsconfig** (`src/tsconfig.demo.json`):
  - Added explicit `rootDir: ..` — TS6 no longer infers `rootDir` from source files, and the demo config references files in `../generic/` which are outside the default `rootDir` of `src/`

## Verification

| Check | Result |
|-------|--------|
| `tsc src/tsconfig.esm.json` | ✅ Pass |
| `tsc src/tsconfig.cjs.json` | ✅ Pass |
| `vue-tsc src/tsconfig.demo.json` | ✅ Pass |
| `tsc themes/tusimple/tsconfig.esm.json` | ✅ Pass |
| `tsc themes/tusimple/tsconfig.cjs.json` | ✅ Pass |
| CJS output format verified | ✅ Correct |