### PR TITLE
fix(build): exclude vitest-setup.ts from esm and cjs outputs

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -11,7 +11,8 @@
 
 - Fix `n-color-picker` passed `style` and `click` (onClick) not applied to trigger, closes [#7528](https://github.com/tusen-ai/naive-ui/issues/7528).
 - Fix `n-data-table`'s empty state not vertically centered when height is set, closes [#7546](https://github.com/tusen-ai/naive-ui/issues/7546).
-- fix(spin): preserve size-based strokeWidth defaults in NSpin, closes [#8061](https://github.com/tusen-ai/naive-ui/issues/8061)
+- fix(spin): preserve size-based strokeWidth defaults in NSpin, closes [#8061](https://github.com/tusen-ai/naive-ui/issues/8061).
+- Fix `vitest-setup.ts` being emitted into build outputs.
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -12,6 +12,7 @@
 - 修复 `n-color-picker` 传入的 style、click 事件不生效，关闭 [#7528](https://github.com/tusen-ai/naive-ui/issues/7528)
 - 修复 `n-data-table` 的 empty 状态在设定高度后没有垂直居中显示，关闭 [#7546](https://github.com/tusen-ai/naive-ui/issues/7546)
 - 修复 `n-spin` 未传入 `strokeWidth` 时无法按 `size` 使用内置线宽（被 Loading 的默认值覆盖）的问题，关闭 [#8061](https://github.com/tusen-ai/naive-ui/issues/8061)
+- 修复 `vitest-setup.ts` 被输出到构建产物的问题
 
 ## 2.44.1
 

--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -8,5 +8,5 @@
     "moduleResolution": "nodenext",
     "outDir": "../lib"
   },
-  "exclude": ["./**/*.spec.*"]
+  "exclude": ["./**/*.spec.*", "./vitest-setup.ts"]
 }

--- a/src/tsconfig.esm.json
+++ b/src/tsconfig.esm.json
@@ -7,5 +7,5 @@
     "module": "ES6",
     "outDir": "../es"
   },
-  "exclude": ["./**/*.spec.*"]
+  "exclude": ["./**/*.spec.*", "./vitest-setup.ts"]
 }


### PR DESCRIPTION
## Description

`vitest-setup.ts` is a test-only setup file, but it is currently emitted into both `es/` and `lib/` build outputs because the tsconfig `exclude` only filters `*.spec.*` files.

This PR adds `./vitest-setup.ts` to the exclude list of both ESM and CJS tsconfigs so that test setup code does not leak into published packages.

## Checklist

- [x] `vitest-setup.ts` is excluded from `src/tsconfig.esm.json`
- [x] `vitest-setup.ts` is excluded from `src/tsconfig.cjs.json`
- [x] Verified that `find es lib -name '*vitest-setup*'` returns no files after rebuilding