### PR TITLE
fix(locale): translate weekPlaceholder in the Japanese locale

### DIFF
--- a/src/locales/common/jaJP.ts
+++ b/src/locales/common/jaJP.ts
@@ -42,7 +42,7 @@ const jaJP: NLocale = {
     monthPlaceholder: '月を選択',
     yearPlaceholder: '年を選択',
     quarterPlaceholder: '四半期を選択',
-    weekPlaceholder: 'Select Week',
+    weekPlaceholder: '週を選択',
     startDatePlaceholder: '開始日',
     endDatePlaceholder: '終了日',
     startDatetimePlaceholder: '開始時間',


### PR DESCRIPTION
The Japanese locale leaves `weekPlaceholder` as the English default `Select Week`, while every other placeholder in the same `DatePicker` block is already translated:

- `datePlaceholder: '日付を選択'`
- `monthPlaceholder: '月を選択'`
- `yearPlaceholder: '年を選択'`
- `quarterPlaceholder: '四半期を選択'`

So `<n-date-picker type="week">` under the `jaJP` locale shows an English placeholder while the rest of the picker is Japanese.

`zh-CN` already translates this key (`weekPlaceholder: '选择周'`), so the Japanese entry was simply missed. This sets it to `週を選択`, following the `〜を選択` form used by the sibling placeholders.

The locale snapshot test (`src/locales/index.spec.tsx`) only mounts the `date`/`datetime`/`year`/`month` pickers, so `weekPlaceholder` is not part of any snapshot and the rendered output is unchanged.
