### PR TITLE
fix(dynamic-tags): ignore Enter while IME composition is active

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - fix(spin): preserve size-based strokeWidth defaults in NSpin, closes [#8061](https://github.com/tusen-ai/naive-ui/issues/8061)
 - Fix `n-tabs` bar transition disabled after nav resize, closes [#7406](https://github.com/tusen-ai/naive-ui/issues/7406).
 - Fix `vitest-setup.ts` being emitted into build outputs.
+- Fix `n-dynamic-tags` committing a tag when Enter is pressed to confirm an IME composition.
 
 
 ## 2.44.1

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - 修复 `n-spin` 未传入 `strokeWidth` 时无法按 `size` 使用内置线宽（被 Loading 的默认值覆盖）的问题，关闭 [#8061](https://github.com/tusen-ai/naive-ui/issues/8061)
 - 修复 `n-tabs` 导航尺寸变化后标签栏过渡动画被禁用的问题，关闭 [#7406](https://github.com/tusen-ai/naive-ui/issues/7406)
 - 修复 `vitest-setup.ts` 被输出到构建产物的问题
+- 修复 `n-dynamic-tags` 在输入法合成（IME composition）期间按 Enter 确认候选词时会误提交标签的问题
 
 ## 2.44.1
 

--- a/src/dynamic-tags/src/DynamicTags.tsx
+++ b/src/dynamic-tags/src/DynamicTags.tsx
@@ -161,6 +161,8 @@ export default defineComponent({
       doChange(tags)
     }
     function handleInputKeyDown(e: KeyboardEvent): void {
+      if (inputInstRef.value?.isCompositing)
+        return
       switch (e.key) {
         case 'Enter':
           handleInputConfirm()

--- a/src/dynamic-tags/tests/DynamicTags.spec.ts
+++ b/src/dynamic-tags/tests/DynamicTags.spec.ts
@@ -238,4 +238,29 @@ describe('n-dynamic-tags', () => {
     expect(wrapper.find('.n-button__content').text()).toEqual('添加')
     wrapper.unmount()
   })
+
+  it('should not commit a tag when Enter is pressed during IME composition', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NDynamicTags, {
+      props: {
+        defaultValue: ['教师'],
+        onUpdateValue
+      }
+    })
+    await wrapper.find('.n-button').trigger('click')
+    const input = wrapper.find('input')
+    await input.setValue('程序员')
+    // Pressing Enter to confirm an IME conversion fires keydown while
+    // composition is still active; it must not commit the tag.
+    await input.trigger('compositionstart')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).not.toHaveBeenCalled()
+    expect(wrapper.findAll('.n-tag').length).toBe(1)
+    // After composition ends, Enter commits the tag as usual.
+    await input.trigger('compositionend')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledWith(['教师', '程序员'])
+    expect(wrapper.findAll('.n-tag').length).toBe(2)
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
### Problem

`n-dynamic-tags` commits a tag on the input's `Enter` keydown without checking whether an IME composition is active:

```ts
function handleInputKeyDown(e: KeyboardEvent): void {
  switch (e.key) {
    case 'Enter':
      handleInputConfirm()
  }
}
```

When entering Japanese/Chinese/Korean text, the `Enter` that confirms a conversion candidate can still reach this handler while composition is in progress (the same situation the existing guards in `n-auto-complete` and `n-mention` already handle). `NInput` forwards keydown to consumers unconditionally, so that first Enter, the one meant to pick the candidate, commits a half-finished tag and clears the input. The word the user was actually trying to confirm never becomes a tag.

### Fix

`n-auto-complete` and `n-mention` already skip Enter while composing:

- `auto-complete/src/AutoComplete.tsx`: `case 'Enter': if (!isComposingRef.value) { ... }`
- `mention/src/Mention.tsx`: `if (inputInstRef.value?.isCompositing) return`

`n-dynamic-tags` already keeps an `inputInstRef` to its `NInput`, and `NInput` exposes `isCompositing`, so it can use the same guard:

```ts
function handleInputKeyDown(e: KeyboardEvent): void {
  if (inputInstRef.value?.isCompositing)
    return
  switch (e.key) {
    case 'Enter':
      handleInputConfirm()
  }
}
```

### Test

Added a spec that types a value, presses Enter during composition (no tag expected), then ends composition and presses Enter (tag expected). It fails before this change and passes after.

The full Vitest suite doesn't start on my Windows setup (every spec throws `Received 'file:///vue-jsx-vapor/vdom'` from the `vue-jsx-vapor` plugin before any test is collected), so I reproduced the same compositionstart / keydown / compositionend sequence in an isolated jsdom test to confirm the behavior. CI here will run the added spec.

Changelog added to `CHANGELOG.en-US.md` and `CHANGELOG.zh-CN.md`.
