### PR TITLE
fix(locale): translate weekPlaceholder in the Korean and Traditional Chinese locales

### DIFF
--- a/src/locales/common/koKR.ts
+++ b/src/locales/common/koKR.ts
@@ -42,7 +42,7 @@ const koKR: NLocale = {
     monthPlaceholder: '월 선택',
     yearPlaceholder: '년 선택',
     quarterPlaceholder: '분기 선택',
-    weekPlaceholder: 'Select Week',
+    weekPlaceholder: '주 선택',
     startDatePlaceholder: '시작 날짜',
     endDatePlaceholder: '종료 날짜',
     startDatetimePlaceholder: '시작 날짜 및 시간',

--- a/src/locales/common/zhTW.ts
+++ b/src/locales/common/zhTW.ts
@@ -42,7 +42,7 @@ const zhTW: NLocale = {
     monthPlaceholder: '選擇月份',
     yearPlaceholder: '選擇年份',
     quarterPlaceholder: '選擇季度',
-    weekPlaceholder: 'Select Week',
+    weekPlaceholder: '選擇週',
     startDatePlaceholder: '開始日期',
     endDatePlaceholder: '結束日期',
     startDatetimePlaceholder: '開始日期時間',


### PR DESCRIPTION
#8114 translated `weekPlaceholder` in the Japanese locale, where it had been left as the English fallback `Select Week`. The same untranslated string is still present in several other locales' DatePicker section. This propagates that fix to the two CJK locales:

- `koKR`: `Select Week` to `주 선택`, following the existing `월 선택` / `년 선택` / `분기 선택` pattern.
- `zhTW`: `Select Week` to `選擇週`, the Traditional form of zhCN's `选择周`, matching `選擇月份` / `選擇年份`.

I checked every `weekPlaceholder` in `src/locales/common`. zhCN (`选择周`) and jaJP (`週を選択`, from #8114) were already done, so these two were the remaining CJK locales still showing the English fallback. A number of non-CJK locales also still carry `Select Week`, but I left those for native speakers rather than guess.
