### PR TITLE
fix(space): respect size prop value of 0

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -23,6 +23,7 @@
 - Fix `n-tabs` bar transition disabled after nav resize, closes [#7406](https://github.com/tusen-ai/naive-ui/issues/7406).
 - Fix `vitest-setup.ts` being emitted into build outputs.
 - Fix `n-dynamic-tags` committing a tag when Enter is pressed to confirm an IME composition.
+- Fix `n-space` `size` prop not taking effect when set to `0`, closes [#7530](https://github.com/tusen-ai/naive-ui/issues/7530).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,6 +23,7 @@
 - 修复 `n-tabs` 导航尺寸变化后标签栏过渡动画被禁用的问题，关闭 [#7406](https://github.com/tusen-ai/naive-ui/issues/7406)
 - 修复 `vitest-setup.ts` 被输出到构建产物的问题
 - 修复 `n-dynamic-tags` 在输入法合成（IME composition）期间按 Enter 确认候选词时会误提交标签的问题
+- 修复 `n-space` `size` 属性设置为 `0` 时不生效的问题，关闭 [#7530](https://github.com/tusen-ai/naive-ui/issues/7530)
 
 ## 2.44.1
 

--- a/src/space/src/Space.tsx
+++ b/src/space/src/Space.tsx
@@ -66,7 +66,7 @@ export default defineComponent({
       = useConfig(props)
     const mergedSizeRef = computed<SpaceSize>(() => {
       return (
-        props.size || mergedComponentPropsRef?.value?.Space?.size || 'medium'
+        props.size ?? mergedComponentPropsRef?.value?.Space?.size ?? 'medium'
       )
     })
     const themeRef = useTheme(

--- a/src/space/tests/Space.spec.tsx
+++ b/src/space/tests/Space.spec.tsx
@@ -71,6 +71,21 @@ describe('n-space', () => {
     wrapper.unmount()
   })
 
+  it('render space number size 0', () => {
+    const wrapper = mount(NSpace, {
+      props: {
+        size: 0
+      },
+      slots: {
+        default: () => [<div>1</div>, <div>2</div>]
+      }
+    })
+
+    const childNodes = getChildrenNode(wrapper)
+    expect(childNodes[0].attributes('style')).toContain('margin-right: 0px;')
+    wrapper.unmount()
+  })
+
   it('render vertical space', () => {
     const wrapper = mount({
       render() {


### PR DESCRIPTION
`n-space` resolves its gap with `props.size || ... || 'medium'`, so passing `size={0}` is treated as falsy and falls back to the `medium` gap instead of rendering no gap (it worked in v2.43 as the reporter notes). Using `??` for the `size` fallback keeps an explicit `0` while still defaulting when it's `undefined`. Added a test covering `size={0}`.

Fixes #7530
