### PR TITLE
refactor(test): use cleanup for mock restoration in tests

### DIFF
--- a/src/alert/tests/Alert.spec.ts
+++ b/src/alert/tests/Alert.spec.ts
@@ -131,7 +131,7 @@ describe('n-alert', () => {
     const handleCloseClick = vi.fn()
     const handleOnAfterLeave = vi.fn()
     // https://github.com/vuejs/test-utils/issues/1912#issuecomment-1351054542
-    const rafSpy = vi
+    using _rafSpy = vi
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation((cb: FrameRequestCallback): number => {
         cb(0)
@@ -160,6 +160,5 @@ describe('n-alert', () => {
     expect(handleOnAfterLeave).toHaveBeenCalled()
 
     wrapper.unmount()
-    rafSpy.mockRestore()
   })
 })

--- a/src/breadcrumb/tests/Breadcrumb.spec.ts
+++ b/src/breadcrumb/tests/Breadcrumb.spec.ts
@@ -9,7 +9,7 @@ describe('n-breadcrumb', () => {
   })
 
   it('should raise an error if breadcrumbItem is not inside a BreadCrumb', () => {
-    const mockErrorLogger = vi
+    using mockErrorLogger = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {})
     const wrapper = mount(NBreadcrumbItem)
@@ -113,10 +113,9 @@ describe('n-breadcrumb', () => {
       const currentUrl = 'http://some-domain/path2'
       // https://github.com/jsdom/jsdom/issues/3492
       // https://jestjs.io/blog#known-issues
-      vi.spyOn(
-        useBrowserLocationModule,
-        'useBrowserLocation'
-      ).mockImplementation(() => ref({ href: currentUrl }))
+      using browserLocationSpy = vi
+        .spyOn(useBrowserLocationModule, 'useBrowserLocation')
+        .mockImplementation(() => ref({ href: currentUrl }))
 
       const wrapper = mount(NBreadcrumb, {
         slots: {
@@ -153,6 +152,7 @@ describe('n-breadcrumb', () => {
           .find(`a.n-breadcrumb-item__link[href="${currentUrl}"]`)
           .attributes('aria-current')
       ).toBe('location')
+      expect(browserLocationSpy).toHaveBeenCalled()
       wrapper.unmount()
     })
 

--- a/src/code/tests/Code.spec.tsx
+++ b/src/code/tests/Code.spec.tsx
@@ -8,7 +8,7 @@ hljs.registerLanguage('javascript', javascript)
 
 describe('n-code', () => {
   it('should warn when no hljs is set', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mount(NCode)
     expect(spy).toHaveBeenCalled()
   })

--- a/src/log/tests/Log.spec.tsx
+++ b/src/log/tests/Log.spec.tsx
@@ -5,7 +5,7 @@ import { NLog } from '../index'
 
 describe('n-log', () => {
   it('should warn with language setted & no hljs is set', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mount(NLog)
     expect(spy).not.toHaveBeenCalled()
     mount(NLog, {

--- a/src/modal/tests/Modal.spec.tsx
+++ b/src/modal/tests/Modal.spec.tsx
@@ -61,7 +61,7 @@ describe('n-modal', () => {
     expect(document.querySelector('.n-modal-body-wrapper')).toEqual(null)
     await wrapper.find('button').trigger('click')
     expect(document.querySelector('.n-modal-body-wrapper')).not.toEqual(null)
-    const rafSpy = vi
+    using _rafSpy = vi
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation((cb: FrameRequestCallback): number => {
         cb(0)
@@ -91,7 +91,6 @@ describe('n-modal', () => {
     ).toContain('display: none')
 
     wrapper.unmount()
-    rafSpy.mockRestore()
   })
 
   it('should work with `preset` prop', async () => {

--- a/src/tabs/tests/Tabs.spec.tsx
+++ b/src/tabs/tests/Tabs.spec.tsx
@@ -373,7 +373,7 @@ describe('n-tabs', () => {
       }
     })
     const barEl = wrapper.find('.n-tabs-bar').element as HTMLElement
-    const addSpy = vi.spyOn(barEl.classList, 'add')
+    using addSpy = vi.spyOn(barEl.classList, 'add')
 
     ;(wrapper.vm as any).handleNavResize({
       contentRect: {


### PR DESCRIPTION
Since current Node.js LTS version `24` and TypeScriptform 5.2 support [`using` ](https://github.com/tc39/proposal-explicit-resource-management).
This PR refactors several component tests to use the `using` cleanup pattern for mock restoration, instead of manually calling `mockRestore()` at the end of tests.

Changes:
- src/alert/tests/Alert.spec.ts
- src/breadcrumb/tests/Breadcrumb.spec.ts
- src/code/tests/Code.spec.tsx
- src/log/tests/Log.spec.tsx
- src/modal/tests/Modal.spec.tsx
- src/tabs/tests/Tabs.spec.tsx