### PR TITLE
fix(menu): center collapsed item icons when options contain a group

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -33,6 +33,7 @@
 - Fix `n-space` `size` prop not taking effect when set to `0`, closes [#7530](https://github.com/tusen-ai/naive-ui/issues/7530).
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
+- Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -33,6 +33,7 @@
 - 修复 `n-space` `size` 属性设置为 `0` 时不生效的问题，关闭 [#7530](https://github.com/tusen-ai/naive-ui/issues/7530)
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
+- 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 
 ## 2.44.1
 

--- a/src/menu/src/use-menu-child.ts
+++ b/src/menu/src/use-menu-child.ts
@@ -99,6 +99,9 @@ export function useMenuChild(props: UseMenuChildProps): UseMenuChild {
       NMenuOptionGroup
       && typeof NMenuOptionGroup.paddingLeftRef.value === 'number'
     ) {
+      if (mergedCollapsedRef.value) {
+        return collapsedWidth / 2 - maxIconSizeRef.value / 2
+      }
       return indent / 2 + NMenuOptionGroup.paddingLeftRef.value
     }
     if (NSubmenu && typeof NSubmenu.paddingLeftRef.value === 'number') {

--- a/src/menu/tests/Menu.spec.tsx
+++ b/src/menu/tests/Menu.spec.tsx
@@ -442,6 +442,39 @@ describe('n-menu', () => {
     wrapper.unmount()
   })
 
+  it('should center collapsed item icons when options contain a group', () => {
+    const options = [
+      {
+        label: 'fantasy',
+        key: 'fantasy'
+      },
+      {
+        type: 'group',
+        label: 'song-group',
+        key: 'group',
+        children: [
+          {
+            label: 'mojito',
+            key: 'mojito'
+          }
+        ]
+      }
+    ]
+    const wrapper = mount(NMenu, {
+      props: {
+        options,
+        collapsed: true,
+        renderIcon: () => h(NIcon, null, { default: () => h(HappyOutline) })
+      }
+    })
+    const contents = wrapper.findAll('.n-menu-item-content')
+    // [0] is the root item, [1] is the item nested inside the group
+    const rootPaddingLeft = (contents[0].element as HTMLElement).style.paddingLeft
+    const groupItemPaddingLeft = (contents[1].element as HTMLElement).style.paddingLeft
+    expect(groupItemPaddingLeft).toEqual(rootPaddingLeft)
+    wrapper.unmount()
+  })
+
   it('should work submenu extra', async () => {
     const options: MenuOption[] = [
       {


### PR DESCRIPTION
When `n-menu` is collapsed and the options contain a `type="group"` group, its child items added an extra `indent / 2` on top of the group's padding, so their icons rendered off-center. This centers them with the same formula root items use in collapsed mode.

Fixes #8105
