### PR TITLE
fix(date-picker): respect is-date-disabled in monthrange panel

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -35,6 +35,7 @@
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
+- Fix `n-date-picker` `is-date-disabled` not taking effect for `monthrange`, `quarterrange` and `yearrange`, closes [#7513](https://github.com/tusen-ai/naive-ui/issues/7513), [#8071](https://github.com/tusen-ai/naive-ui/issues/8071).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -35,6 +35,7 @@
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
+- 修复 `n-date-picker` 的 `is-date-disabled` 在 `monthrange`、`quarterrange`、`yearrange` 下不生效的问题，关闭 [#7513](https://github.com/tusen-ai/naive-ui/issues/7513)、[#8071](https://github.com/tusen-ai/naive-ui/issues/8071)
 
 ## 2.44.1
 

--- a/src/date-picker/src/panel/monthrange.tsx
+++ b/src/date-picker/src/panel/monthrange.tsx
@@ -48,9 +48,8 @@ export default defineComponent({
       mergedClsPrefix: string,
       type: 'start' | 'end'
     ): VNode => {
-      const { handleColItemClick } = useCalendarRef
-      // TODO
-      const disabled = false
+      const { mergedIsDateDisabled, handleColItemClick } = useCalendarRef
+      const disabled = mergedIsDateDisabled(item.ts)
       return (
         <div
           data-n-date

--- a/src/date-picker/tests/DatePicker.spec.tsx
+++ b/src/date-picker/tests/DatePicker.spec.tsx
@@ -393,4 +393,31 @@ describe('n-date-picker', () => {
 
     wrapper.unmount()
   })
+
+  it('should work with `is-date-disabled` prop for `monthrange`', async () => {
+    const isDateDisabled = vi.fn(() => true)
+    const wrapper = mount(NDatePicker, {
+      attachTo: document.body,
+      props: {
+        type: 'monthrange',
+        isDateDisabled
+      }
+    })
+
+    await wrapper.find('.n-input__input').trigger('click')
+    const items = Array.from(
+      document.querySelectorAll('.n-date-panel-month-calendar__picker-col-item')
+    )
+    expect(items.length).toBeGreaterThan(0)
+    expect(isDateDisabled).toHaveBeenCalled()
+    expect(
+      items.every(item =>
+        item.classList.contains(
+          'n-date-panel-month-calendar__picker-col-item--disabled'
+        )
+      )
+    ).toBe(true)
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
The `monthrange` panel hard-coded `disabled` to `false` in `renderItem` (left as a `// TODO`), so `is-date-disabled` never took effect for `monthrange`, `quarterrange` or `yearrange`. This computes it from the panel's existing `mergedIsDateDisabled`, the same helper `daterange` already uses. Added a test for `monthrange`.

Fixes #7513, Fixes #8071
