### PR TITLE
fix(data-table): show header when data is empty and ellipsis is set

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -35,6 +35,7 @@
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
+- Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -35,6 +35,7 @@
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
+- 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
 
 ## 2.44.1
 

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -1093,7 +1093,9 @@ export default defineComponent({
                       </tbody>
                     ) : null}
                   </table>
-                  {this.empty && this.xScrollable ? createEmptyNode() : null}
+                  {this.empty && (this.xScrollable || this.showHeader)
+                    ? createEmptyNode()
+                    : null}
                 </>
               )
             }
@@ -1172,7 +1174,7 @@ export default defineComponent({
     )
 
     if (this.empty) {
-      if (this.explicitlyScrollable || this.xScrollable) {
+      if (this.explicitlyScrollable || this.xScrollable || this.showHeader) {
         // empty node is integrated into table node
         return tableNode
       }

--- a/src/data-table/tests/DataTable.spec.tsx
+++ b/src/data-table/tests/DataTable.spec.tsx
@@ -1165,6 +1165,23 @@ describe('props.columns', () => {
     wrapper.unmount()
   })
 
+  it('should show header with empty data when `ellipsis` is set', () => {
+    const columns: DataTableColumns = [
+      {
+        title: 'Name',
+        key: 'name',
+        width: 100,
+        ellipsis: {
+          tooltip: true
+        }
+      }
+    ]
+    const wrapper = mount(() => <NDataTable columns={columns} data={[]} />)
+    expect(wrapper.find('thead').exists()).toBe(true)
+    expect(wrapper.find('thead [data-col-key="name"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
   it('should work with `children` prop', async () => {
     const columns: DataTableColumns = [
       {


### PR DESCRIPTION
Since 2.44, `n-data-table`'s empty branch only renders the header when the table is scrollable (`explicitlyScrollable`/`xScrollable`). Setting `ellipsis` on a column forces `table-layout: fixed`, which makes `xScrollable` false, so an empty table dropped its header entirely. This keeps the header when it's rendered inside the body, restoring the pre-2.44 behavior. Added a test for empty data with `ellipsis`.

Fixes #8118
