### PR TITLE
feat(data-table): add expand-on-click prop 支持点击树形数据行展开/收起

### DIFF
--- a/src/data-table/demos/enUS/index.demo-entry.md
+++ b/src/data-table/demos/enUS/index.demo-entry.md
@@ -81,6 +81,7 @@ export-csv.vue
 | default-expanded-row-keys | `Array<string \| number>` | `[]` | The key value of the expanded tree data by default |  |
 | default-expand-all | `boolean` | `false` | Whether to expand all expandable rows. Can't be used with async expanding data. | 2.30.4 |
 | expanded-row-keys | `Array<string \| number>` | `undefined` | Expanded row keys. |  |
+| expand-on-click | `boolean` | `false` | Whether to expand or collapse tree data rows after click. | 2.44.0 |
 | filter-icon-popover-props | `PopoverProps` | `{ trigger: click, placement: bottom }` | Filter icon's Popover attribute of the button, See [Popover props](popover#Popover-Props) | 2.39.0 |
 | flex-height | `boolean` | `false` | Whether to make table body's height auto fit table area height. Make it enabled will make `table-layout` always set to `'fixed'`. |  |
 | get-csv-cell | `(value: any, row: object, col: DataTableBaseColumn) => string` | `undefined` | Get CSV's cell content. | 2.40.2 |

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -93,6 +93,7 @@ empty-debug.vue
 | default-expanded-row-keys | `Array<string \| number>` | `[]` | 默认展开行的 key 值 |  |
 | default-expand-all | `boolean` | `false` | 是否默认展开全部可展开的行，不可在异步展开行时使用 | 2.30.4 |
 | expanded-row-keys | `Array<string \| number>` | `undefined` | 展开行的 key 值 |  |
+| expand-on-click | `boolean` | `false` | 是否在点击树形数据行后展开或收缩该行 | 2.44.0 |
 | filter-icon-popover-props | `PopoverProps` | `{ trigger: click, placement: bottom }` | 过滤按钮的 Popover 属性，属性参考 [Popover props](popover#Popover-Props) | 2.39.0 |
 | flex-height | `boolean` | `false` | 是否让表格主体的高度自动适应整个表格区域的高度，打开这个选项会让 `table-layout` 始终为 `'fixed'` |  |
 | get-csv-cell | `(value: any, row: object, col: DataTableBaseColumn) => string` | `undefined` | 获取 CSV 的单元格数据 | 2.40.2 |

--- a/src/data-table/src/DataTable.tsx
+++ b/src/data-table/src/DataTable.tsx
@@ -262,6 +262,7 @@ export default defineComponent({
       rowClassNameRef: toRef(props, 'rowClassName'),
       mergedCheckedRowKeySetRef,
       mergedExpandedRowKeysRef,
+      expandOnClickRef: toRef(props, 'expandOnClick'),
       mergedInderminateRowKeySetRef,
       localeRef,
       expandableRef,

--- a/src/data-table/src/TableParts/Body.tsx
+++ b/src/data-table/src/TableParts/Body.tsx
@@ -196,6 +196,7 @@ export default defineComponent({
       summaryPlacementRef,
       treeMateRef,
       scrollbarPropsRef,
+      expandOnClickRef,
       setHeaderScrollLeft,
       doUpdateExpandedRowKeys,
       handleTableBodyScroll,
@@ -501,6 +502,7 @@ export default defineComponent({
       rowProps: rowPropsRef,
       loadingKeySet: loadingKeySetRef,
       expandable: expandableRef,
+      expandOnClick: expandOnClickRef,
       stickyExpandedRows: stickyExpandedRowsRef,
       renderExpandIcon: renderExpandIconRef,
       scrollbarProps: scrollbarPropsRef,
@@ -626,6 +628,7 @@ export default defineComponent({
               handleCheckboxUpdateChecked,
               handleRadioUpdateChecked,
               handleUpdateExpanded,
+              expandOnClick,
               heightForRow,
               minRowHeight,
               virtualScrollX
@@ -1029,9 +1032,31 @@ export default defineComponent({
                 }
               }
 
+              const expandableTmNode
+                = !isSummary && !rowInfo.tmNode.isLeaf ? rowInfo.tmNode : null
               const row = (
                 <tr
                   {...props}
+                  onClick={(e) => {
+                    props?.onClick?.(e)
+                    if (
+                      !expandOnClick
+                      || expandableTmNode === null
+                      || e.defaultPrevented
+                    ) {
+                      return
+                    }
+                    const { target } = e
+                    if (
+                      target instanceof Element
+                      && target.closest(
+                        `.${mergedClsPrefix}-data-table-expand-trigger`
+                      )
+                    ) {
+                      return
+                    }
+                    handleUpdateExpanded(rowKey, expandableTmNode)
+                  }}
                   onMouseenter={(e) => {
                     this.hoverKey = rowKey
                     props?.onMouseenter?.(e)

--- a/src/data-table/src/interface.ts
+++ b/src/data-table/src/interface.ts
@@ -92,6 +92,7 @@ export const dataTableProps = {
   },
   defaultExpandAll: Boolean,
   expandedRowKeys: Array as PropType<RowKey[]>,
+  expandOnClick: Boolean,
   stickyExpandedRows: Boolean,
   virtualScroll: Boolean,
   virtualScrollX: Boolean,
@@ -404,6 +405,7 @@ export interface DataTableInjection {
   localeRef: Ref<NLocale['DataTable']>
   filterMenuCssVarsRef: Ref<CSSProperties>
   mergedExpandedRowKeysRef: Ref<RowKey[]>
+  expandOnClickRef: Ref<boolean>
   rowKeyRef: Ref<CreateRowKey | undefined>
   renderExpandRef: Ref<undefined | RenderExpand>
   summaryRef: Ref<undefined | CreateSummary>

--- a/src/data-table/tests/DataTable.spec.tsx
+++ b/src/data-table/tests/DataTable.spec.tsx
@@ -1229,6 +1229,134 @@ describe('props.columns', () => {
     wrapper.unmount()
   })
 
+  it('should work with `expand-on-click` prop', async () => {
+    interface RowData {
+      name: string
+      index: string
+      children?: RowData[]
+    }
+
+    const columns: DataTableColumns<RowData> = [
+      {
+        title: 'Name',
+        key: 'name',
+        render(rowData) {
+          if (rowData.index === '07') {
+            return h(
+              'button',
+              {
+                class: 'prevent-expand',
+                onClick(e: MouseEvent) {
+                  e.preventDefault()
+                }
+              },
+              rowData.name
+            )
+          }
+          return rowData.name
+        }
+      },
+      {
+        title: 'Index',
+        key: 'index'
+      }
+    ]
+    const data: RowData[] = [
+      {
+        name: '07akioni',
+        index: '07',
+        children: [
+          {
+            name: '08akioni',
+            index: '08'
+          }
+        ]
+      },
+      {
+        name: '11akioni',
+        index: '11'
+      }
+    ]
+    const rowKey = (row: RowData): string => row.index
+    const onUpdateExpandedRowKeys = vi.fn()
+    const onRowClick = vi.fn()
+    const rowProps = vi.fn(() => ({
+      onClick: onRowClick
+    }))
+    const onPreventedRowClick = vi.fn((e: MouseEvent) => {
+      e.preventDefault()
+    })
+
+    let wrapper = mount(() => (
+      <NDataTable
+        columns={columns}
+        data={data}
+        row-key={rowKey}
+        onUpdateExpandedRowKeys={onUpdateExpandedRowKeys}
+      />
+    ))
+    await wrapper.findAll('tbody .n-data-table-tr')[0].trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('tbody .n-data-table-tr').length).toBe(2)
+    expect(onUpdateExpandedRowKeys).not.toHaveBeenCalled()
+    wrapper.unmount()
+
+    wrapper = mount(() => (
+      <NDataTable
+        columns={columns}
+        data={data}
+        row-key={rowKey}
+        rowProps={() => ({ onClick: onPreventedRowClick })}
+        expand-on-click
+        onUpdateExpandedRowKeys={onUpdateExpandedRowKeys}
+      />
+    ))
+    await wrapper.findAll('tbody .n-data-table-tr')[0].trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('tbody .n-data-table-tr').length).toBe(2)
+    expect(onPreventedRowClick).toHaveBeenCalled()
+    expect(onUpdateExpandedRowKeys).not.toHaveBeenCalled()
+    wrapper.unmount()
+
+    wrapper = mount(() => (
+      <NDataTable
+        columns={columns}
+        data={data}
+        row-key={rowKey}
+        rowProps={rowProps}
+        expand-on-click
+        onUpdateExpandedRowKeys={onUpdateExpandedRowKeys}
+      />
+    ))
+    await wrapper.find('.prevent-expand').trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('tbody .n-data-table-tr').length).toBe(2)
+    expect(onUpdateExpandedRowKeys).not.toHaveBeenCalled()
+
+    await wrapper.findAll('tbody .n-data-table-tr')[0].trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('tbody .n-data-table-tr').length).toBe(3)
+    expect(wrapper.text()).toContain('08akioni')
+    expect(onUpdateExpandedRowKeys).toHaveBeenLastCalledWith(['07'])
+    expect(onRowClick).toHaveBeenCalled()
+
+    await wrapper.findAll('tbody .n-data-table-tr')[0].trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('tbody .n-data-table-tr').length).toBe(2)
+    expect(onUpdateExpandedRowKeys).toHaveBeenLastCalledWith([])
+
+    await wrapper.findAll('tbody .n-data-table-tr')[1].trigger('click')
+    await nextTick()
+    expect(onUpdateExpandedRowKeys).toHaveBeenCalledTimes(2)
+
+    await wrapper.find('tbody .n-data-table-expand-trigger').trigger('click')
+    await nextTick()
+    expect(wrapper.findAll('tbody .n-data-table-tr').length).toBe(3)
+    expect(onUpdateExpandedRowKeys).toHaveBeenCalledTimes(3)
+    expect(onUpdateExpandedRowKeys).toHaveBeenLastCalledWith(['07'])
+    wrapper.unmount()
+  })
+
   it('should work with `className` prop', async () => {
     const columns: DataTableColumns = [
       {


### PR DESCRIPTION
# feat(data-table): add expand-on-click prop

## 背景

为解决 #7504，`DataTable` 在树形数据场景下目前只能通过点击展开图标展开/收起行。展开图标点击区域较小，在行内内容较多或操作区靠右时使用不够方便。

## 主要变更

- 为 `NDataTable` 新增 `expand-on-click` 属性，支持点击树形数据行展开或收起
- 默认行为保持不变，仅在显式开启 `expand-on-click` 后生效
- 行点击展开复用现有展开逻辑，兼容 `expanded-row-keys`、`on-update:expanded-row-keys` 与异步 `on-load`
- 保留原有展开图标行为，避免点击展开图标时触发行级双重切换
- 保留 `row-props` 的 `onClick` 执行顺序，并支持通过 `event.preventDefault()` 阻止行点击展开
- 补充中英文 API 文档
- 补充 `expand-on-click` 相关测试用例

## 测试说明

- `npx pnpm@11.10.0 run test src/data-table/tests/DataTable.spec.tsx -t "expand-on-click"` ✅
- `npx pnpm@11.10.0 run test src/data-table` ✅
- `npx pnpm@11.10.0 exec eslint src/data-table/src/DataTable.tsx src/data-table/src/TableParts/Body.tsx src/data-table/src/interface.ts src/data-table/tests/DataTable.spec.tsx src/data-table/demos/enUS/index.demo-entry.md src/data-table/demos/zhCN/index.demo-entry.md` ✅
- `npx pnpm@11.10.0 run lint:src-type` ✅
- `git diff --check` ✅

## 影响范围

- 新增 opt-in 属性，不影响 `DataTable` 现有默认行为
- 仅影响树形数据行的点击展开交互
- 点击内部控件时可通过 `event.preventDefault()` 避免触发行展开
- 文档新增 `expand-on-click` 属性说明

## Changelog

- 建议在 `CHANGELOG.zh-CN.md` 和 `CHANGELOG.en-US.md` 的 `NEXT_VERSION` 下添加：
  - `n-data-table` 新增 `expand-on-click` 属性，支持点击树形数据行展开或收起

Closes #7504