### PR TITLE
chore(ci): fix lint failures

### DIFF
--- a/src/card/tests/Card.spec.ts
+++ b/src/card/tests/Card.spec.ts
@@ -219,7 +219,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card-header').classes()).toContain('custom-header-class')
+    expect(wrapper.find('.n-card-header').classes()).toContain(
+      'custom-header-class'
+    )
     wrapper.unmount()
   })
 
@@ -233,7 +235,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card-content').classes()).toContain('custom-content-class')
+    expect(wrapper.find('.n-card-content').classes()).toContain(
+      'custom-content-class'
+    )
     wrapper.unmount()
   })
 
@@ -247,7 +251,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card__footer').classes()).toContain('custom-footer-class')
+    expect(wrapper.find('.n-card__footer').classes()).toContain(
+      'custom-footer-class'
+    )
     wrapper.unmount()
   })
 
@@ -262,7 +268,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card-header__extra').classes()).toContain('custom-extra-class')
+    expect(wrapper.find('.n-card-header__extra').classes()).toContain(
+      'custom-extra-class'
+    )
     wrapper.unmount()
   })
 
@@ -296,20 +304,6 @@ describe('n-card', () => {
     })
 
     expect(wrapper.find('.n-card').attributes('role')).toBe('article')
-    wrapper.unmount()
-  })
-
-  it('should work with `content-scrollable` prop', async () => {
-    const wrapper = mount(NCard, {
-      props: {
-        contentScrollable: true
-      },
-      slots: {
-        default: () => 'content'
-      }
-    })
-
-    expect(wrapper.find('.n-scrollbar').exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -347,7 +341,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card').classes()).toContain('n-card--content-segmented')
+    expect(wrapper.find('.n-card').classes()).toContain(
+      'n-card--content-segmented'
+    )
     wrapper.unmount()
   })
 
@@ -363,7 +359,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card').classes()).toContain('n-card--footer-segmented')
+    expect(wrapper.find('.n-card').classes()).toContain(
+      'n-card--footer-segmented'
+    )
     wrapper.unmount()
   })
 
@@ -379,7 +377,9 @@ describe('n-card', () => {
       }
     })
 
-    expect(wrapper.find('.n-card').classes()).toContain('n-card--action-segmented')
+    expect(wrapper.find('.n-card').classes()).toContain(
+      'n-card--action-segmented'
+    )
     wrapper.unmount()
   })
 })

--- a/src/equation/tests/Equation.spec.tsx
+++ b/src/equation/tests/Equation.spec.tsx
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { h, provide, ref } from 'vue'
-import { NEquation } from '../index'
 import { configProviderInjectionKey } from '../../config-provider/src/context'
+import { NEquation } from '../index'
 
 describe('n-equation', () => {
   it('should work with import on demand', () => {
@@ -12,7 +12,9 @@ describe('n-equation', () => {
     const wrapper = mount(NEquation, {
       props: { value: 'E = mc^2' }
     })
-    expect(wrapper.find('.katex').exists() || wrapper.text().includes('no katex')).toBe(true)
+    expect(
+      wrapper.find('.katex').exists() || wrapper.text().includes('no katex')
+    ).toBe(true)
     wrapper.unmount()
   })
 
@@ -73,7 +75,8 @@ describe('n-equation', () => {
 
   it('should use katex from config provider', () => {
     const mockKatex = {
-      renderToString: (value: string) => `<span class="katex-config">${value}</span>`
+      renderToString: (value: string) =>
+        `<span class="katex-config">${value}</span>`
     }
 
     const wrapper = mount({


### PR DESCRIPTION
## Summary

- remove the redundant duplicate `content-scrollable` card test
- sort equation test imports with the repository ESLint configuration

## Root cause

The main branch lint job rejected an identical test title in `Card.spec.ts` and an out-of-order relative import in `Equation.spec.tsx`.

## Validation

- `pnpm run lint`
- `pnpm run lint:code`
- `pnpm run test src/card src/equation`

No changelog is included because this only repairs CI test/lint issues and does not change a public API or user-facing behavior.
