### PR TITLE
fix(empty): support size via n-config-provider component-options

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -33,6 +33,7 @@
 - Fix `n-image` rendering the `placeholder` slot together with the `error` slot when the image fails to load, closes [#7526](https://github.com/tusen-ai/naive-ui/issues/7526).
 - Fix `n-space` `size` prop not taking effect when set to `0`, closes [#7530](https://github.com/tusen-ai/naive-ui/issues/7530).
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
+- Fix `n-config-provider`'s `component-options` not controlling the `size` of `n-empty`, closes [#8139](https://github.com/tusen-ai/naive-ui/issues/8139).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -33,6 +33,7 @@
 - 修复 `n-image` 图片加载失败时 `placeholder` 插槽与 `error` 插槽同时显示的问题，关闭 [#7526](https://github.com/tusen-ai/naive-ui/issues/7526)
 - 修复 `n-space` `size` 属性设置为 `0` 时不生效的问题，关闭 [#7530](https://github.com/tusen-ai/naive-ui/issues/7530)
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
+- 修复 `n-config-provider` 的 `component-options` 无法控制 `n-empty` 组件 `size` 的问题，关闭 [#8139](https://github.com/tusen-ai/naive-ui/issues/8139)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 

--- a/src/config-provider/src/internal-interface.ts
+++ b/src/config-provider/src/internal-interface.ts
@@ -278,7 +278,7 @@ export interface GlobalComponentConfig {
   DynamicTags?: {
     size?: DynamicTagsSize
   }
-  Empty?: Pick<EmptyProps, 'description' | 'renderIcon'>
+  Empty?: Pick<EmptyProps, 'description' | 'renderIcon' | 'size'>
   Form?: {
     size?: FormSize
   }

--- a/src/empty/src/Empty.tsx
+++ b/src/empty/src/Empty.tsx
@@ -22,8 +22,10 @@ export const emptyProps = {
     default: true
   },
   size: {
-    type: String as PropType<'tiny' | 'small' | 'medium' | 'large' | 'huge'>,
-    default: 'medium'
+    type: String as PropType<
+      'tiny' | 'small' | 'medium' | 'large' | 'huge' | undefined
+    >,
+    default: undefined
   },
   renderIcon: Function as PropType<() => VNodeChild>
 }
@@ -62,8 +64,19 @@ export default defineComponent({
         mergedComponentPropsRef?.value?.Empty?.renderIcon
         || (() => <EmptyIcon />)
     )
-    const cssVarsRef = computed(() => {
+    const mergedSizeRef = computed<
+      'tiny' | 'small' | 'medium' | 'large' | 'huge'
+    >(() => {
       const { size } = props
+      const configSize = mergedComponentPropsRef?.value?.Empty?.size
+      if (size !== undefined)
+        return size
+      if (configSize !== undefined)
+        return configSize
+      return 'medium'
+    })
+    const cssVarsRef = computed(() => {
+      const size = mergedSizeRef.value
       const {
         common: { cubicBezierEaseInOut },
         self: {
@@ -88,7 +101,7 @@ export default defineComponent({
           'empty',
           computed(() => {
             let hash = ''
-            const { size } = props
+            const { value: size } = mergedSizeRef
             hash += size[0]
             return hash
           }),
@@ -99,6 +112,7 @@ export default defineComponent({
     return {
       mergedClsPrefix: mergedClsPrefixRef,
       mergedRenderIcon: mergedRenderIconRef,
+      mergedSize: mergedSizeRef,
       localizedDescription: computed(() => {
         return mergedDescriptionRef.value || localeRef.value.description
       }),

--- a/src/empty/tests/Empty.spec.ts
+++ b/src/empty/tests/Empty.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
-import { h } from 'vue'
+import { h, nextTick } from 'vue'
+import { NConfigProvider } from '../../config-provider'
 import { NEmpty } from '../index'
 
 describe('n-empty', () => {
@@ -110,7 +111,9 @@ describe('n-empty', () => {
       }
     })
 
-    expect(wrapper.find('.n-empty__description').text()).toContain('Custom Description')
+    expect(wrapper.find('.n-empty__description').text()).toContain(
+      'Custom Description'
+    )
     wrapper.unmount()
   })
 
@@ -168,6 +171,54 @@ describe('n-empty', () => {
     })
 
     expect(wrapper.find('.n-empty__description').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('should respect size from n-config-provider component-options', async () => {
+    const wrapper = mount(NConfigProvider, {
+      props: {
+        componentOptions: {
+          Empty: { size: 'large' }
+        }
+      },
+      slots: {
+        default: () => h(NEmpty)
+      }
+    })
+
+    await nextTick()
+    expect(
+      wrapper.findComponent(NEmpty).find('.n-empty').attributes('style')
+    ).toMatchSnapshot()
+
+    await wrapper.setProps({
+      componentOptions: {
+        Empty: { size: 'tiny' }
+      }
+    })
+    await nextTick()
+    expect(
+      wrapper.findComponent(NEmpty).find('.n-empty').attributes('style')
+    ).toMatchSnapshot()
+    wrapper.unmount()
+  })
+
+  it('should prioritize prop size over config-provider size', async () => {
+    const wrapper = mount(NConfigProvider, {
+      props: {
+        componentOptions: {
+          Empty: { size: 'large' }
+        }
+      },
+      slots: {
+        default: () => h(NEmpty, { size: 'tiny' })
+      }
+    })
+
+    await nextTick()
+    expect(
+      wrapper.findComponent(NEmpty).find('.n-empty').attributes('style')
+    ).toMatchSnapshot()
     wrapper.unmount()
   })
 })

--- a/src/empty/tests/__snapshots__/Empty.spec.ts.snap
+++ b/src/empty/tests/__snapshots__/Empty.spec.ts.snap
@@ -1,5 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`n-empty > should prioritize prop size over config-provider size 1`] = `"--n-icon-size: 28px; --n-font-size: 12px; --n-bezier: cubic-bezier(.4, 0, .2, 1); --n-text-color: rgba(194, 194, 194, 1); --n-icon-color: rgba(194, 194, 194, 1); --n-extra-text-color: rgb(51, 54, 57);"`;
+
+exports[`n-empty > should respect size from n-config-provider component-options 1`] = `"--n-icon-size: 46px; --n-font-size: 15px; --n-bezier: cubic-bezier(.4, 0, .2, 1); --n-text-color: rgba(194, 194, 194, 1); --n-icon-color: rgba(194, 194, 194, 1); --n-extra-text-color: rgb(51, 54, 57);"`;
+
+exports[`n-empty > should respect size from n-config-provider component-options 2`] = `"--n-icon-size: 28px; --n-font-size: 12px; --n-bezier: cubic-bezier(.4, 0, .2, 1); --n-text-color: rgba(194, 194, 194, 1); --n-icon-color: rgba(194, 194, 194, 1); --n-extra-text-color: rgb(51, 54, 57);"`;
+
 exports[`n-empty > should work with \`size\` prop 1`] = `"--n-icon-size: 40px; --n-font-size: 14px; --n-bezier: cubic-bezier(.4, 0, .2, 1); --n-text-color: rgba(194, 194, 194, 1); --n-icon-color: rgba(194, 194, 194, 1); --n-extra-text-color: rgb(51, 54, 57);"`;
 
 exports[`n-empty > should work with \`size\` prop 2`] = `"--n-icon-size: 34px; --n-font-size: 14px; --n-bezier: cubic-bezier(.4, 0, .2, 1); --n-text-color: rgba(194, 194, 194, 1); --n-icon-color: rgba(194, 194, 194, 1); --n-extra-text-color: rgb(51, 54, 57);"`;


### PR DESCRIPTION
Fix #8139

n-config-provider 无法控制 empty 组件 size，因为：
1. `Empty` 类型在 `GlobalComponentConfig` 中没有声明 `size` 字段
2. Empty 组件没有从 `mergedComponentPropsRef` 中读取 size

## 修改

- `src/config-provider/src/internal-interface.ts`: 给 `Empty` 类型添加 `size` 字段
- `src/empty/src/Empty.tsx`:
  - 把 `size` 默认值从 `'medium'` 改为 `undefined`，以便正确检测用户是否传入了 size
  - 新增 `mergedSizeRef` 计算属性：props.size 优先，然后是 configSize，最后是 'medium'
  - `cssVarsRef` 和 themeClass hash 都使用 `mergedSizeRef` 而不是 `props.size`
- `src/empty/tests/Empty.spec.ts`: 新增测试用例验证 ConfigProvider 设置 size 的功能，以及 props.size 与 configSize 的优先级