### PR TITLE
feat(split): add draggable prop to keep trigger visible but disable dragging

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -16,6 +16,7 @@
 - `n-tabs` adds `show-scroll-button` and `center-active-tab` props, closes [#5846](https://github.com/tusen-ai/naive-ui/issues/5846), [#2128](https://github.com/tusen-ai/naive-ui/issues/2128).
 - `n-tabs` adds `scrollToCurrentTab` method, closes [#7548](https://github.com/tusen-ai/naive-ui/issues/7548).
 - `n-tabs` supports RTL, `placement` adds `'start'` and `'end'`.
+- `n-split` adds `draggable` prop to keep the resize trigger visible while disabling dragging, closes [#8106](https://github.com/tusen-ai/naive-ui/issues/8106).
 
 ### Fixes
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -16,6 +16,7 @@
 - `n-tabs` 新增 `show-scroll-button` 和 `center-active-tab` 属性，关闭 [#5846](https://github.com/tusen-ai/naive-ui/issues/5846)、[#2128](https://github.com/tusen-ai/naive-ui/issues/2128)
 - `n-tabs` 新增 `scrollToCurrentTab` 方法，关闭 [#7548](https://github.com/tusen-ai/naive-ui/issues/7548)
 - `n-tabs` 支持 RTL，`placement` 新增 `'start'`、`'end'`
+- `n-split` 新增 `draggable` 属性，设为 `false` 时保留分割条可见但禁止拖拽，关闭 [#8106](https://github.com/tusen-ai/naive-ui/issues/8106)
 
 ### Fixes
 

--- a/src/split/demos/enUS/draggable.demo.vue
+++ b/src/split/demos/enUS/draggable.demo.vue
@@ -1,0 +1,24 @@
+<markdown>
+# Drag Disabled
+</markdown>
+
+<template>
+  <n-split
+    direction="horizontal"
+    style="height: 200px"
+    :max="0.75"
+    :min="0.25"
+    :draggable="false"
+  >
+    <template #1>
+      <div :style="{ height: '200px' }">
+        Pane 1
+      </div>
+    </template>
+    <template #2>
+      <div :style="{ height: '200px' }">
+        Pane 2
+      </div>
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/enUS/index.demo-entry.md
+++ b/src/split/demos/enUS/index.demo-entry.md
@@ -13,6 +13,7 @@ nest.vue
 event.vue
 slot.vue
 controlled.vue
+draggable.vue
 ```
 
 ## API
@@ -24,6 +25,7 @@ controlled.vue
 | default-size | `number` | `0.5` | Default split size, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2 |
 | direction | `'horizontal' \| 'vertical'` | `'horizontal'` | The direction of the split. | 2.36.0 |
 | disabled | `boolean` | `false` | Whether to disable the split. | 2.36.0 |
+| draggable | `boolean` | `true` | Whether the resize trigger is draggable. When `false`, the trigger is still visible but cannot be dragged. | NEXT_VERSION |
 | max | `string \| number` | `1` | The maximum split threshold, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2 |
 | min | `string \| number` | `0` | The minimum threshold for splitting, when it's `number` it should in 0 ~ 1, when it's `string` it should be formatted in `${number}px`. | 2.36.0, `string` 2.38.2 |
 | pane1-class | `string` | `undefined` | The class name of the first pane. | 2.38.2 |

--- a/src/split/demos/zhCN/draggable.demo.vue
+++ b/src/split/demos/zhCN/draggable.demo.vue
@@ -1,0 +1,24 @@
+<markdown>
+# 禁止拖拽
+</markdown>
+
+<template>
+  <n-split
+    direction="horizontal"
+    style="height: 200px"
+    :max="0.75"
+    :min="0.25"
+    :draggable="false"
+  >
+    <template #1>
+      <div :style="{ height: '200px' }">
+        Pane 1
+      </div>
+    </template>
+    <template #2>
+      <div :style="{ height: '200px' }">
+        Pane 2
+      </div>
+    </template>
+  </n-split>
+</template>

--- a/src/split/demos/zhCN/index.demo-entry.md
+++ b/src/split/demos/zhCN/index.demo-entry.md
@@ -14,6 +14,7 @@ event.vue
 slot.vue
 controlled.vue
 pixel-value.vue
+draggable.vue
 ```
 
 ## API
@@ -25,6 +26,7 @@ pixel-value.vue
 | default-size | `string \| number` | `0.5` | Split 的默认分割大小，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2 |
 | direction | `'horizontal' \| 'vertical'` | `'horizontal'` | Split 的分割方向 | 2.36.0 |
 | disabled | `boolean` | `false` | 是否禁用 | 2.36.0 |
+| draggable | `boolean` | `true` | 是否可拖拽分割条，设为 `false` 时分割条仍可见但不可拖拽 | NEXT_VERSION |
 | max | `string \| number` | `1` | Split 的分割最大阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2 |
 | min | `string \| number` | `0` | Split 的分割最小阈值，为 `number` 类型时应该为 0 ~ 1 之间的值，为 `string` 类型时应该为 `${number}px` 格式 | 2.36.0, `string` 2.38.2 |
 | pane1-class | `string` | `undefined` | 第一个面板的类名 | 2.38.2 |

--- a/src/split/src/Split.tsx
+++ b/src/split/src/Split.tsx
@@ -24,6 +24,10 @@ export const splitProps = {
     default: 3
   },
   disabled: Boolean,
+  draggable: {
+    type: Boolean,
+    default: true
+  },
   defaultSize: {
     type: [String, Number] as PropType<string | number>,
     default: 0.5
@@ -137,12 +141,19 @@ export default defineComponent({
 
     const resizeTriggerWrapperStyle = computed(() => {
       const horizontal = props.direction === 'horizontal'
+      const cursor = props.draggable
+        ? props.direction === 'horizontal'
+          ? 'col-resize'
+          : 'row-resize'
+        : 'default'
       return {
         width: horizontal ? `${props.resizeTriggerSize}px` : '',
         height: horizontal ? '' : `${props.resizeTriggerSize}px`,
-        cursor: props.direction === 'horizontal' ? 'col-resize' : 'row-resize'
+        cursor
       }
     })
+
+    const resizableRef = computed(() => !props.disabled && props.draggable)
 
     let offset = 0
     const handleMouseDown = (e: MouseEvent): void => {
@@ -236,6 +247,7 @@ export default defineComponent({
       mergedClsPrefix: mergedClsPrefixRef,
       resizeTriggerWrapperStyle,
       resizeTriggerStyle,
+      resizable: resizableRef,
       handleMouseDown,
       firstPaneStyle
     }
@@ -260,9 +272,13 @@ export default defineComponent({
         {!this.disabled && (
           <div
             ref="resizeTriggerElRef"
-            class={`${this.mergedClsPrefix}-split__resize-trigger-wrapper`}
+            class={[
+              `${this.mergedClsPrefix}-split__resize-trigger-wrapper`,
+              !this.resizable
+              && `${this.mergedClsPrefix}-split__resize-trigger-wrapper--disabled`
+            ]}
             style={this.resizeTriggerWrapperStyle}
-            onMousedown={this.handleMouseDown}
+            onMousedown={this.resizable ? this.handleMouseDown : undefined}
           >
             {resolveSlot(this.$slots['resize-trigger'], () => [
               <div

--- a/src/split/src/styles/index.cssr.ts
+++ b/src/split/src/styles/index.cssr.ts
@@ -32,5 +32,16 @@ export default cB('split', `
     c('&:hover', `
       background-color: var(--n-resize-trigger-color-hover);
     `)
+  ]),
+  cE('resize-trigger-wrapper', null, [
+    cM('disabled', [
+      cE('resize-trigger', `
+        pointer-events: none;
+      `, [
+        c('&:hover', `
+          background-color: var(--n-resize-trigger-color);
+        `)
+      ])
+    ])
   ])
 ])

--- a/src/split/tests/Split.spec.tsx
+++ b/src/split/tests/Split.spec.tsx
@@ -21,7 +21,9 @@ describe('n-split', () => {
       props: { defaultSize: 0.3 }
     })
     // The style uses calc() format: flex: 0 0 calc(30% - 0.9px)
-    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain('flex: 0 0 calc(30%')
+    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain(
+      'flex: 0 0 calc(30%'
+    )
     wrapper.unmount()
   })
 
@@ -30,10 +32,14 @@ describe('n-split', () => {
       props: { size: 0.4 }
     })
     // The style uses calc() format
-    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain('flex: 0 0 calc(40%')
+    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain(
+      'flex: 0 0 calc(40%'
+    )
 
     await wrapper.setProps({ size: 0.6 })
-    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain('flex: 0 0 calc(60%')
+    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain(
+      'flex: 0 0 calc(60%'
+    )
     wrapper.unmount()
   })
 
@@ -63,7 +69,51 @@ describe('n-split', () => {
 
     await wrapper.setProps({ disabled: true })
     // When disabled, resize trigger should not exist
-    expect(wrapper.find('.n-split__resize-trigger-wrapper').exists()).toBe(false)
+    expect(wrapper.find('.n-split__resize-trigger-wrapper').exists()).toBe(
+      false
+    )
+    wrapper.unmount()
+  })
+
+  it('should work with `draggable` prop', async () => {
+    const onDragStart = vi.fn()
+    const onUpdateSize = vi.fn()
+    const wrapper = mount(NSplit, {
+      props: {
+        onDragStart,
+        onUpdateSize,
+        defaultSize: 0.5
+      },
+      slots: {
+        1: () => 'Pane 1',
+        2: () => 'Pane 2'
+      }
+    })
+
+    // default: draggable is true, wrapper exists without disabled modifier
+    expect(wrapper.find('.n-split__resize-trigger-wrapper').exists()).toBe(true)
+    expect(
+      wrapper.find('.n-split__resize-trigger-wrapper').classes()
+    ).not.toContain('n-split__resize-trigger-wrapper--disabled')
+
+    // when draggable is false, wrapper still renders (trigger visible) but is marked disabled
+    await wrapper.setProps({ draggable: false })
+    expect(wrapper.find('.n-split__resize-trigger-wrapper').exists()).toBe(true)
+    expect(
+      wrapper.find('.n-split__resize-trigger-wrapper').classes()
+    ).toContain('n-split__resize-trigger-wrapper--disabled')
+
+    // mousedown should not trigger drag callbacks nor update size
+    const trigger = wrapper.find('.n-split__resize-trigger-wrapper')
+    await trigger.trigger('mousedown')
+    expect(onDragStart).not.toHaveBeenCalled()
+    expect(onUpdateSize).not.toHaveBeenCalled()
+
+    // switching back to draggable restores normal interaction surface
+    await wrapper.setProps({ draggable: true })
+    expect(
+      wrapper.find('.n-split__resize-trigger-wrapper').classes()
+    ).not.toContain('n-split__resize-trigger-wrapper--disabled')
     wrapper.unmount()
   })
 
@@ -96,7 +146,8 @@ describe('n-split', () => {
   it('should work with `resize-trigger` slot', () => {
     const wrapper = mount(NSplit, {
       slots: {
-        'resize-trigger': () => h('div', { class: 'custom-trigger' }, 'Trigger'),
+        'resize-trigger': () =>
+          h('div', { class: 'custom-trigger' }, 'Trigger'),
         1: () => 'Pane 1',
         2: () => 'Pane 2'
       }
@@ -133,8 +184,12 @@ describe('n-split', () => {
         2: () => 'Pane 2'
       }
     })
-    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain('background-color: red')
-    expect(wrapper.find('.n-split-pane-2').attributes('style')).toContain('background-color: blue')
+    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain(
+      'background-color: red'
+    )
+    expect(wrapper.find('.n-split-pane-2').attributes('style')).toContain(
+      'background-color: blue'
+    )
     wrapper.unmount()
   })
 
@@ -171,7 +226,9 @@ describe('n-split', () => {
     })
 
     await wrapper.setProps({ defaultSize: 0.7 })
-    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain('flex: 0 0 calc(70%')
+    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain(
+      'flex: 0 0 calc(70%'
+    )
     wrapper.unmount()
   })
 
@@ -186,7 +243,9 @@ describe('n-split', () => {
       }
     })
 
-    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain('flex: 0 0 200px')
+    expect(wrapper.find('.n-split-pane-1').attributes('style')).toContain(
+      'flex: 0 0 200px'
+    )
     wrapper.unmount()
   })
 


### PR DESCRIPTION
Closes #8106

## Problem

`n-split` currently couples two semantics into the single `disabled` prop:
- hide the resize trigger wrapper entirely
- prevent dragging

Callers often need only the second behavior (keep the bar visible as part of the layout, but lock the size). The existing `disabled` API cannot express this — setting it removes the trigger from the DOM, which breaks layouts that visually depend on the bar.

## Solution

Add a new `draggable` prop (default `true`), so callers can independently control whether the resize trigger can be dragged while keeping it rendered.

| `disabled` | `draggable` | Wrapper rendered | Draggable | Cursor            |
| ----------- | ------------- | ---------------- | --------- | ----------------- |
| `false`   | `true` (default) | ✅             | ✅        | col-/row-resize   |
| `false`   | `false`     | ✅                | ❌        | `default`        |
| `true`    | *             | ❌                | ❌        | —                 |

`disabled` keeps its existing behavior for full backward compatibility.

## Changes

- **Split.tsx**: introduce `draggable` prop and a derived `resizable` ref (`!disabled && draggable`). Render the wrapper unless `disabled`; attach `onMousedown` only when `resizable`. Switch wrapper cursor to `default` when not draggable.
- **styles/index.cssr.ts**: new `__resize-trigger-wrapper--disabled` modifier that suppresses the inner trigger's hover-color change and pointer events.
- **Split.spec.tsx**: cover the `disabled` × `draggable` combinations, asserting wrapper presence, modifier class, and that `onDragStart` / `onUpdateSize` are not invoked when dragging is disabled.
- **Demos**: add zhCN / enUS `draggable.demo.vue`; register them and document the new prop in both demo entries with `NEXT_VERSION` per CONTRIBUTING.
- **CHANGELOG**: add a Feats line in both en-US and zh-CN.