### PR TITLE
docs: store site theme in localStorage instead of URL

### DIFF
--- a/demo/SiteHeader.vue
+++ b/demo/SiteHeader.vue
@@ -68,7 +68,6 @@ export default defineComponent({
     const router = useRouter()
 
     const mobilePopoverRef = ref(null)
-    const themeAndLocaleReg = /^(\/[^/]+){2}/
 
     // i18n
     const { t } = i18n(locales)
@@ -82,6 +81,7 @@ export default defineComponent({
 
     // locale
     const localeNameRef = useLocaleName()
+    const localePathRef = computed(() => `/${localeNameRef.value}`)
 
     // menu
     const menuOptionsRef = computed(() => {
@@ -89,17 +89,17 @@ export default defineComponent({
         {
           key: 'home',
           label: t('home'),
-          path: themeAndLocaleReg.exec(route.path)[0]
+          path: localePathRef.value
         },
         {
           key: 'doc',
           label: t('doc'),
-          path: `${themeAndLocaleReg.exec(route.path)[0]}/docs/introduction`
+          path: `${localePathRef.value}/docs/introduction`
         },
         {
           key: 'component',
           label: t('component'),
-          path: `${themeAndLocaleReg.exec(route.path)[0]}/components/button`
+          path: `${localePathRef.value}/components/button`
         }
       ]
     })
@@ -129,18 +129,18 @@ export default defineComponent({
         {
           key: 'home',
           label: t('home'),
-          path: themeAndLocaleReg.exec(route.path)[0]
+          path: localePathRef.value
         },
         {
           key: 'doc',
           label: t('doc'),
           children: docOptionsRef.value,
-          path: `${themeAndLocaleReg.exec(route.path)[0]}/docs/introduction`
+          path: `${localePathRef.value}/docs/introduction`
         },
         {
           key: 'component',
           label: t('component'),
-          path: `${themeAndLocaleReg.exec(route.path)[0]}/components/button`,
+          path: `${localePathRef.value}/components/button`,
           children: componentOptionsRef.value
         },
         {
@@ -272,11 +272,11 @@ export default defineComponent({
     const isMobileRef = useIsMobile()
     const isTabletRef = useIsTablet()
     function handleLogoClick() {
-      if (/^(\/[^/]+){2}$/.test(route.path)) {
+      if (route.name === 'home') {
         message.info(t('alreadyHome'))
         return
       }
-      router.push(/^(\/[^/]+){2}/.exec(route.path)[0])
+      router.push(localePathRef.value)
     }
 
     // responsive menu

--- a/demo/pages/Layout.vue
+++ b/demo/pages/Layout.vue
@@ -28,12 +28,9 @@ export default defineComponent({
       return findMenuValue(optionsRef.value, route.path)
     })
     watch(toRef(route, 'path'), (value, oldValue) => {
-      const langAndThemeReg = /\/(zh-CN|en-US)\/(light|dark|os-theme)/g
-      // only theme & lang change do not restore the scroll status
-      if (
-        value.replace(langAndThemeReg, '')
-        !== oldValue.replace(langAndThemeReg, '')
-      ) {
+      const langReg = /^\/(zh-CN|en-US)/g
+      // only lang change does not restore the scroll status
+      if (value.replace(langReg, '') !== oldValue.replace(langReg, '')) {
         layoutInstRef.value.scrollTo(0, 0)
       }
     })

--- a/demo/routes/routes.js
+++ b/demo/routes/routes.js
@@ -1,3 +1,5 @@
+import { setThemePreference } from '../store/theme'
+
 export const enDocRoutes = [
   // basic docs
   {
@@ -1028,45 +1030,63 @@ export const zhComponentRoutes = [
   }
 ]
 
+// Theme used to be part of the URL (e.g. /en-US/os-theme/components/button).
+// Keep old links working while migrating the encoded preference to storage.
+export const legacyThemeRoute = {
+  path: '/:lang(zh-CN|en-US)/:theme(light|dark|os-theme)/:pathMatch(.*)*',
+  redirect: (to) => {
+    setThemePreference(to.params.theme)
+    const pathSegments = to.params.pathMatch
+    const path = Array.isArray(pathSegments)
+      ? pathSegments.join('/')
+      : pathSegments
+    return {
+      path: `/${to.params.lang}${path ? `/${path}` : ''}`,
+      query: to.query,
+      hash: to.hash
+    }
+  }
+}
+
 export const routes = [
+  legacyThemeRoute,
   {
     name: 'home',
-    path: '/:lang/:theme',
+    path: '/:lang(zh-CN|en-US)',
     component: () => import('../pages/home/index.vue')
   },
   {
     name: 'enDocs',
-    path: '/en-US/:theme/docs',
+    path: '/en-US/docs',
     component: () => import('../pages/Layout.vue'),
     children: enDocRoutes
   },
   {
     name: 'zhDocs',
-    path: '/zh-CN/:theme/docs',
+    path: '/zh-CN/docs',
     component: () => import('../pages/Layout.vue'),
     children: zhDocRoutes
   },
   {
     name: 'enComponents',
-    path: '/en-US/:theme/components',
+    path: '/en-US/components',
     component: () => import('../pages/Layout.vue'),
     children: enComponentRoutes
   },
   {
     name: 'zhComponents',
-    path: '/zh-CN/:theme/components',
+    path: '/zh-CN/components',
     component: () => import('../pages/Layout.vue'),
     children: zhComponentRoutes
   },
   {
     name: 'not-found',
     path: '/:pathMatch(.*)*',
-    redirect: {
+    redirect: () => ({
       name: 'home',
       params: {
-        lang: navigator.language === 'zh-CN' ? 'zh-CN' : 'en-US',
-        theme: 'os-theme'
+        lang: navigator.language === 'zh-CN' ? 'zh-CN' : 'en-US'
       }
-    }
+    })
   }
 ]

--- a/demo/routes/routes.spec.js
+++ b/demo/routes/routes.spec.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { themeStorageKey } from '../store/theme'
+import { legacyThemeRoute } from './routes'
+
+function createMemoryStorage() {
+  const values = new Map()
+  return {
+    clear: () => values.clear(),
+    getItem: key => values.get(key) ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, String(value))
+  }
+}
+
+function createTestRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      legacyThemeRoute,
+      {
+        path: '/:pathMatch(.*)*',
+        component: { template: '<div />' }
+      }
+    ]
+  })
+}
+
+describe('legacy theme route', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: createMemoryStorage()
+    })
+  })
+
+  it('migrates an explicit theme and preserves the full destination', async () => {
+    const router = createTestRouter()
+
+    await router.push('/en-US/dark/components/button?source=legacy#examples')
+    await router.isReady()
+
+    expect(router.currentRoute.value.fullPath).toBe(
+      '/en-US/components/button?source=legacy#examples'
+    )
+    expect(window.localStorage.getItem(themeStorageKey)).toBe('dark')
+  })
+
+  it('uses a missing preference for an OS-theme URL', async () => {
+    window.localStorage.setItem(themeStorageKey, 'light')
+    const router = createTestRouter()
+
+    await router.push('/zh-CN/os-theme/docs/introduction')
+    await router.isReady()
+
+    expect(router.currentRoute.value.fullPath).toBe('/zh-CN/docs/introduction')
+    expect(window.localStorage.getItem(themeStorageKey)).toBeNull()
+  })
+
+  it('redirects a legacy locale home without adding a trailing slash', async () => {
+    const router = createTestRouter()
+
+    await router.push('/en-US/light')
+    await router.isReady()
+
+    expect(router.currentRoute.value.fullPath).toBe('/en-US')
+    expect(window.localStorage.getItem(themeStorageKey)).toBe('light')
+  })
+})

--- a/demo/store/index.js
+++ b/demo/store/index.js
@@ -16,6 +16,7 @@ import {
   createComponentMenuOptions,
   createDocumentationMenuOptions
 } from './menu-options'
+import { setThemePreference, useThemePreference } from './theme'
 
 let route = null
 let router = null
@@ -23,10 +24,6 @@ let router = null
 let localeNameRef = null
 // useMemo
 let dateLocaleRef = null
-// theme
-const osThemeRef = useOsTheme()
-let themeNameRef = null
-let rawThemeNameRef = null // could be `os-theme`
 
 export function initRouter(_router, _route) {
   route = _route
@@ -42,23 +39,22 @@ export function initRouter(_router, _route) {
   dateLocaleRef = useMemo(() => {
     return route.path.startsWith('/zh-CN') ? dateZhCN : dateEnUS
   })
-  rawThemeNameRef = useMemo(() => route.params.theme)
-  themeNameRef = useMemo({
-    get() {
-      switch (route.params.theme) {
-        case 'os-theme':
-          return osThemeRef.value
-        case 'dark':
-          return 'dark'
-        default:
-          return 'light'
-      }
-    },
-    set(theme) {
-      router.push(changeThemeInPath(route.fullPath, theme))
-    }
-  })
 }
+
+// theme
+// Theme is a user preference, so it is persisted in localStorage instead of
+// being kept in the URL. A missing preference means following the OS color
+// scheme; only an explicit light or dark choice is persisted.
+const osThemeRef = useOsTheme()
+const themePreferenceRef = useThemePreference()
+const themeNameRef = computed({
+  get() {
+    return themePreferenceRef.value ?? osThemeRef.value ?? 'light'
+  },
+  set(theme) {
+    setThemePreference(theme)
+  }
+})
 
 // display mode
 const _displayModeRef = ref(window.localStorage.getItem('mode') ?? 'debug')
@@ -94,14 +90,12 @@ const configProviderRef = computed(() => {
 // options
 const docOptionsRef = computed(() =>
   createDocumentationMenuOptions({
-    theme: rawThemeNameRef.value,
     lang: localeNameRef.value,
     mode: displayModeRef.value
   })
 )
 const componentOptionsRef = computed(() =>
   createComponentMenuOptions({
-    theme: rawThemeNameRef.value,
     lang: localeNameRef.value,
     mode: displayModeRef.value
   })
@@ -139,20 +133,12 @@ export function siteSetup() {
 }
 
 function changeLangInPath(path, lang) {
-  const langReg = /^\/(zh-CN|en-US)\//
-  return path.replace(langReg, `/${lang}/`)
-}
-
-function changeThemeInPath(path, theme) {
-  const themeReg = /(^\/[^/]+\/)([^/]+)/
-  return path.replace(themeReg, `$1${theme}`)
+  const langReg = /^\/(zh-CN|en-US)(\/|$)/
+  return path.replace(langReg, `/${lang}$2`)
 }
 
 export function push(partialPath) {
-  const { fullPath } = route
-  router.push(
-    fullPath.replace(/(^\/[^/]+\/[^/]+)((\/.*)|$)/, `$1${partialPath}`)
-  )
+  router.push(`/${localeNameRef.value}${partialPath}`)
 }
 
 export function useDisplayMode() {

--- a/demo/store/menu-options.js
+++ b/demo/store/menu-options.js
@@ -68,7 +68,7 @@ function appendCounts(item) {
   }
 }
 
-function createItems(lang, theme, prefix, items) {
+function createItems(lang, prefix, items) {
   const isZh = lang === 'zh-CN'
   const langKey = isZh ? 'zh' : 'en'
   return items.map((rawItem) => {
@@ -78,19 +78,17 @@ function createItems(lang, theme, prefix, items) {
       label: rawItem[langKey] || rawItem.en,
       extra: renderItemExtra(rawItem, isZh),
       extraString: getItemExtraString(rawItem, isZh),
-      path: rawItem.path
-        ? `/${lang}/${theme}${prefix}${rawItem.path}`
-        : undefined
+      path: rawItem.path ? `/${lang}${prefix}${rawItem.path}` : undefined
     }
     if (rawItem.children) {
-      item.children = createItems(lang, theme, prefix, rawItem.children)
+      item.children = createItems(lang, prefix, rawItem.children)
     }
     return item
   })
 }
 
-export function createDocumentationMenuOptions({ lang, theme }) {
-  return createItems(lang, theme, '/docs', [
+export function createDocumentationMenuOptions({ lang }) {
+  return createItems(lang, '/docs', [
     {
       en: 'Introduction',
       zh: '介绍',
@@ -222,8 +220,8 @@ export function createDocumentationMenuOptions({ lang, theme }) {
   ])
 }
 
-export function createComponentMenuOptions({ lang, theme }) {
-  return createItems(lang, theme, '/components', [
+export function createComponentMenuOptions({ lang }) {
+  return createItems(lang, '/components', [
     appendCounts({
       zh: '通用组件',
       en: 'Common Components',

--- a/demo/store/theme.js
+++ b/demo/store/theme.js
@@ -1,0 +1,41 @@
+import { ref } from 'vue'
+
+export const themeStorageKey = 'naive-ui-theme'
+
+function normalizeThemePreference(themeName) {
+  return themeName === 'light' || themeName === 'dark' ? themeName : null
+}
+
+export function readThemePreference(storage) {
+  try {
+    const targetStorage = storage ?? window.localStorage
+    return normalizeThemePreference(targetStorage.getItem(themeStorageKey))
+  }
+  catch {
+    return null
+  }
+}
+
+export function writeThemePreference(themeName, storage) {
+  try {
+    const targetStorage = storage ?? window.localStorage
+    const preference = normalizeThemePreference(themeName)
+    if (preference === null)
+      targetStorage.removeItem(themeStorageKey)
+    else targetStorage.setItem(themeStorageKey, preference)
+  }
+  catch {
+    // The in-memory preference still works when storage is unavailable.
+  }
+}
+
+const themePreferenceRef = ref(readThemePreference())
+
+export function setThemePreference(themeName) {
+  themePreferenceRef.value = normalizeThemePreference(themeName)
+  writeThemePreference(themeName)
+}
+
+export function useThemePreference() {
+  return themePreferenceRef
+}

--- a/demo/store/theme.spec.js
+++ b/demo/store/theme.spec.js
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  readThemePreference,
+  setThemePreference,
+  themeStorageKey,
+  useThemePreference,
+  writeThemePreference
+} from './theme'
+
+function createMemoryStorage() {
+  const values = new Map()
+  return {
+    clear: () => values.clear(),
+    getItem: key => values.get(key) ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, String(value))
+  }
+}
+
+describe('theme preference', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: createMemoryStorage()
+    })
+    setThemePreference('os-theme')
+  })
+
+  it('reads only explicit theme preferences', () => {
+    window.localStorage.setItem(themeStorageKey, 'dark')
+    expect(readThemePreference()).toBe('dark')
+
+    window.localStorage.setItem(themeStorageKey, 'os-theme')
+    expect(readThemePreference()).toBeNull()
+
+    window.localStorage.setItem(themeStorageKey, 'invalid')
+    expect(readThemePreference()).toBeNull()
+  })
+
+  it('uses a missing value to represent the OS theme', () => {
+    writeThemePreference('light')
+    expect(window.localStorage.getItem(themeStorageKey)).toBe('light')
+
+    writeThemePreference('os-theme')
+    expect(window.localStorage.getItem(themeStorageKey)).toBeNull()
+  })
+
+  it('keeps the reactive preference in sync', () => {
+    setThemePreference('dark')
+    expect(useThemePreference().value).toBe('dark')
+    expect(window.localStorage.getItem(themeStorageKey)).toBe('dark')
+
+    setThemePreference('os-theme')
+    expect(useThemePreference().value).toBeNull()
+    expect(window.localStorage.getItem(themeStorageKey)).toBeNull()
+  })
+
+  it('falls back safely when storage is unavailable', () => {
+    const unavailableStorage = {
+      getItem() {
+        throw new Error('unavailable')
+      },
+      setItem() {
+        throw new Error('unavailable')
+      },
+      removeItem() {
+        throw new Error('unavailable')
+      }
+    }
+
+    expect(readThemePreference(unavailableStorage)).toBeNull()
+    expect(() => writeThemePreference('dark', unavailableStorage)).not.toThrow()
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('unavailable')
+      }
+    })
+    expect(readThemePreference()).toBeNull()
+    expect(() => writeThemePreference('dark')).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Theme is a user preference, so the docs site should not encode it in every URL. This rewrite removes the theme segment from canonical routes and gives the preference a small, explicit storage contract:

- canonical routes are now locale-only (`/:lang`, `/en-US/docs/...`, `/zh-CN/components/...`)
- only an explicit `light` or `dark` choice is stored under `naive-ui-theme`; a missing value means following the OS color scheme
- theme state stays reactive even when browser storage is unavailable
- header, footer, and sidebar navigation now derive paths from locale state instead of parsing theme-bearing URLs

## Legacy links

A dedicated compatibility route handles the old `/:lang/:theme/...` shape. It removes the theme segment, migrates the encoded `light`, `dark`, or `os-theme` preference, and preserves the destination path, query, and hash. This keeps existing docs links working without mixing migration behavior into the catch-all route.

## Impact

Docs site only; `src/` is untouched. Theme toggles now persist across pages and sessions without changing the shareable URL.

## Verification

- `pnpm test` — 192 test files, 1059 tests passed
- `pnpm build:site` — production site build passed
- changed-file ESLint and `git diff --check` passed
- 7 focused route/storage assertions cover explicit theme migration, OS-theme reset, legacy home redirects, query/hash preservation, invalid stored values, reactive state, and unavailable storage

`pnpm lint` reaches `lint:demo-type` and reports only the two pre-existing implicit-any errors in `src/dropdown/demos/{enUS,zhCN}/manual-position.demo.vue`. Those files are unchanged here; the same fix has already landed on `main` in #8137 and still needs to reach the `docs` base branch.
