### PR TITLE
fix(image): drop removed images from image group preview

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -35,6 +35,7 @@
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
+- Fix `n-image-group` still previewing images whose `n-image` has been removed, closes [#8150](https://github.com/tusen-ai/naive-ui/issues/8150).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -35,6 +35,7 @@
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
+- 修复 `n-image-group` 中的 `n-image` 被移除后仍可在预览中切换到该图片的问题，关闭 [#8150](https://github.com/tusen-ai/naive-ui/issues/8150)
 
 ## 2.44.1
 

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -126,14 +126,15 @@ export default defineComponent({
       showErrorRef.value = false
     })
 
-    watchEffect((onInvalidate) => {
-      const unregister = imageGroupHandle?.registerImageUrl?.(
+    let unregisterImageUrl: (() => void) | undefined
+    watchEffect(() => {
+      unregisterImageUrl = imageGroupHandle?.registerImageUrl?.(
         imageId,
         mergedPreviewSrcRef.value || ''
       )
-      onInvalidate(() => {
-        unregister?.()
-      })
+    })
+    onBeforeUnmount(() => {
+      unregisterImageUrl?.()
     })
 
     function onImgClick(e: PointerEvent) {

--- a/src/image/src/ImageGroup.tsx
+++ b/src/image/src/ImageGroup.tsx
@@ -94,7 +94,7 @@ export default defineComponent({
       }
 
       return function unregisterPreviewUrl() {
-        if (!registeredImageUrlMap.value.has(sid)) {
+        if (registeredImageUrlMap.value.has(sid)) {
           registeredImageUrlMap.value.delete(sid)
         }
       }

--- a/src/image/tests/Image.spec.tsx
+++ b/src/image/tests/Image.spec.tsx
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { h, nextTick } from 'vue'
+import { h, nextTick, ref } from 'vue'
 import { NImage, NImageGroup } from '../index'
 import NImagePreview from '../src/ImagePreview'
 
@@ -107,6 +107,50 @@ describe('n-image', () => {
     expect(wrapper.findComponent(NImagePreview).exists()).toBe(true)
     wrapper.unmount()
   })
+
+  it('should not preview removed images in `image group`', async () => {
+    const srcList = ref(['image-1.png', 'image-2.png'])
+    const wrapper = mount(() =>
+      h(NImageGroup, null, {
+        default: () => srcList.value.map(src => h(NImage, { key: src, src }))
+      })
+    )
+
+    srcList.value = ['image-1.png']
+    await nextTick()
+
+    await wrapper.find('img').trigger('click')
+    wrapper.findComponent(NImageGroup).vm.next()
+    await nextTick()
+
+    expect(wrapper.findComponent(NImagePreview).props('src')).toBe(
+      'image-1.png'
+    )
+    wrapper.unmount()
+  })
+
+  it('should keep image order in `image group` when `src` changes', async () => {
+    const srcList = ref(['image-1.png', 'image-2.png', 'image-3.png'])
+    const wrapper = mount(() =>
+      h(NImageGroup, null, {
+        default: () =>
+          srcList.value.map((src, index) => h(NImage, { key: index, src }))
+      })
+    )
+
+    srcList.value = ['image-1.png', 'image-2-updated.png', 'image-3.png']
+    await nextTick()
+
+    await wrapper.findAll('img')[0].trigger('click')
+    wrapper.findComponent(NImageGroup).vm.next()
+    await nextTick()
+
+    expect(wrapper.findComponent(NImagePreview).props('src')).toBe(
+      'image-2-updated.png'
+    )
+    wrapper.unmount()
+  })
+
   it('should inherit attrs', () => {
     const wrapper = mount(NImage, {
       attrs: {


### PR DESCRIPTION
When an `n-image` inside an `n-image-group` was removed, its entry stayed in the group's registered url map, so preview-prev and preview-next could still switch to the deleted image. The unregister callback had its condition inverted (`if (!map.has(sid))`), so it only ran when the entry was already gone.

The callback now deletes the entry when it is there, and `n-image` calls it on unmount instead of on every effect invalidation, so updating a `src` still replaces the url in place and keeps the image's position in the group.

Fixes #8150