### PR TITLE
fix(data-table): escape line breaks and quotes in exported CSV

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -35,6 +35,7 @@
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
+- Fix `n-data-table`'s exported CSV being broken by cells containing line breaks, commas or double quotes, closes [#8153](https://github.com/tusen-ai/naive-ui/issues/8153).
 
 ## 2.44.1
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -35,7 +35,7 @@
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
-- Fix `n-data-table`'s exported CSV being broken by cells containing line breaks, commas or double quotes, closes [#8153](https://github.com/tusen-ai/naive-ui/issues/8153).
+- Fix `n-data-table`'s exported CSV being broken by line breaks, commas or double quotes in cells and column titles, closes [#8153](https://github.com/tusen-ai/naive-ui/issues/8153).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -35,6 +35,7 @@
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
+- 修复 `n-data-table` 导出的 CSV 在单元格含有换行、逗号或双引号时格式错误的问题，关闭 [#8153](https://github.com/tusen-ai/naive-ui/issues/8153)
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -35,7 +35,7 @@
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
-- 修复 `n-data-table` 导出的 CSV 在单元格含有换行、逗号或双引号时格式错误的问题，关闭 [#8153](https://github.com/tusen-ai/naive-ui/issues/8153)
+- 修复 `n-data-table` 导出的 CSV 在单元格或列标题含有换行、逗号、双引号时格式错误的问题，关闭 [#8153](https://github.com/tusen-ai/naive-ui/issues/8153)
 
 ## 2.44.1
 

--- a/src/data-table/demos/enUS/index.demo-entry.md
+++ b/src/data-table/demos/enUS/index.demo-entry.md
@@ -83,8 +83,8 @@ export-csv.vue
 | expanded-row-keys | `Array<string \| number>` | `undefined` | Expanded row keys. |  |
 | filter-icon-popover-props | `PopoverProps` | `{ trigger: click, placement: bottom }` | Filter icon's Popover attribute of the button, See [Popover props](popover#Popover-Props) | 2.39.0 |
 | flex-height | `boolean` | `false` | Whether to make table body's height auto fit table area height. Make it enabled will make `table-layout` always set to `'fixed'`. |  |
-| get-csv-cell | `(value: any, row: object, col: DataTableBaseColumn) => string` | `undefined` | Get CSV's cell content. | 2.40.2 |
-| get-csv-header | `(cols: Array<DataTableColumn>) => string` | `undefined` | Get CSV's header content. | 2.40.2 |
+| get-csv-cell | `(value: any, row: object, col: DataTableBaseColumn) => string` | `undefined` | Get CSV's cell content. The returned string is used as-is, so escape special characters (commas, quotes, line breaks) yourself if needed. | 2.40.2 |
+| get-csv-header | `(cols: Array<DataTableColumn>) => string` | `undefined` | Get CSV's header content. The returned string is used as-is, so escape special characters (commas, quotes, line breaks) yourself if needed. | 2.40.2 |
 | header-height | `number` | `28` | Header height value when `virtual-scroll-header` is enabled. | 2.40.0 |
 | height-for-row | `(rowData: object, index: number) => number` | `undefined` | Height configuration function for each row of the table. It must be used with `virtual-scroll-x`. If it's not configured, each rows height would be set to `min-row-height`. | 2.40.0 |
 | indent | `number` | `16` | Indent of row content when using tree data. |  |

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -95,8 +95,8 @@ empty-debug.vue
 | expanded-row-keys | `Array<string \| number>` | `undefined` | 展开行的 key 值 |  |
 | filter-icon-popover-props | `PopoverProps` | `{ trigger: click, placement: bottom }` | 过滤按钮的 Popover 属性，属性参考 [Popover props](popover#Popover-Props) | 2.39.0 |
 | flex-height | `boolean` | `false` | 是否让表格主体的高度自动适应整个表格区域的高度，打开这个选项会让 `table-layout` 始终为 `'fixed'` |  |
-| get-csv-cell | `(value: any, row: object, col: DataTableBaseColumn) => string` | `undefined` | 获取 CSV 的单元格数据 | 2.40.2 |
-| get-csv-header | `(cols: Array<DataTableColumn>) => string` | `undefined` | 获取 CSV 的 header | 2.40.2 |
+| get-csv-cell | `(value: any, row: object, col: DataTableBaseColumn) => string` | `undefined` | 获取 CSV 的单元格数据。返回值会被原样使用,如有需要请自行转义特殊字符(逗号、引号、换行符) | 2.40.2 |
+| get-csv-header | `(cols: Array<DataTableColumn>) => string` | `undefined` | 获取 CSV 的 header。返回值会被原样使用,如有需要请自行转义特殊字符(逗号、引号、换行符) | 2.40.2 |
 | header-height | `number` | `28` | 在开启 `virtual-scroll-header` 属性的情况下，表头的高度 | 2.40.0 |
 | height-for-row | `(rowData: object, index: number) => number` | `undefined` | 每行高度的配置函数，必须配合 `virtual-scroll-x` 使用，如果不进行配置，每一行的高度会被设为 `min-row-height` | 2.40.0 |
 | indent | `number` | `16` | 使用树形数据时行内容的缩进 |  |

--- a/src/data-table/src/public-types.ts
+++ b/src/data-table/src/public-types.ts
@@ -1,11 +1,21 @@
 import type { SharedSpinProps } from '../../_internal'
 import type { TableBaseColumn } from './interface'
 
+/**
+ * Returned string is used as-is in the exported CSV and is not escaped by
+ * naive-ui, so escape special characters (commas, quotes, line breaks)
+ * yourself if the value may contain them.
+ */
 export type DataTableGetCsvCell = (
   value: any,
   rowData: object,
   column: TableBaseColumn
 ) => string
+/**
+ * Returned string is used as-is in the exported CSV and is not escaped by
+ * naive-ui, so escape special characters (commas, quotes, line breaks)
+ * yourself if the value may contain them.
+ */
 export type DataTableGetCsvHeader = (column: TableBaseColumn) => string
 export type DataTableSize = 'small' | 'medium' | 'large'
 export type DataTableSpinProps = SharedSpinProps

--- a/src/data-table/src/utils.ts
+++ b/src/data-table/src/utils.ts
@@ -201,7 +201,7 @@ function formatCsvCell(value: unknown): string {
   if (value === null || value === undefined) {
     return ''
   }
-  const cell = typeof value === 'string' ? value : `${value}`
+  const cell = `${value}`
   if (/[",\r\n]/.test(cell)) {
     return `"${cell.replace(/"/g, '""')}"`
   }
@@ -222,7 +222,7 @@ export function generateCsv(
   )
   const header = exportableColumns
     .map((col: any) => {
-      return getCsvHeader ? getCsvHeader(col) : col.title
+      return getCsvHeader ? getCsvHeader(col) : formatCsvCell(col.title)
     })
     .join(',')
   const rows = data.map((row) => {

--- a/src/data-table/src/utils.ts
+++ b/src/data-table/src/utils.ts
@@ -198,15 +198,14 @@ export function isColumnSorting(
 }
 
 function formatCsvCell(value: unknown): string {
-  if (typeof value === 'string') {
-    return value.replace(/,/g, '\\,')
-  }
-  else if (value === null || value === undefined) {
+  if (value === null || value === undefined) {
     return ''
   }
-  else {
-    return `${value}`.replace(/,/g, '\\,')
+  const cell = typeof value === 'string' ? value : `${value}`
+  if (/[",\r\n]/.test(cell)) {
+    return `"${cell.replace(/"/g, '""')}"`
   }
+  return cell
 }
 
 export function generateCsv(

--- a/src/data-table/tests/utils.spec.ts
+++ b/src/data-table/tests/utils.spec.ts
@@ -1,0 +1,75 @@
+import type { TableColumn } from '../src/interface'
+import { generateCsv } from '../src/utils'
+
+const columns = [
+  { title: 'Name', key: 'name' },
+  { title: 'Address', key: 'address' }
+] as TableColumn[]
+
+describe('generateCsv', () => {
+  it('should keep plain cells unquoted', () => {
+    const csv = generateCsv(
+      columns,
+      [{ name: 'Jim Green', address: 'London' }],
+      undefined,
+      undefined
+    )
+
+    expect(csv).toBe('Name,Address\nJim Green,London')
+  })
+
+  it('should quote cells containing a line break', () => {
+    const csv = generateCsv(
+      columns,
+      [{ name: 'Jim Green', address: '11111111\r\n222222222' }],
+      undefined,
+      undefined
+    )
+
+    expect(csv).toBe('Name,Address\nJim Green,"11111111\r\n222222222"')
+  })
+
+  it('should quote cells containing a comma', () => {
+    const csv = generateCsv(
+      columns,
+      [{ name: 'Jim Green', address: 'London, UK' }],
+      undefined,
+      undefined
+    )
+
+    expect(csv).toBe('Name,Address\nJim Green,"London, UK"')
+  })
+
+  it('should quote cells containing a double quote and double the quote', () => {
+    const csv = generateCsv(
+      columns,
+      [{ name: 'Jim Green', address: 'The "Old" House' }],
+      undefined,
+      undefined
+    )
+
+    expect(csv).toBe('Name,Address\nJim Green,"The ""Old"" House"')
+  })
+
+  it('should quote non string cells containing a comma', () => {
+    const csv = generateCsv(
+      columns,
+      [{ name: 'Jim Green', address: { toString: () => 'a,b' } }],
+      undefined,
+      undefined
+    )
+
+    expect(csv).toBe('Name,Address\nJim Green,"a,b"')
+  })
+
+  it('should keep empty cells for null and undefined', () => {
+    const csv = generateCsv(
+      columns,
+      [{ name: null, address: undefined }],
+      undefined,
+      undefined
+    )
+
+    expect(csv).toBe('Name,Address\n,')
+  })
+})

--- a/src/data-table/tests/utils.spec.ts
+++ b/src/data-table/tests/utils.spec.ts
@@ -51,15 +51,18 @@ describe('generateCsv', () => {
     expect(csv).toBe('Name,Address\nJim Green,"The ""Old"" House"')
   })
 
-  it('should quote non string cells containing a comma', () => {
+  it('should quote headers containing a comma', () => {
     const csv = generateCsv(
-      columns,
-      [{ name: 'Jim Green', address: { toString: () => 'a,b' } }],
+      [
+        { title: 'Name', key: 'name' },
+        { title: 'Address, City', key: 'address' }
+      ] as TableColumn[],
+      [{ name: 'Jim Green', address: 'London' }],
       undefined,
       undefined
     )
 
-    expect(csv).toBe('Name,Address\nJim Green,"a,b"')
+    expect(csv).toBe('Name,"Address, City"\nJim Green,London')
   })
 
   it('should keep empty cells for null and undefined', () => {


### PR DESCRIPTION
`formatCsvCell` only escaped commas, and it did so with a backslash (`a\,b`), which no CSV parser un-escapes. A cell that holds a line break, a comma or a double quote therefore leaks into the next row or column when the table is exported, as the reporter shows with an address value containing `\r\n`. Column titles were not escaped at all, so a title with a comma splits the header row the same way.

Cells and default column titles are now wrapped in double quotes when they contain `,`, `"`, `\r` or `\n`, with inner quotes doubled, following RFC 4180. Plain values stay unquoted. Output from `get-csv-cell` and `get-csv-header` is still written as given, since those already return the final text.

Fixes #8153