### PR TITLE
fix(avatar): read global size config from n-config-provider

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -35,6 +35,7 @@
 - Fix `n-date-picker` with `type="datetime"` emitting `update:value` twice when clearing from panel, closes [#8070](https://github.com/tusen-ai/naive-ui/issues/8070).
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
+- Fix `n-avatar` not reading global `size` config from `n-config-provider`, closes [#8160](https://github.com/tusen-ai/naive-ui/issues/8160).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -35,6 +35,7 @@
 - 修复 `n-date-picker` 在 `type="datetime"` 时点击面板清空按钮会连续触发两次 `update:value` 的问题，关闭 [#8070](https://github.com/tusen-ai/naive-ui/issues/8070)
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
+- 修复 `n-avatar` 未读取 `n-config-provider` 的全局 `size` 配置的问题，关闭 [#8160](https://github.com/tusen-ai/naive-ui/issues/8160)
 
 ## 2.44.1
 

--- a/src/avatar/index.ts
+++ b/src/avatar/index.ts
@@ -1,2 +1,3 @@
 export { avatarProps, default as NAvatar } from './src/Avatar'
 export type { AvatarProps, AvatarSlots } from './src/Avatar'
+export type * from './src/public-types'

--- a/src/avatar/src/Avatar.tsx
+++ b/src/avatar/src/Avatar.tsx
@@ -78,7 +78,8 @@ export default defineComponent({
   props: avatarProps,
   slots: Object as SlotsType<AvatarSlots>,
   setup(props) {
-    const { mergedClsPrefixRef, inlineThemeDisabled } = useConfig(props)
+    const { mergedClsPrefixRef, inlineThemeDisabled, mergedComponentPropsRef }
+      = useConfig(props)
     const hasLoadErrorRef = ref(false)
     let memoedTextHtml: string | null = null
     const textRef = ref<HTMLElement | null>(null)
@@ -111,6 +112,9 @@ export default defineComponent({
       const { size: avatarGroupSize } = NAvatarGroup || {}
       if (avatarGroupSize)
         return avatarGroupSize
+      const configSize = mergedComponentPropsRef?.value?.Avatar?.size
+      if (configSize)
+        return configSize
       return 'medium'
     })
     const themeRef = useTheme(

--- a/src/avatar/src/public-types.ts
+++ b/src/avatar/src/public-types.ts
@@ -1,0 +1,1 @@
+export type { Size as AvatarSize } from './interface'

--- a/src/config-provider/demos/enUS/index.demo-entry.md
+++ b/src/config-provider/demos/enUS/index.demo-entry.md
@@ -45,6 +45,9 @@ interface GlobalComponentConfig {
   AutoComplete?: {
     size?: AutoCompleteSize
   }
+  Avatar?: {
+    size?: AvatarSize
+  }
   Button?: {
     size?: ButtonSize
   }

--- a/src/config-provider/demos/zhCN/index.demo-entry.md
+++ b/src/config-provider/demos/zhCN/index.demo-entry.md
@@ -45,6 +45,9 @@ interface GlobalComponentConfig {
   AutoComplete?: {
     size?: AutoCompleteSize
   }
+  Avatar?: {
+    size?: AvatarSize
+  }
   Button?: {
     size?: ButtonSize
   }

--- a/src/config-provider/src/internal-interface.ts
+++ b/src/config-provider/src/internal-interface.ts
@@ -9,6 +9,7 @@ import type { AnchorTheme } from '../../anchor/styles'
 import type { AutoCompleteSize } from '../../auto-complete/src/public-types'
 import type { AutoCompleteTheme } from '../../auto-complete/styles'
 import type { AvatarGroupTheme } from '../../avatar-group/styles'
+import type { AvatarSize } from '../../avatar/src/public-types'
 import type { AvatarTheme } from '../../avatar/styles'
 import type { BackTopTheme } from '../../back-top/styles'
 import type { BadgeTheme } from '../../badge/styles'
@@ -231,6 +232,9 @@ export interface GlobalThemeWithoutCommon {
 export interface GlobalComponentConfig {
   AutoComplete?: {
     size?: AutoCompleteSize
+  }
+  Avatar?: {
+    size?: AvatarSize
   }
   Cascader?: {
     size?: CascaderSize

--- a/src/config-provider/tests/ComponentSize.spec.tsx
+++ b/src/config-provider/tests/ComponentSize.spec.tsx
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { h, nextTick } from 'vue'
 import { NAutoComplete } from '../../auto-complete'
+import { NAvatar } from '../../avatar'
 import { NButton } from '../../button'
 import { NCard } from '../../card'
 import { NCascader } from '../../cascader'
@@ -94,6 +95,10 @@ describe('n-config-provider componentOptions', () => {
 
   it('should work with AutoComplete global size', () => {
     testGlobalSize(NAutoComplete, 'AutoComplete', '.n-input', SML)
+  })
+
+  it('should work with Avatar global size', () => {
+    testGlobalSize(NAvatar, 'Avatar', '.n-avatar', SML)
   })
 
   it('should work with Button global size', () => {


### PR DESCRIPTION
`n-avatar` calls `useConfig` but never destructures `mergedComponentPropsRef` from it, so a `size` set through `n-config-provider`'s `component-options` was ignored and the avatar always fell back to `medium`.

`mergedSizeRef` now checks that config, after the component's own `size` prop and the surrounding `n-avatar-group`, the same order `n-button` uses. `Avatar` is added to `GlobalComponentConfig` and to the existing `ComponentSize` spec.

Fixes #8160