### PR TITLE
fix(image): unregisterPreviewUrl never removes an entry from the map

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -45,6 +45,7 @@
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 - Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
+- Fix `n-image-group`'s `unregisterPreviewUrl` never removing an entry from the registered URL map on unmount, closes [#8170](https://github.com/tusen-ai/naive-ui/issues/8170).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -45,6 +45,7 @@
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 - 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
+- 修复 `n-image-group` 的 `unregisterPreviewUrl` 在组件卸载时从未真正从已注册的 URL map 中移除条目的问题，关闭 [#8170](https://github.com/tusen-ai/naive-ui/issues/8170)
 
 ## 2.44.1
 

--- a/src/image/src/ImageGroup.tsx
+++ b/src/image/src/ImageGroup.tsx
@@ -94,7 +94,7 @@ export default defineComponent({
       }
 
       return function unregisterPreviewUrl() {
-        if (!registeredImageUrlMap.value.has(sid)) {
+        if (registeredImageUrlMap.value.has(sid)) {
           registeredImageUrlMap.value.delete(sid)
         }
       }


### PR DESCRIPTION
## Summary

`n-image-group`'s `unregisterPreviewUrl` had an inverted guard, so it never actually removed an entry from `registeredImageUrlMap` on unmount.

```ts
return function unregisterPreviewUrl() {
  if (!registeredImageUrlMap.value.has(sid)) {
    registeredImageUrlMap.value.delete(sid)
  }
}
```

`Map.prototype.delete()` is a no-op when the key is already absent, so this only calls `delete()` in exactly the case where it does nothing (key already gone), and skips it in the normal unmount case where the key is actually present. So any `n-image` rendered inside an `n-image-group` leaves its URL registered in `registeredImageUrlMap` forever, even after the component unmounts, growing the map with stale entries for images that no longer exist in the DOM.

Fixes #8170

## Fix

One-line inversion of the condition:

```ts
return function unregisterPreviewUrl() {
  if (registeredImageUrlMap.value.has(sid)) {
    registeredImageUrlMap.value.delete(sid)
  }
}
```

## Scope

This is separate from #8158/#8168 (the `registerImageUrl` re-registration guard using the wrong key), which is already being fixed in that other PR. This one only touches the unregister path in the same function.

I didn't add a new unit test since `registeredImageUrlMap` isn't exposed on the component's public instance for a black-box assertion, and `imageId` is a module-level `uuid++` counter (never reused across mounts), so there's no externally-observable symptom to assert on without reaching into internals. Happy to add one if there's a preferred pattern for asserting on this kind of internal state in this codebase.