### PR TITLE
fix(tree-select): ignore Enter while IME composition is active

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -45,6 +45,7 @@
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 - Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
+- Fix `n-tree-select` selecting the keyboard-focused node when Enter is pressed during IME composition, closes [#8173](https://github.com/tusen-ai/naive-ui/issues/8173).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -45,6 +45,7 @@
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 - 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
+- 修复 `n-tree-select` 在输入法合成（IME composition）期间按 Enter 会选中当前键盘聚焦节点的问题，关闭 [#8173](https://github.com/tusen-ai/naive-ui/issues/8173)
 
 ## 2.44.1
 

--- a/src/tree-select/src/TreeSelect.tsx
+++ b/src/tree-select/src/TreeSelect.tsx
@@ -676,22 +676,24 @@ export default defineComponent({
     }
     function handleKeydown(e: KeyboardEvent): void {
       if (e.key === 'Enter') {
-        if (mergedShowRef.value) {
-          const { enterBehavior } = treeHandleKeydown(e)
-          if (!props.multiple) {
-            switch (enterBehavior) {
-              case 'default':
-              case 'toggleSelect':
-                closeMenu()
-                focusSelection()
-                break
-              default:
-                break
+        if (!triggerInstRef.value?.isComposing) {
+          if (mergedShowRef.value) {
+            const { enterBehavior } = treeHandleKeydown(e)
+            if (!props.multiple) {
+              switch (enterBehavior) {
+                case 'default':
+                case 'toggleSelect':
+                  closeMenu()
+                  focusSelection()
+                  break
+                default:
+                  break
+              }
             }
           }
-        }
-        else {
-          openMenu()
+          else {
+            openMenu()
+          }
         }
         e.preventDefault()
       }

--- a/src/tree-select/tests/TreeSelect.spec.ts
+++ b/src/tree-select/tests/TreeSelect.spec.ts
@@ -85,4 +85,35 @@ describe('n-tree-select', () => {
       'n-base-selection--multiple'
     )
   })
+  it('should not select a node when Enter is pressed during IME composition', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NTreeSelect, {
+      props: {
+        options: [
+          {
+            label: '1',
+            key: '1'
+          },
+          {
+            label: '2',
+            key: '2'
+          }
+        ],
+        show: true,
+        filterable: true,
+        onUpdateValue
+      }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('2')
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    await input.trigger('compositionstart')
+    await input.setValue('2')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).not.toHaveBeenCalled()
+    await input.trigger('compositionend')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue.mock.calls[0][0]).toBe('2')
+  })
 })


### PR DESCRIPTION
`n-tree-select`'s `handleKeydown` acts on `Enter` without checking whether an IME composition is in progress, so the Enter that confirms a conversion candidate also toggles the currently keyboard-focused tree node and closes the menu in single-select mode.

The trigger is `NInternalSelection`, which already tracks `isComposing`, so the fix is the same guard `n-select` uses: skip the Enter handling while composing, and still call `preventDefault`.

Fixes #8173