### PR TITLE
fix(cascader): ignore Enter while IME composition is active

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -45,6 +45,7 @@
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 - Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
+- Fix `n-cascader` selecting the highlighted option when Enter is pressed to confirm an IME composition, closes [#8172](https://github.com/tusen-ai/naive-ui/issues/8172).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -45,6 +45,7 @@
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 - 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
+- 修复 `n-cascader` 在输入法合成（IME composition）期间按 Enter 确认候选词时会误选中高亮选项的问题，关闭 [#8172](https://github.com/tusen-ai/naive-ui/issues/8172)
 
 ## 2.44.1
 

--- a/src/cascader/src/Cascader.tsx
+++ b/src/cascader/src/Cascader.tsx
@@ -755,6 +755,8 @@ export default defineComponent({
             return
         // eslint-disable-next-line no-fallthrough
         case 'Enter':
+          if (triggerInstRef.value?.isComposing)
+            break
           if (!mergedShowRef.value) {
             openMenu()
           }

--- a/src/cascader/tests/Cascader.spec.ts
+++ b/src/cascader/tests/Cascader.spec.ts
@@ -135,6 +135,33 @@ describe('n-cascader', () => {
     wrapper.unmount()
   })
 
+  it('should not select an option when Enter is pressed during IME composition', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NCascader, {
+      attachTo: document.body,
+      props: { options: getOptions(), filterable: true, onUpdateValue }
+    })
+    await wrapper.find('.n-base-selection').trigger('click')
+    const input = wrapper.find('input')
+    await input.trigger('compositionstart')
+    await input.setValue('l-1-1-1')
+    await input.trigger('compositionend')
+
+    await input.trigger('compositionstart')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).not.toHaveBeenCalled()
+
+    await input.setValue('l-1-1-1')
+    await input.trigger('compositionend')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledWith(
+      'v-1-1-1',
+      expect.anything(),
+      expect.anything()
+    )
+    wrapper.unmount()
+  })
+
   it('should work with `default-value` prop', async () => {
     const wrapper = mount(NCascader, {
       props: { options: getOptions(), defaultValue: 'l-1-1-2' }


### PR DESCRIPTION
When a filterable `n-cascader` is filtered with an IME, the Enter that confirms the conversion candidate still reaches the cascader's keydown handler, so the highlighted option gets selected before the user has finished typing.

`n-select` already skips Enter while the trigger reports `isComposing`, and cascader uses the same `NInternalSelection` trigger, so it can read the same flag. Added a spec covering the composing and non-composing Enter, plus changelog entries.

Fixes #8172