### PR TITLE
fix(image): reset loaded state when src changes

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -45,6 +45,7 @@
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 - Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
+- Fix `n-image` not showing the `placeholder` slot again when `src` changes, closes [#8176](https://github.com/tusen-ai/naive-ui/issues/8176).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -45,6 +45,7 @@
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 - 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
+- 修复 `n-image` 在 `src` 变化后不再显示 `placeholder` 插槽的问题，关闭 [#8176](https://github.com/tusen-ai/naive-ui/issues/8176)
 
 ## 2.44.1
 

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -121,9 +121,12 @@ export default defineComponent({
       }
     })
 
+    const loadedRef = ref(false)
+
     watchEffect(() => {
       void (props.src || props.imgProps?.src)
       showErrorRef.value = false
+      loadedRef.value = false
     })
 
     watchEffect((onInvalidate) => {
@@ -144,8 +147,6 @@ export default defineComponent({
     function onPreviewClose() {
       previewShowRef.value = false
     }
-
-    const loadedRef = ref(false)
 
     provide(imageContextKey, {
       previewedImgPropsRef: toRef(props, 'previewedImgProps')

--- a/src/image/tests/Image.spec.tsx
+++ b/src/image/tests/Image.spec.tsx
@@ -166,6 +166,31 @@ describe('n-image', () => {
     wrapper.unmount()
   })
 
+  it('should show placeholder slot again when src changes', async () => {
+    const wrapper = mount(NImage, {
+      props: {
+        src: 'https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg'
+      },
+      slots: {
+        placeholder: () => 'Placeholder'
+      }
+    })
+
+    await wrapper.find('img').trigger('load')
+
+    expect(wrapper.text()).not.toContain('Placeholder')
+
+    await wrapper.setProps({
+      src: 'https://www.naiveui.com/assets/naivelogo.93278402.svg'
+    })
+
+    expect(wrapper.text()).toContain('Placeholder')
+    expect(wrapper.find('img').attributes('style')).toContain(
+      'visibility: hidden;'
+    )
+    wrapper.unmount()
+  })
+
   it('should show fallback src when native lazy image fails to load', async () => {
     const fallbackSrc = 'https://www.naiveui.com/assets/naivelogo.93278402.svg'
     const wrapper = mount(NImage, {


### PR DESCRIPTION
Once an image loaded, `loaded` stayed true forever, so changing `src` left the old image on screen and the placeholder slot never came back while the new source was loading. The watchEffect that already resets `showError` on a `src` change now resets `loaded` too.

Fixes #8176