### PR TITLE
fix: allow root style to override theme css vars in back-top, color-picker and scrollbar

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -28,6 +28,7 @@
 
 ### Fixes
 
+- Fix `n-back-top`, `n-color-picker` and `n-scrollbar` root `style` not overriding theme CSS variables, closes [#8159](https://github.com/tusen-ai/naive-ui/issues/8159).
 - Fix `n-modal` mask inside scrollbar causing `Blocked aria-hidden on an element because its descendant retained focus` warning, closes [#7556](https://github.com/tusen-ai/naive-ui/issues/7556).
 - Fix `n-color-picker` passed `style` and `click` (onClick) not applied to trigger, closes [#7528](https://github.com/tusen-ai/naive-ui/issues/7528).
 - Fix `n-data-table`'s `scrollTo` method type missing, closes [#7554](https://github.com/tusen-ai/naive-ui/issues/7554).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -28,6 +28,7 @@
 
 ### Fixes
 
+- 修复 `n-back-top`、`n-color-picker` 与 `n-scrollbar` 根节点传入的 `style` 无法覆盖主题 CSS 变量的问题，关闭 [#8159](https://github.com/tusen-ai/naive-ui/issues/8159)
 - 修复 `n-modal` 遮罩层位于 scrollbar 内部导致 `Blocked aria-hidden on an element because its descendant retained focus` 警告，关闭 [#7556](https://github.com/tusen-ai/naive-ui/issues/7556)
 - 修复 `n-color-picker` 传入的 style、click 事件不生效，关闭 [#7528](https://github.com/tusen-ai/naive-ui/issues/7528)
 - 修复 `n-data-table` 的 `scrollTo` 方法类型缺失，关闭 [#7554](https://github.com/tusen-ai/naive-ui/issues/7554)

--- a/src/_internal/scrollbar/src/Scrollbar.tsx
+++ b/src/_internal/scrollbar/src/Scrollbar.tsx
@@ -863,9 +863,10 @@ const Scrollbar = defineComponent({
     }
     const createChildren = (): VNode => {
       this.onRender?.()
+      const { style: attrStyle, ...attrs } = this.$attrs
       return h(
         'div',
-        mergeProps(this.$attrs, {
+        mergeProps(attrs, {
           role: 'none',
           ref: 'wrapperRef',
           class: [
@@ -873,7 +874,7 @@ const Scrollbar = defineComponent({
             this.themeClass,
             rtlEnabled && `${mergedClsPrefix}-scrollbar--rtl`
           ],
-          style: this.cssVars,
+          style: [this.cssVars, attrStyle],
           onMouseenter: triggerDisplayManually
             ? undefined
             : this.handleMouseEnterWrapper,

--- a/src/_internal/scrollbar/tests/Scrollbar.spec.ts
+++ b/src/_internal/scrollbar/tests/Scrollbar.spec.ts
@@ -5,4 +5,19 @@ describe('n-scrollbar', () => {
   it('should work with import on demand', () => {
     mount(NScrollbar)
   })
+
+  it('should allow root style to override theme css vars', () => {
+    const wrapper = mount(NScrollbar, {
+      attrs: {
+        style: {
+          '--n-scrollbar-color': 'rgb(1, 2, 3)'
+        }
+      }
+    })
+    const el = wrapper.find('.n-scrollbar').element as HTMLElement
+    expect(el.style.getPropertyValue('--n-scrollbar-color')).toEqual(
+      'rgb(1, 2, 3)'
+    )
+    wrapper.unmount()
+  })
 })

--- a/src/back-top/src/BackTop.tsx
+++ b/src/back-top/src/BackTop.tsx
@@ -288,17 +288,18 @@ export default defineComponent({
                 {{
                   default: () => {
                     this.onRender?.()
+                    const { style: attrStyle, ...attrs } = this.$attrs
                     return this.mergedShow
                       ? h(
                           'div',
-                          mergeProps(this.$attrs, {
+                          mergeProps(attrs, {
                             class: [
                               `${mergedClsPrefix}-back-top`,
                               this.themeClass,
                               this.transitionDisabled
                               && `${mergedClsPrefix}-back-top--transition-disabled`
                             ],
-                            style: [this.style, this.cssVars],
+                            style: [this.style, this.cssVars, attrStyle],
                             onClick: this.handleClick
                           }),
                           resolveSlot(this.$slots.default, () => [

--- a/src/back-top/tests/BackTop.spec.ts
+++ b/src/back-top/tests/BackTop.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import { NBackTop } from '../index'
 
 describe('n-back-top', () => {
@@ -23,6 +24,25 @@ describe('n-back-top', () => {
     wrapper.element.scrollTop = 1000
     await wrapper.trigger('scroll')
     expect(wrapper.html()).toContain('teleport start')
+    wrapper.unmount()
+  })
+
+  it('should allow root style to override theme css vars', async () => {
+    const wrapper = mount(NBackTop, {
+      attachTo: document.body,
+      props: {
+        show: true
+      },
+      attrs: {
+        style: {
+          '--n-text-color': 'rgb(1, 2, 3)'
+        }
+      }
+    })
+    await nextTick()
+    const el = document.querySelector('.n-back-top') as HTMLElement
+    expect(el).not.toEqual(null)
+    expect(el.style.getPropertyValue('--n-text-color')).toEqual('rgb(1, 2, 3)')
     wrapper.unmount()
   })
 })

--- a/src/color-picker/src/ColorPicker.tsx
+++ b/src/color-picker/src/ColorPicker.tsx
@@ -772,10 +772,11 @@ export default defineComponent({
             <VTarget>
               {{
                 default: () => {
-                  const triggerProps = mergeProps(this.$attrs, {
+                  const { style: attrStyle, ...attrs } = this.$attrs
+                  const triggerProps = mergeProps(attrs, {
                     ref: this.setTriggerRef,
                     value: this.mergedValue,
-                    style: this.cssVars,
+                    style: [this.cssVars, attrStyle],
                     class: this.themeClass
                   })
                   const onClick = mergeEventHandlers([

--- a/src/color-picker/tests/ColorPicker.spec.tsx
+++ b/src/color-picker/tests/ColorPicker.spec.tsx
@@ -282,5 +282,20 @@ describe('n-color-picker 2', () => {
       expect(document.querySelector('.n-color-picker-panel')).not.toEqual(null)
       wrapper.unmount()
     })
+
+    it('should allow root style to override theme css vars', () => {
+      const wrapper = mount(NColorPicker, {
+        attrs: {
+          style: {
+            '--n-text-color': 'rgb(1, 2, 3)'
+          }
+        }
+      })
+      const el = wrapper.find('.n-color-picker').element as HTMLElement
+      expect(el.style.getPropertyValue('--n-text-color')).toEqual(
+        'rgb(1, 2, 3)'
+      )
+      wrapper.unmount()
+    })
   })
 })


### PR DESCRIPTION
## Description

Fixes #8159: root `style` cannot override theme CSS variables in `n-back-top`, `n-color-picker` and `n-scrollbar`.

## Root Cause

`mergeProps(this.$attrs, { ..., style: this.cssVars })` always puts the theme's `cssVars` after the user's `$attrs.style` in the merged array, and Vue's `normalizeStyle` gives the later entry priority for a shared key. So CSS variables set through the root style (or the `style` prop) could never override theme values.

## Changes

Follows the same pattern as the `n-menu` fix (#8136): extract `style` out of `$attrs` and append it after `cssVars` so user styles take priority:

- `src/_internal/scrollbar/src/Scrollbar.tsx`: `style: [this.cssVars, attrStyle]`
- `src/back-top/src/BackTop.tsx`: `style: [this.style, this.cssVars, attrStyle]`
- `src/color-picker/src/ColorPicker.tsx`: `style: [this.cssVars, attrStyle]`
- CHANGELOG entries (en-US / zh-CN)

## Tests

Added regression tests to all three components asserting `style.getPropertyValue('--n-*')` reflects the user-provided value:

- `src/back-top/tests/BackTop.spec.ts`
- `src/_internal/scrollbar/tests/Scrollbar.spec.ts`
- `src/color-picker/tests/ColorPicker.spec.tsx`

All 24 tests in the three test files pass. Verified the new scrollbar test fails without the fix (control experiment).