### PR TITLE
fix(avatar): reset loaded state when src changes

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -45,6 +45,7 @@
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 - Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
+- Fix `n-avatar` not showing the `placeholder` slot again when `src` changes, closes [#8180](https://github.com/tusen-ai/naive-ui/issues/8180).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -45,6 +45,7 @@
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 - 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
+- 修复 `n-avatar` 在 `src` 变化后不再显示 `placeholder` 插槽的问题，关闭 [#8180](https://github.com/tusen-ai/naive-ui/issues/8180)
 
 ## 2.44.1
 

--- a/src/avatar/src/Avatar.tsx
+++ b/src/avatar/src/Avatar.tsx
@@ -231,14 +231,15 @@ export default defineComponent({
       }
     })
 
+    const loadedRef = ref(!props.lazy)
+
     watch(
       () => props.src || props.imgProps?.src,
       () => {
         hasLoadErrorRef.value = false
+        loadedRef.value = !props.lazy
       }
     )
-
-    const loadedRef = ref(!props.lazy)
 
     return {
       textRef,

--- a/src/avatar/tests/Avatar.spec.tsx
+++ b/src/avatar/tests/Avatar.spec.tsx
@@ -147,6 +147,32 @@ describe('n-avatar', () => {
     wrapper.unmount()
   })
 
+  it('should show placeholder slot again when src changes', async () => {
+    const wrapper = mount(NAvatar, {
+      props: {
+        src: 'https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg',
+        lazy: true
+      },
+      slots: {
+        placeholder: () => 'Placeholder'
+      }
+    })
+
+    await wrapper.find('img').trigger('load')
+
+    expect(wrapper.text()).not.toContain('Placeholder')
+
+    await wrapper.setProps({
+      src: 'https://www.naiveui.com/assets/naivelogo.93278402.svg'
+    })
+
+    expect(wrapper.text()).toContain('Placeholder')
+    expect(wrapper.find('img').attributes('style')).toContain(
+      'visibility: hidden;'
+    )
+    wrapper.unmount()
+  })
+
   it('should work with `objectFit` prop', () => {
     const wrapper = mount(NAvatar, {
       props: {


### PR DESCRIPTION
`loadedRef` in `Avatar.tsx` was only ever set to `true`, in `mergedOnLoad`. The watch that already resets `hasLoadErrorRef` when `src` changes left it alone, so after one successful load the placeholder slot never came back and the `<img>` was never collapsed while the next source loaded.

The watch now resets it too, back to `!props.lazy`, which is the same value the ref is initialized with, so a non-lazy avatar keeps behaving as before.

Fixes #8180
