### PR TITLE
fix(input-number): ignore Enter while IME composition is active

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -45,6 +45,7 @@
 - Fix `n-input-otp` only keeping the last character when browser extension autofill sets the full OTP value on a single input, closes [#7540](https://github.com/tusen-ai/naive-ui/pull/7540).
 - Fix `n-menu` item icons not centered in collapsed mode when the options contain a `type="group"` group, closes [#8105](https://github.com/tusen-ai/naive-ui/issues/8105).
 - Fix `n-data-table` not rendering the table header when data is empty and a column has `ellipsis` set, closes [#8118](https://github.com/tusen-ai/naive-ui/issues/8118).
+- Fix `n-input-number` committing the value when Enter is pressed to confirm an IME composition, closes [#8179](https://github.com/tusen-ai/naive-ui/issues/8179).
 
 ## 2.44.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -45,6 +45,7 @@
 - 修复 `n-input-otp` 在浏览器扩展自动填充时将完整 OTP 写入单个输入框时只保留最后一个字符的问题，关闭 [#7540](https://github.com/tusen-ai/naive-ui/pull/7540)
 - 修复 `n-menu` 在缩起（collapsed）状态下选项包含 `type="group"` 分组时菜单项图标未居中的问题，关闭 [#8105](https://github.com/tusen-ai/naive-ui/issues/8105)
 - 修复 `n-data-table` 在数据为空且列设置了 `ellipsis` 时不渲染表头的问题，关闭 [#8118](https://github.com/tusen-ai/naive-ui/issues/8118)
+- 修复 `n-input-number` 在输入法合成（IME composition）期间按 Enter 确认候选词时会误提交数值的问题，关闭 [#8179](https://github.com/tusen-ai/naive-ui/issues/8179)
 
 ## 2.44.1
 

--- a/src/input-number/src/InputNumber.tsx
+++ b/src/input-number/src/InputNumber.tsx
@@ -541,6 +541,8 @@ export default defineComponent({
     }
     function handleKeyDown(e: KeyboardEvent): void {
       if (e.key === 'Enter') {
+        if (inputInstRef.value?.isCompositing)
+          return
         if (e.target === inputInstRef.value?.wrapperElRef) {
           // hit input wrapper
           // which means not activated

--- a/src/input-number/tests/InputNumber.spec.tsx
+++ b/src/input-number/tests/InputNumber.spec.tsx
@@ -283,4 +283,27 @@ describe('n-input-number', () => {
     expect(wrapper.find('input').element.id).toEqual('i am an id')
     wrapper.unmount()
   })
+
+  it('should not update value when Enter is pressed during IME composition', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NInputNumber, {
+      attachTo: document.body,
+      props: {
+        defaultValue: 2,
+        updateValueOnInput: false,
+        onUpdateValue
+      }
+    })
+    const input = wrapper.find('input')
+    input.element.value = '24'
+    await input.trigger('input')
+    expect(onUpdateValue).toHaveBeenCalledTimes(0)
+    await input.trigger('compositionstart')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledTimes(0)
+    await input.trigger('compositionend')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledWith(24)
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
`n-input-number`'s `handleKeyDown` acted on Enter without looking at composition state, so the Enter that confirms an IME candidate also derived and committed the displayed value and deactivated the input.

The underlying `n-input` already exposes `isCompositing`, so the Enter branch now returns early while a composition is active, the same way `n-select` and `n-dynamic-tags` do.

Fixes #8179
