### PR TITLE
fix(input-number): do not commit the value on Enter during IME composition

### DIFF
--- a/src/input-number/src/InputNumber.tsx
+++ b/src/input-number/src/InputNumber.tsx
@@ -541,6 +541,8 @@ export default defineComponent({
     }
     function handleKeyDown(e: KeyboardEvent): void {
       if (e.key === 'Enter') {
+        if (inputInstRef.value?.isCompositing)
+          return
         if (e.target === inputInstRef.value?.wrapperElRef) {
           // hit input wrapper
           // which means not activated

--- a/src/input-number/tests/InputNumber.spec.tsx
+++ b/src/input-number/tests/InputNumber.spec.tsx
@@ -283,4 +283,30 @@ describe('n-input-number', () => {
     expect(wrapper.find('input').element.id).toEqual('i am an id')
     wrapper.unmount()
   })
+
+  it('should not commit the value when Enter is pressed during IME composition', async () => {
+    const onUpdateValue = vi.fn()
+    const wrapper = mount(NInputNumber, {
+      attachTo: document.body,
+      props: {
+        defaultValue: 1,
+        onUpdateValue
+      }
+    })
+    const input = wrapper.find('input')
+    // a work-in-progress value: tracked by the input but not yet committed
+    input.element.value = '42.'
+    await input.trigger('input')
+    expect(onUpdateValue).toHaveBeenCalledTimes(0)
+    // Enter during IME composition must not commit the tracked value
+    await input.trigger('compositionstart')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledTimes(0)
+    // once composition ends, Enter commits normally
+    await input.trigger('compositionend')
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(onUpdateValue).toHaveBeenCalledTimes(1)
+    expect(onUpdateValue).toHaveBeenCalledWith(42)
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
Fixes #8179.

## Problem

`n-input-number`'s `handleKeyDown` commits the value on Enter without checking whether an IME composition is active. When typing with a Chinese/Japanese IME, pressing Enter to confirm a candidate commits the number and closes the input instead of just confirming the composition. Other components already guard this with the `isCompositing` flag exposed by `NInput` (see `DynamicTags`, `Mention`).

## Solution

Mirror the existing guard: return early from the Enter branch while `inputInstRef.value?.isCompositing` is true.

## Tests

Added a test in `InputNumber.spec.tsx`: after a tracked work-in-progress value (`42.`), Enter during composition does not commit; once composition ends, the next Enter commits `42` normally. Verified the test fails without the guard (non-vacuous).