### PR TITLE
fix(image, avatar): show placeholder again when src changes

### DIFF
--- a/src/avatar/src/Avatar.tsx
+++ b/src/avatar/src/Avatar.tsx
@@ -231,14 +231,15 @@ export default defineComponent({
       }
     })
 
+    const loadedRef = ref(!props.lazy)
+
     watch(
       () => props.src || props.imgProps?.src,
       () => {
         hasLoadErrorRef.value = false
+        loadedRef.value = !props.lazy
       }
     )
-
-    const loadedRef = ref(!props.lazy)
 
     return {
       textRef,

--- a/src/avatar/tests/Avatar.spec.tsx
+++ b/src/avatar/tests/Avatar.spec.tsx
@@ -159,4 +159,25 @@ describe('n-avatar', () => {
     )
     wrapper.unmount()
   })
+
+  it('should show placeholder slot again after src changes', async () => {
+    const wrapper = mount(NAvatar, {
+      props: {
+        lazy: true,
+        src: 'a.jpg'
+      },
+      slots: {
+        placeholder: () => 'Placeholder'
+      }
+    })
+
+    expect(wrapper.text()).toContain('Placeholder')
+
+    await wrapper.find('img').trigger('load')
+    expect(wrapper.text()).not.toContain('Placeholder')
+
+    await wrapper.setProps({ src: 'b.jpg' })
+    expect(wrapper.text()).toContain('Placeholder')
+    wrapper.unmount()
+  })
 })

--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -121,9 +121,12 @@ export default defineComponent({
       }
     })
 
+    const loadedRef = ref(false)
+
     watchEffect(() => {
       void (props.src || props.imgProps?.src)
       showErrorRef.value = false
+      loadedRef.value = false
     })
 
     watchEffect((onInvalidate) => {
@@ -144,8 +147,6 @@ export default defineComponent({
     function onPreviewClose() {
       previewShowRef.value = false
     }
-
-    const loadedRef = ref(false)
 
     provide(imageContextKey, {
       previewedImgPropsRef: toRef(props, 'previewedImgProps')

--- a/src/image/tests/Image.spec.tsx
+++ b/src/image/tests/Image.spec.tsx
@@ -237,4 +237,24 @@ describe('n-image', () => {
     expect(document.querySelector('.n-image-preview-overlay')).toEqual(null)
     wrapper.unmount()
   })
+
+  it('should show placeholder slot again after src changes', async () => {
+    const wrapper = mount(NImage, {
+      props: {
+        src: 'a.jpg'
+      },
+      slots: {
+        placeholder: () => 'Placeholder'
+      }
+    })
+
+    expect(wrapper.text()).toContain('Placeholder')
+
+    await wrapper.find('img').trigger('load')
+    expect(wrapper.text()).not.toContain('Placeholder')
+
+    await wrapper.setProps({ src: 'b.jpg' })
+    expect(wrapper.text()).toContain('Placeholder')
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
Fixes #8176. Fixes #8180.

## Problem

Both `n-image` and `n-avatar` reset their error state when `src` changes, but never reset `loaded`. Once an image loads successfully, `loadedRef` stays `true` forever, so the placeholder never reappears when the consumer switches `src` — even while the new image is still loading.

- `n-image`: `loadedRef` is only ever set to `true` (`mergedOnLoad` / `mergedOnError`), and the `watchEffect` reacting to `src` only clears `showErrorRef`.
- `n-avatar`: same gap — the `watch` on `src` only clears `hasLoadErrorRef`.

## Solution

Reset `loadedRef` in the existing `src`-reaction: `false` for `n-image`, `!props.lazy` for `n-avatar` (preserving lazy semantics). Declarations were moved above the watchers to satisfy `ts/no-use-before-define`.

## Tests

Added one test per component: placeholder renders initially, disappears after `load`, reappears after `src` changes. Both tests verified to fail without the fix.