### PR TITLE
fix(modal): remove redundant omit that breaks the preset props type check

### DIFF
--- a/src/modal/src/Modal.tsx
+++ b/src/modal/src/Modal.tsx
@@ -25,7 +25,6 @@ import {
   call,
   eventEffectNotPerformed,
   keep,
-  omit,
   useIsComposing,
   warnOnce
 } from '../../_utils'
@@ -296,13 +295,8 @@ export default defineComponent({
       isMounted: isMountedRef,
       containerRef,
       presetProps: computed(() => {
-        const pickedProps = keep(props, forwardedPresetPropsKeys)
         // TODO: remove as any after vue fix the issue introduced in 3.2.27
-        return omit(pickedProps, [
-          'onClose',
-          'onNegativeClick',
-          'onPositiveClick'
-        ]) as any
+        return keep(props, forwardedPresetPropsKeys) as any
       }),
       handleEsc,
       handleAfterLeave,


### PR DESCRIPTION
#8189 switched Modal's `presetProps` to `keep(props, forwardedPresetPropsKeys)`, and those keys already exclude `onClose`, `onNegativeClick` and `onPositiveClick`. That left the `omit()` call below it both redundant and impossible to type, so `tsc` now reports three TS2322 errors on Modal.tsx. The lint and test jobs fail on every PR against main because of it, and since `lint:src-type` is the same `tsc -b tsconfig.esm.json` step `build:package` starts with, the release build on main is broken too. Sorry about that, it only surfaces in a full project type check, not in the modal tests I ran.

Dropping the `omit()` call and its now-unused import clears all three. Nothing changes at runtime, the three keys were already absent from the object `keep()` builds.

One error is left after this: `src/pagination/tests/Pagination.virtual-jump.browser.spec.tsx(53,10): error TS2874`, from an unrelated commit. It still fails the test and test-browser jobs, and I haven't touched it here.