### PR TITLE
test(pagination): import h in the virtual jump browser spec

### DIFF
--- a/src/pagination/tests/Pagination.virtual-jump.browser.spec.tsx
+++ b/src/pagination/tests/Pagination.virtual-jump.browser.spec.tsx
@@ -1,5 +1,5 @@
 import { locators, page } from 'vitest/browser'
-import { createApp, defineComponent, nextTick, ref } from 'vue'
+import { createApp, defineComponent, h, nextTick, ref } from 'vue'
 import { NPagination } from '../index'
 
 declare module 'vitest/browser' {


### PR DESCRIPTION
`Pagination.virtual-jump.browser.spec.tsx` uses JSX but doesn't import `h`, and the repo's tsconfig sets `jsxFactory: "h"`. So `tsc -p tsconfig.test.json --noEmit` fails with `error TS2874: This JSX tag requires 'h' to be in scope, but it could not be found`.

Both the `test` and `test:browser` scripts run that type check before vitest, so the two CI jobs currently fail on every open PR. Adding `h` to the existing vue import fixes it, same as the data-table browser spec next door.